### PR TITLE
Add MoonBit fallback parser, DuckDB lazy-loading with improved errors, doctor command, and CI matrix

### DIFF
--- a/.github/workflows/core-fallback-matrix.yml
+++ b/.github/workflows/core-fallback-matrix.yml
@@ -23,8 +23,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -36,12 +34,13 @@ jobs:
       - name: Install dependencies (skip native build scripts)
         run: pnpm install --frozen-lockfile --ignore-scripts
 
-      - name: Install MoonBit (with build mode only)
+      - name: Setup MoonBit (with build mode only)
         if: matrix.moonbit_mode == 'with_moonbit_build'
-        run: |
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
-          echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
-          moon version
+        uses: hustcer/setup-moonbit@v1
+
+      - name: Verify MoonBit toolchain
+        if: matrix.moonbit_mode == 'with_moonbit_build'
+        run: moon version
 
       - name: Prepare no-MoonBit-build mode
         if: matrix.moonbit_mode == 'without_moonbit_build'

--- a/.github/workflows/core-fallback-matrix.yml
+++ b/.github/workflows/core-fallback-matrix.yml
@@ -42,6 +42,12 @@ jobs:
         if: matrix.moonbit_mode == 'with_moonbit_build'
         run: moon version
 
+      - name: Update MoonBit registry
+        if: matrix.moonbit_mode == 'with_moonbit_build'
+        run: |
+          cd src/core
+          moon update
+
       - name: Prepare no-MoonBit-build mode
         if: matrix.moonbit_mode == 'without_moonbit_build'
         run: rm -rf src/core/_build

--- a/.github/workflows/core-fallback-matrix.yml
+++ b/.github/workflows/core-fallback-matrix.yml
@@ -1,0 +1,65 @@
+name: core-fallback-matrix
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: core-fallback-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  core-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        moonbit_mode: [without_moonbit_build, with_moonbit_build]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      # These tests do not require native duckdb bindings.
+      - name: Install dependencies (skip native build scripts)
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Install MoonBit (with build mode only)
+        if: matrix.moonbit_mode == 'with_moonbit_build'
+        run: |
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
+          echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
+          moon version
+
+      - name: Prepare no-MoonBit-build mode
+        if: matrix.moonbit_mode == 'without_moonbit_build'
+        run: rm -rf src/core/_build
+
+      - name: Build MoonBit JS core
+        if: matrix.moonbit_mode == 'with_moonbit_build'
+        run: |
+          cd src/core
+          moon build --target js
+          test -f _build/js/debug/build/src/main/main.js
+
+      - name: Assert MoonBit build is absent in fallback mode
+        if: matrix.moonbit_mode == 'without_moonbit_build'
+        run: test ! -f src/core/_build/js/debug/build/src/main/main.js
+
+      - name: Run core/fallback parity tests
+        run: pnpm vitest run tests/core/loader.test.ts tests/core/resolve-affected-glob-parity.test.ts tests/resolvers/bitflow-native.test.ts tests/commands/doctor.test.ts tests/storage/duckdb-load.test.ts
+
+      - name: Type check CLI/core
+        run: pnpm -s tsc --noEmit

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,13 @@
+# TODO
+
+## 進行中
+- [x] DuckDB のネイティブバイナリが無い環境で CLI が即死しないよう、`duckdb` 初期化を遅延ロード + エラーメッセージ改善する
+- [x] `resolveAffectedFallback` のパーサを複数行 `task(...)` 定義に対応させる
+- [x] `resolveAffectedFallback` の glob 解釈を MoonBit 実装仕様と突き合わせる（差分テスト追加）
+
+## 次のマイルストーン
+- [x] `flaker doctor` コマンドを追加し、DuckDB/MoonBit の実行環境チェックを 1 コマンドで確認可能にする
+- [x] CI で「MoonBit あり / なし」の 2 パターンを回し、フォールバック経路を常時検証する
+
+## 完了済み
+- [x] MoonBit 未ビルド時でも affected target を解決できる TypeScript fallback を実装

--- a/docs/duckdb-debug.md
+++ b/docs/duckdb-debug.md
@@ -1,0 +1,18 @@
+# DuckDB デバッグメモ
+
+`duckdb.node` が見つからない場合は、次の順に確認してください。
+
+1. `pnpm ignored-builds` で `duckdb` が無視されていないか確認
+2. `package.json` の `pnpm.onlyBuiltDependencies` に `duckdb` を追加
+3. Node ヘッダをローカル指定して再ビルド
+
+```bash
+npm_config_nodedir=$(dirname $(dirname $(which node))) pnpm rebuild duckdb
+```
+
+## この環境で確認したこと
+
+- 事象: `Cannot find module .../duckdb/lib/binding/duckdb.node`
+- 原因1: `pnpm` が `duckdb` のビルドスクリプトを自動無視していた
+- 原因2: プロキシ下で `node-gyp` が Node ヘッダを外部取得しようとして 403 になり得る
+- 対策: `npm_config_nodedir` を指定してローカル Node ヘッダを使う

--- a/package.json
+++ b/package.json
@@ -15,6 +15,11 @@
   "author": "",
   "license": "ISC",
   "packageManager": "pnpm@10.27.0",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "duckdb"
+    ]
+  },
   "dependencies": {
     "@octokit/rest": "^22.0.1",
     "adm-zip": "^0.5.16",

--- a/src/cli/adapters/actrun.ts
+++ b/src/cli/adapters/actrun.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 import type { TestCaseResult, TestResultAdapter } from "./types.js";
+import { resolveTestIdentity } from "../identity.js";
 
 export interface ActrunTask {
   id: string;
@@ -55,13 +56,14 @@ export const actrunAdapter: TestResultAdapter = {
     const output: ActrunRunOutput = JSON.parse(input);
     return output.tasks.map((task) => {
       const { suite, testName } = parseTaskId(task.id);
-      return {
+      return resolveTestIdentity({
         suite,
         testName,
+        taskId: task.id,
         status: mapStatus(task),
         durationMs: 0,
         retryCount: 0,
-      };
+      });
     });
   },
 };

--- a/src/cli/adapters/junit.ts
+++ b/src/cli/adapters/junit.ts
@@ -1,4 +1,5 @@
 import type { TestCaseResult, TestResultAdapter } from "./types.js";
+import { resolveTestIdentity } from "../identity.js";
 
 function getAttr(tag: string, attr: string): string | undefined {
   const re = new RegExp(`${attr}="([^"]*)"`, "i");
@@ -45,13 +46,13 @@ export const junitAdapter: TestResultAdapter = {
           status = "skipped";
         }
 
-        const result: TestCaseResult = {
+        const result: TestCaseResult = resolveTestIdentity({
           suite: suiteName,
           testName,
           status,
           durationMs,
           retryCount: 0,
-        };
+        });
 
         if (errorMessage !== undefined) {
           result.errorMessage = errorMessage;

--- a/src/cli/adapters/playwright.ts
+++ b/src/cli/adapters/playwright.ts
@@ -1,4 +1,5 @@
 import type { TestCaseResult, TestResultAdapter } from "./types.js";
+import { resolveTestIdentity } from "../identity.js";
 
 interface PlaywrightResult {
   status: string;
@@ -31,10 +32,12 @@ interface PlaywrightReport {
 
 function walkSuites(
   suite: PlaywrightSuite,
-  parentTitle: string | null,
+  currentFile: string | null,
+  currentTaskId: string | null,
   out: TestCaseResult[],
 ): void {
-  const currentTitle = parentTitle ?? suite.title;
+  const nextFile = suite.file ?? currentFile ?? suite.title;
+  const nextTaskId = currentTaskId ?? suite.title;
 
   if (suite.specs) {
     for (const spec of suite.specs) {
@@ -61,14 +64,15 @@ function walkSuites(
           (r) => r.status === "failed" && r.error,
         );
 
-        const result: TestCaseResult = {
-          suite: currentTitle,
+        const result: TestCaseResult = resolveTestIdentity({
+          suite: nextFile,
           testName: spec.title,
+          taskId: nextTaskId,
           status,
           durationMs: lastResult.duration,
           retryCount: maxRetry,
           variant: { project: test.projectName },
-        };
+        });
 
         if (firstFailure?.error) {
           result.errorMessage = firstFailure.error.message;
@@ -81,7 +85,7 @@ function walkSuites(
 
   if (suite.suites) {
     for (const child of suite.suites) {
-      walkSuites(child, child.title, out);
+      walkSuites(child, nextFile, child.title, out);
     }
   }
 }
@@ -92,7 +96,7 @@ export const playwrightAdapter: TestResultAdapter = {
     const report: PlaywrightReport = JSON.parse(input);
     const results: TestCaseResult[] = [];
     for (const suite of report.suites) {
-      walkSuites(suite, null, results);
+      walkSuites(suite, suite.file ?? null, suite.title, results);
     }
     return results;
   },

--- a/src/cli/adapters/types.ts
+++ b/src/cli/adapters/types.ts
@@ -1,11 +1,17 @@
+import type { QuarantineManifestEntry } from "../quarantine-manifest.js";
+
 export interface TestCaseResult {
   suite: string;
   testName: string;
+  taskId?: string | null;
+  filter?: string | null;
   status: "passed" | "failed" | "skipped" | "flaky";
   durationMs: number;
   retryCount: number;
   errorMessage?: string;
-  variant?: Record<string, string>;
+  variant?: Record<string, string> | null;
+  testId?: string;
+  quarantine?: QuarantineManifestEntry | null;
 }
 
 export interface TestResultAdapter {

--- a/src/cli/commands/collect-local.ts
+++ b/src/cli/commands/collect-local.ts
@@ -5,6 +5,7 @@ import { actrunAdapter, extractTestReportsFromArtifacts } from "../adapters/actr
 import { playwrightAdapter } from "../adapters/playwright.js";
 import { junitAdapter } from "../adapters/junit.js";
 import type { MetricStore, WorkflowRun, TestResult } from "../storage/types.js";
+import { toStoredTestResult } from "../storage/test-result-mapper.js";
 
 export interface CollectLocalOpts {
   store: MetricStore;
@@ -89,18 +90,13 @@ export async function runCollectLocal(opts: CollectLocalOpts): Promise<CollectLo
 
     // Insert test results
     if (testCases.length > 0) {
-      const testResults: TestResult[] = testCases.map((tc) => ({
-        workflowRunId: runId,
-        suite: tc.suite,
-        testName: tc.testName,
-        status: tc.status,
-        durationMs: tc.durationMs,
-        retryCount: tc.retryCount,
-        errorMessage: tc.errorMessage ?? null,
-        commitSha,
-        variant: tc.variant ?? null,
-        createdAt: startedAt,
-      }));
+      const testResults: TestResult[] = testCases.map((tc) =>
+        toStoredTestResult(tc, {
+          workflowRunId: runId,
+          commitSha,
+          createdAt: startedAt,
+        }),
+      );
       await store.insertTestResults(testResults);
       testsImported += testResults.length;
     }

--- a/src/cli/commands/collect.ts
+++ b/src/cli/commands/collect.ts
@@ -4,6 +4,7 @@ import { junitAdapter } from "../adapters/junit.js";
 import { playwrightAdapter } from "../adapters/playwright.js";
 import type { TestResultAdapter } from "../adapters/types.js";
 import type { MetricStore, WorkflowRun, TestResult } from "../storage/types.js";
+import { toStoredTestResult } from "../storage/test-result-mapper.js";
 
 export interface GitHubClient {
   listWorkflowRuns(): Promise<{
@@ -141,18 +142,13 @@ export async function collectWorkflowRuns(
 
     const testCases = adapter.parse(reportContent);
 
-    const testResults: TestResult[] = testCases.map((tc) => ({
-      workflowRunId: run.id,
-      suite: tc.suite,
-      testName: tc.testName,
-      status: tc.status,
-      durationMs: tc.durationMs,
-      retryCount: tc.retryCount,
-      errorMessage: tc.errorMessage ?? null,
-      commitSha: run.head_sha,
-      variant: tc.variant ?? null,
-      createdAt: new Date(run.created_at),
-    }));
+    const testResults: TestResult[] = testCases.map((tc) =>
+      toStoredTestResult(tc, {
+        workflowRunId: run.id,
+        commitSha: run.head_sha,
+        createdAt: new Date(run.created_at),
+      }),
+    );
 
     if (testResults.length > 0) {
       await store.insertTestResults(testResults);

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -1,0 +1,102 @@
+import { loadConfig } from "../config.js";
+import { hasMoonBitJsBuild } from "../core/loader.js";
+
+export interface DoctorCheck {
+  name: string;
+  ok: boolean;
+  detail: string;
+}
+
+export interface DoctorReport {
+  checks: DoctorCheck[];
+  ok: boolean;
+}
+
+export interface DoctorDeps {
+  createStore: () => { initialize: () => Promise<void>; close: () => Promise<void> };
+  hasMoonBitBuild: () => Promise<boolean>;
+  canLoadConfig: () => boolean;
+}
+
+export async function runDoctor(cwd: string, deps?: Partial<DoctorDeps>): Promise<DoctorReport> {
+  const resolved: DoctorDeps = {
+    createStore: deps?.createStore ?? (() => { throw new Error("createStore is not configured"); }),
+    hasMoonBitBuild: deps?.hasMoonBitBuild ?? hasMoonBitJsBuild,
+    canLoadConfig: deps?.canLoadConfig ?? (() => {
+      loadConfig(cwd);
+      return true;
+    }),
+  };
+
+  const checks: DoctorCheck[] = [];
+
+  // Config check
+  try {
+    const ok = resolved.canLoadConfig();
+    checks.push({
+      name: "config",
+      ok,
+      detail: ok ? "flaker.toml is readable" : "flaker.toml check returned false",
+    });
+  } catch (error) {
+    checks.push({
+      name: "config",
+      ok: false,
+      detail: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  // DuckDB check
+  const store = resolved.createStore();
+  let storeInitialized = false;
+  try {
+    await store.initialize();
+    storeInitialized = true;
+    await store.close();
+    checks.push({ name: "duckdb", ok: true, detail: "DuckDB initialized successfully" });
+  } catch (error) {
+    checks.push({
+      name: "duckdb",
+      ok: false,
+      detail: error instanceof Error ? error.message : String(error),
+    });
+  } finally {
+    if (storeInitialized) {
+      try {
+        await store.close();
+      } catch {
+        // best effort
+      }
+    }
+  }
+
+  // MoonBit build check
+  try {
+    const hasBuild = await resolved.hasMoonBitBuild();
+    checks.push({
+      name: "moonbit",
+      ok: true,
+      detail: hasBuild
+        ? "MoonBit JS build detected"
+        : "MoonBit JS build not found (TypeScript fallback will be used)",
+    });
+  } catch (error) {
+    checks.push({
+      name: "moonbit",
+      ok: false,
+      detail: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  return {
+    checks,
+    ok: checks.every((c) => c.ok),
+  };
+}
+
+export function formatDoctorReport(report: DoctorReport): string {
+  const lines = report.checks.map((c) => `${c.ok ? "OK" : "NG"} ${c.name}: ${c.detail}`);
+  lines.push("");
+  lines.push(report.ok ? "Doctor checks passed." : "Doctor checks failed.");
+  return lines.join("\n");
+}

--- a/src/cli/commands/import.ts
+++ b/src/cli/commands/import.ts
@@ -3,6 +3,7 @@ import { playwrightAdapter } from "../adapters/playwright.js";
 import { junitAdapter } from "../adapters/junit.js";
 import type { TestResultAdapter } from "../adapters/types.js";
 import type { MetricStore, WorkflowRun, TestResult } from "../storage/types.js";
+import { toStoredTestResult } from "../storage/test-result-mapper.js";
 
 interface ImportOpts {
   store: MetricStore;
@@ -54,18 +55,13 @@ export async function runImport(opts: ImportOpts): Promise<ImportResult> {
   };
   await store.insertWorkflowRun(workflowRun);
 
-  const testResults: TestResult[] = testCases.map((tc) => ({
-    workflowRunId: runId,
-    suite: tc.suite,
-    testName: tc.testName,
-    status: tc.status,
-    durationMs: tc.durationMs,
-    retryCount: tc.retryCount,
-    errorMessage: tc.errorMessage ?? null,
-    commitSha,
-    variant: tc.variant ?? null,
-    createdAt: now,
-  }));
+  const testResults: TestResult[] = testCases.map((tc) =>
+    toStoredTestResult(tc, {
+      workflowRunId: runId,
+      commitSha,
+      createdAt: now,
+    }),
+  );
 
   await store.insertTestResults(testResults);
   return { testsImported: testResults.length };

--- a/src/cli/commands/quarantine.ts
+++ b/src/cli/commands/quarantine.ts
@@ -29,19 +29,24 @@ export type QuarantineOpts =
 export async function runQuarantine(
   opts: QuarantineOpts,
 ): Promise<QuarantinedTest[] | undefined> {
-  const { store } = opts;
+      const { store } = opts;
 
   switch (opts.action) {
     case "add": {
       await store.addQuarantine(
-        opts.suite,
-        opts.testName,
+        {
+          suite: opts.suite,
+          testName: opts.testName,
+        },
         opts.reason ?? "manual",
       );
       return undefined;
     }
     case "remove": {
-      await store.removeQuarantine(opts.suite, opts.testName);
+      await store.removeQuarantine({
+        suite: opts.suite,
+        testName: opts.testName,
+      });
       return undefined;
     }
     case "list": {
@@ -55,7 +60,17 @@ export async function runQuarantine(
       const reason = `auto:flaky_rate>=${threshold}%`;
       for (const f of flaky) {
         if (f.flakyRate >= threshold && f.totalRuns >= minRuns) {
-          await store.addQuarantine(f.suite, f.testName, reason);
+          await store.addQuarantine(
+            {
+              suite: f.suite,
+              testName: f.testName,
+              taskId: f.taskId,
+              filter: f.filter,
+              variant: f.variant,
+              testId: f.testId,
+            },
+            reason,
+          );
         }
       }
       return undefined;

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -1,19 +1,67 @@
 import type { MetricStore } from "../storage/types.js";
-import type { TestMeta } from "../core/loader.js";
-import { runSample, type SampleOpts } from "./sample.js";
-import { DirectRunner } from "../runners/direct.js";
+import { runSample } from "./sample.js";
+import type { QuarantineManifestEntry } from "../quarantine-manifest.js";
+import {
+  orchestrate,
+  withQuarantineRuntime,
+  type ExecuteResult,
+  type RunnerAdapter,
+  type TestId,
+} from "../runners/index.js";
 
 export interface RunOpts {
   store: MetricStore;
-  command: string;
+  runner: RunnerAdapter;
   count?: number;
   percentage?: number;
   mode: "random" | "weighted";
   seed?: number;
   skipQuarantined?: boolean;
+  quarantineManifestEntries?: QuarantineManifestEntry[];
+  cwd?: string;
 }
 
-export async function runTests(opts: RunOpts): Promise<void> {
+function buildListedTestIndex(listedTests: TestId[]): Map<string, TestId[]> {
+  const index = new Map<string, TestId[]>();
+  for (const test of listedTests) {
+    const key = `${test.suite}\0${test.testName}`;
+    const existing = index.get(key);
+    if (existing) {
+      existing.push(test);
+    } else {
+      index.set(key, [test]);
+    }
+  }
+  return index;
+}
+
+function enrichSampledTests(sampled: Array<{ suite: string; test_name: string }>, listedTests: TestId[]): TestId[] {
+  const index = buildListedTestIndex(listedTests);
+  return sampled.map((test) => {
+    const key = `${test.suite}\0${test.test_name}`;
+    const enriched = index.get(key)?.shift();
+    return (
+      enriched ?? {
+        suite: test.suite,
+        testName: test.test_name,
+      }
+    );
+  });
+}
+
+async function loadListedTests(
+  runner: RunnerAdapter,
+  cwd?: string,
+): Promise<TestId[]> {
+  try {
+    return await runner.listTests({ cwd });
+  } catch {
+    return [];
+  }
+}
+
+export async function runTests(opts: RunOpts): Promise<ExecuteResult> {
+  const listedTests = await loadListedTests(opts.runner, opts.cwd);
   const sampled = await runSample({
     store: opts.store,
     count: opts.count,
@@ -21,12 +69,13 @@ export async function runTests(opts: RunOpts): Promise<void> {
     mode: opts.mode,
     seed: opts.seed,
     skipQuarantined: opts.skipQuarantined,
+    quarantineManifestEntries: opts.quarantineManifestEntries,
+    listedTests,
   });
-
-  const runner = new DirectRunner(opts.command);
-
-  for (const test of sampled) {
-    const pattern = `${test.suite}.*${test.test_name}`;
-    runner.run(pattern);
-  }
+  const runtimeRunner =
+    opts.quarantineManifestEntries && opts.quarantineManifestEntries.length > 0
+      ? withQuarantineRuntime(opts.runner, opts.quarantineManifestEntries)
+      : opts.runner;
+  const tests = enrichSampledTests(sampled, listedTests);
+  return orchestrate(runtimeRunner, tests, { cwd: opts.cwd });
 }

--- a/src/cli/commands/sample.ts
+++ b/src/cli/commands/sample.ts
@@ -1,7 +1,13 @@
 import type { MetricStore } from "../storage/types.js";
 import type { TestMeta, MetriciCore } from "../core/loader.js";
 import type { DependencyResolver } from "../resolvers/types.js";
+import type { TestId } from "../runners/types.js";
 import { loadCore } from "../core/loader.js";
+import { createStableTestId } from "../identity.js";
+import {
+  isManifestQuarantined,
+  type QuarantineManifestEntry,
+} from "../quarantine-manifest.js";
 
 export interface SampleOpts {
   store: MetricStore;
@@ -12,6 +18,22 @@ export interface SampleOpts {
   resolver?: DependencyResolver;
   changedFiles?: string[];
   skipQuarantined?: boolean;
+  quarantineManifestEntries?: QuarantineManifestEntry[];
+  listedTests?: TestId[];
+}
+
+function buildListedTestIndex(listedTests: TestId[]): Map<string, TestId[]> {
+  const index = new Map<string, TestId[]>();
+  for (const test of listedTests) {
+    const key = `${test.suite}\0${test.testName}`;
+    const existing = index.get(key);
+    if (existing) {
+      existing.push(test);
+    } else {
+      index.set(key, [test]);
+    }
+  }
+  return index;
 }
 
 export async function runSample(opts: SampleOpts): Promise<TestMeta[]> {
@@ -19,8 +41,38 @@ export async function runSample(opts: SampleOpts): Promise<TestMeta[]> {
   let allTests = await buildTestMeta(opts.store);
   if (opts.skipQuarantined) {
     const quarantined = await opts.store.queryQuarantined();
-    const qSet = new Set(quarantined.map((q) => `${q.suite}\0${q.testName}`));
-    allTests = allTests.filter((t) => !qSet.has(`${t.suite}\0${t.test_name}`));
+    const qSet = new Set(quarantined.map((q) => q.testId));
+    const manifestEntries = opts.quarantineManifestEntries ?? [];
+    const listedTestIndex = buildListedTestIndex(opts.listedTests ?? []);
+    allTests = allTests.filter(
+      (t) => {
+        const key = `${t.suite}\0${t.test_name}`;
+        const enriched = listedTestIndex.get(key)?.[0];
+        const plainId = createStableTestId({
+          suite: t.suite,
+          testName: t.test_name,
+        });
+        const enrichedId = enriched
+          ? createStableTestId({
+              suite: enriched.suite,
+              testName: enriched.testName,
+              taskId: enriched.taskId,
+              filter: enriched.filter,
+              variant: enriched.variant,
+            })
+          : null;
+
+        if (qSet.has(plainId) || (enrichedId != null && qSet.has(enrichedId))) {
+          return false;
+        }
+
+        return !isManifestQuarantined(manifestEntries, {
+          suite: enriched?.suite ?? t.suite,
+          testName: enriched?.testName ?? t.test_name,
+          taskId: enriched?.taskId,
+        });
+      },
+    );
   }
 
   let count: number;

--- a/src/cli/commands/self-eval.ts
+++ b/src/cli/commands/self-eval.ts
@@ -220,7 +220,10 @@ async function evaluateScenario(store: MetricStore, scenario: Scenario): Promise
 
   // For quarantine scenario, quarantine the high-failure test
   if (scenario.name === "quarantine-skip") {
-    await store.addQuarantine("tests/quarantined.spec.ts", "quarantined_test", "auto");
+    await store.addQuarantine(
+      { suite: "tests/quarantined.spec.ts", testName: "quarantined_test" },
+      "auto",
+    );
   }
 
   // Run sampling

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -28,11 +28,8 @@ const DEFAULT_CONFIG: FlakerConfig = {
   flaky: { window_days: 14, detection_threshold: 0.1 },
 };
 
-function deepMerge<T extends Record<string, unknown>>(
-  target: T,
-  source: Record<string, unknown>,
-): T {
-  const result = { ...target } as Record<string, unknown>;
+function deepMerge<T>(target: T, source: Record<string, unknown>): T {
+  const result = { ...(target as Record<string, unknown>) };
   for (const key of Object.keys(source)) {
     const sv = source[key];
     const tv = result[key];

--- a/src/cli/core/loader.ts
+++ b/src/cli/core/loader.ts
@@ -190,14 +190,15 @@ function wrapMbtCore(mbt: MbtJsExports): MetriciCore {
 }
 
 let cachedCore: MetriciCore | undefined;
+const MOONBIT_JS_BUILD_URL = new URL(
+  "../../../src/core/_build/js/debug/build/src/main/main.js",
+  import.meta.url,
+);
 
 export async function loadCore(): Promise<MetriciCore> {
   if (cachedCore) return cachedCore;
   try {
-    const mbtPath = new URL(
-      "../../../src/core/_build/js/debug/build/src/main/main.js",
-      import.meta.url,
-    ).href;
+    const mbtPath = MOONBIT_JS_BUILD_URL.href;
     const mbt = (await import(mbtPath)) as MbtJsExports;
     if (
       typeof mbt.detect_flaky_json === "function" &&
@@ -222,6 +223,15 @@ export async function loadCore(): Promise<MetriciCore> {
   return cachedCore;
 }
 
+export async function hasMoonBitJsBuild(): Promise<boolean> {
+  try {
+    await access(MOONBIT_JS_BUILD_URL);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /** Synchronous fallback for contexts where async is not possible */
 export function loadCoreSync(): MetriciCore {
   return {
@@ -233,7 +243,151 @@ export function loadCoreSync(): MetriciCore {
   };
 }
 
-/** TS fallback: returns empty (no workflow parsing without MoonBit) */
-function resolveAffectedFallback(_workflowText: string, _changedPaths: string[]): string[] {
-  return [];
+interface FallbackTask {
+  id: string;
+  needs: string[];
+  srcs: string[];
 }
+
+/** TS fallback for affected-target resolution when MoonBit build is unavailable. */
+function resolveAffectedFallback(workflowText: string, changedPaths: string[]): string[] {
+  const tasks = parseWorkflowTasks(workflowText);
+  if (tasks.length === 0 || changedPaths.length === 0) return [];
+
+  const initial = new Set<string>();
+  for (const task of tasks) {
+    if (task.srcs.length === 0) continue;
+    const matched = changedPaths.some((path) => task.srcs.some((pattern) => matchGlob(pattern, path)));
+    if (matched) {
+      initial.add(task.id);
+    }
+  }
+  if (initial.size === 0) return [];
+
+  const byNeed = new Map<string, string[]>();
+  for (const task of tasks) {
+    for (const need of task.needs) {
+      const dependents = byNeed.get(need);
+      if (dependents) dependents.push(task.id);
+      else byNeed.set(need, [task.id]);
+    }
+  }
+
+  // Expand transitive dependents (A needed by B => A change affects B)
+  const affected = new Set(initial);
+  const queue = [...initial];
+  for (let i = 0; i < queue.length; i++) {
+    const current = queue[i];
+    for (const dependent of byNeed.get(current) ?? []) {
+      if (!affected.has(dependent)) {
+        affected.add(dependent);
+        queue.push(dependent);
+      }
+    }
+  }
+  return [...affected];
+}
+
+function parseWorkflowTasks(workflowText: string): FallbackTask[] {
+  const blocks = extractTaskBlocks(workflowText);
+  const tasks: FallbackTask[] = [];
+  for (const block of blocks) {
+    const id = getQuotedValue(block, "id");
+    if (!id) continue;
+
+    tasks.push({
+      id,
+      needs: getQuotedArrayValue(block, "needs"),
+      srcs: getQuotedArrayValue(block, "srcs"),
+    });
+  }
+  return tasks;
+}
+
+function extractTaskBlocks(workflowText: string): string[] {
+  const blocks: string[] = [];
+  let i = 0;
+  while (i < workflowText.length) {
+    const idx = workflowText.indexOf("task(", i);
+    if (idx === -1) break;
+
+    let depth = 0;
+    let inString = false;
+    let end = idx;
+    for (; end < workflowText.length; end++) {
+      const ch = workflowText[end];
+      const prev = end > 0 ? workflowText[end - 1] : "";
+
+      if (ch === "\"" && prev !== "\\") {
+        inString = !inString;
+      }
+      if (inString) continue;
+
+      if (ch === "(") depth++;
+      if (ch === ")") {
+        depth--;
+        if (depth === 0) {
+          end++;
+          break;
+        }
+      }
+    }
+    if (end > idx) {
+      blocks.push(workflowText.slice(idx, end));
+      i = end;
+    } else {
+      i = idx + 5;
+    }
+  }
+  return blocks;
+}
+
+function getQuotedValue(line: string, key: string): string | null {
+  const m = new RegExp(`${key}\\s*=\\s*(['"])(.*?)\\1`, "s").exec(line);
+  return m?.[2] ?? null;
+}
+
+function getQuotedArrayValue(line: string, key: string): string[] {
+  const m = new RegExp(`${key}\\s*=\\s*\\[(.*?)\\]`, "s").exec(line);
+  if (!m) return [];
+  const inner = m[1].trim();
+  if (!inner) return [];
+  const values: string[] = [];
+  const re = /(['"])(.*?)\1/g;
+  for (const match of inner.matchAll(re)) {
+    values.push(match[2]);
+  }
+  return values;
+}
+
+function matchGlob(pattern: string, target: string): boolean {
+  const normalizedPattern = pattern.replaceAll("\\", "/");
+  const normalizedTarget = target.replaceAll("\\", "/");
+  const regex = globToRegex(normalizedPattern);
+  return regex.test(normalizedTarget);
+}
+
+function globToRegex(pattern: string): RegExp {
+  let out = "^";
+  for (let i = 0; i < pattern.length; i++) {
+    const ch = pattern[i];
+    if (ch === "*") {
+      const next = pattern[i + 1];
+      if (next === "*") {
+        out += ".*";
+        i++;
+      } else {
+        out += "[^/]*";
+      }
+      continue;
+    }
+    if (".+?^${}()|[]\\".includes(ch)) {
+      out += `\\${ch}`;
+    } else {
+      out += ch;
+    }
+  }
+  out += "$";
+  return new RegExp(out);
+}
+import { access } from "node:fs/promises";

--- a/src/cli/identity.ts
+++ b/src/cli/identity.ts
@@ -1,0 +1,67 @@
+export interface TestIdentityFields {
+  suite: string;
+  testName: string;
+  taskId?: string | null;
+  filter?: string | null;
+  variant?: Record<string, string> | null;
+  testId?: string;
+}
+
+export interface ResolvedTestIdentity extends TestIdentityFields {
+  taskId: string;
+  filter: string | null;
+  variant: Record<string, string> | null;
+  testId: string;
+}
+
+export function normalizeVariant(
+  variant?: Record<string, string> | null,
+): Record<string, string> | null {
+  if (!variant) return null;
+
+  const entries = Object.entries(variant)
+    .filter(([, value]) => value != null)
+    .map(([key, value]) => [key, String(value)] as const)
+    .sort(([a], [b]) => a.localeCompare(b));
+
+  if (entries.length === 0) return null;
+  return Object.fromEntries(entries);
+}
+
+export function createStableTestId(input: TestIdentityFields): string {
+  const taskId = input.taskId ?? input.suite;
+  const filter = input.filter ?? null;
+  const variant = normalizeVariant(input.variant);
+
+  return JSON.stringify({
+    taskId,
+    suite: input.suite,
+    testName: input.testName,
+    filter,
+    variant,
+  });
+}
+
+export function resolveTestIdentity<T extends TestIdentityFields>(
+  input: T,
+): T & ResolvedTestIdentity {
+  const taskId = input.taskId ?? input.suite;
+  const filter = input.filter ?? null;
+  const variant = normalizeVariant(input.variant);
+  const testId =
+    input.testId ??
+    createStableTestId({
+      ...input,
+      taskId,
+      filter,
+      variant,
+    });
+
+  return {
+    ...input,
+    taskId,
+    filter,
+    variant,
+    testId,
+  };
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -23,6 +23,7 @@ import {
 import { runEval, formatEvalReport } from "./commands/eval.js";
 import { runReason, formatReasoningReport } from "./commands/reason.js";
 import { runSelfEval, formatSelfEvalReport } from "./commands/self-eval.js";
+import { runDoctor, formatDoctorReport } from "./commands/doctor.js";
 import { DuckDBStore } from "./storage/duckdb.js";
 
 const program = new Command();
@@ -75,7 +76,19 @@ program
           created: `>=${created.toISOString().split("T")[0]}`,
           per_page: 100,
         });
-        return response.data;
+        return {
+          total_count: response.data.total_count,
+          workflow_runs: response.data.workflow_runs.map((run) => ({
+            id: run.id,
+            head_branch: run.head_branch ?? "",
+            head_sha: run.head_sha,
+            event: run.event,
+            conclusion: run.conclusion ?? "",
+            created_at: run.created_at,
+            run_started_at: run.run_started_at ?? run.created_at,
+            updated_at: run.updated_at,
+          })),
+        };
       },
       async listArtifacts(runId: number) {
         const response = await octokit.actions.listWorkflowRunArtifacts({
@@ -517,6 +530,18 @@ program
       console.log(formatSelfEvalReport(report));
     }
     process.exit(report.overallScore >= 80 ? 0 : 1);
+  });
+
+// --- doctor ---
+program
+  .command("doctor")
+  .description("Check local flaker runtime requirements")
+  .action(async () => {
+    const report = await runDoctor(process.cwd(), {
+      createStore: () => new DuckDBStore(":memory:"),
+    });
+    console.log(formatDoctorReport(report));
+    process.exit(report.ok ? 0 : 1);
   });
 
 program.parse();

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -25,8 +25,75 @@ import { runReason, formatReasoningReport } from "./commands/reason.js";
 import { runSelfEval, formatSelfEvalReport } from "./commands/self-eval.js";
 import { runDoctor, formatDoctorReport } from "./commands/doctor.js";
 import { DuckDBStore } from "./storage/duckdb.js";
+import { createRunner } from "./runners/index.js";
+import { resolveTestIdentity } from "./identity.js";
+import { toStoredTestResult } from "./storage/test-result-mapper.js";
+import {
+  formatQuarantineManifestReport,
+  loadQuarantineManifest,
+  loadQuarantineManifestIfExists,
+  resolveQuarantineManifestPath,
+  validateQuarantineManifest,
+} from "./quarantine-manifest.js";
 
 const program = new Command();
+
+async function collectKnownQuarantineTaskIds(
+  cwd: string,
+  store: DuckDBStore,
+  runnerConfig: {
+    type: string;
+    command: string;
+    execute?: string;
+    list?: string;
+  },
+): Promise<string[]> {
+  const taskIds = new Set<string>();
+  const persisted = await store.raw<{ task_id: string }>(`
+    SELECT DISTINCT task_id
+    FROM test_results
+    WHERE task_id IS NOT NULL AND task_id <> ''
+  `);
+  for (const row of persisted) {
+    taskIds.add(row.task_id);
+  }
+
+  try {
+    const runner = createRunner(runnerConfig);
+    const listedTests = await runner.listTests({ cwd });
+    for (const test of listedTests) {
+      const resolved = resolveTestIdentity({
+        suite: test.suite,
+        testName: test.testName,
+        taskId: test.taskId,
+        filter: test.filter,
+        variant: test.variant,
+      });
+      taskIds.add(resolved.taskId);
+    }
+  } catch {
+    // Best-effort: fall back to persisted task ids only.
+  }
+
+  return [...taskIds].sort();
+}
+
+async function listRunnerTests(
+  cwd: string,
+  runnerConfig: {
+    type: string;
+    command: string;
+    execute?: string;
+    list?: string;
+  },
+) {
+  try {
+    const runner = createRunner(runnerConfig);
+    return await runner.listTests({ cwd });
+  } catch {
+    return [];
+  }
+}
 
 program
   .name("flaker")
@@ -180,6 +247,13 @@ program
       try {
         const changedFiles = opts.changed?.split(",").map(f => f.trim()).filter(Boolean);
         const mode = opts.strategy as "random" | "weighted" | "affected" | "hybrid";
+        const manifest = opts.skipQuarantined
+          ? loadQuarantineManifestIfExists({ cwd: process.cwd() })
+          : null;
+        const listedTests =
+          opts.skipQuarantined && manifest
+            ? await listRunnerTests(process.cwd(), config.runner)
+            : [];
 
         // Create resolver from config for affected/hybrid
         let resolver;
@@ -208,6 +282,8 @@ program
           skipQuarantined: opts.skipQuarantined,
           resolver,
           changedFiles,
+          quarantineManifestEntries: manifest?.entries,
+          listedTests,
         });
         for (const t of sampled) {
           console.log(`${t.suite} > ${t.test_name}`);
@@ -235,6 +311,9 @@ program
       await store.initialize();
 
       try {
+        const manifest = opts.skipQuarantined
+          ? loadQuarantineManifestIfExists({ cwd: process.cwd() })
+          : null;
         if (opts.runner === "actrun") {
           const actRunner = new ActrunRunner({
             workflow: config.runner.command,
@@ -271,18 +350,15 @@ program
                 createdAt: new Date(result.startedAt),
                 durationMs: result.durationMs,
               });
-              await store.insertTestResults(testCases.map((tc) => ({
-                workflowRunId: runId,
-                suite: tc.suite,
-                testName: tc.testName,
-                status: tc.status,
-                durationMs: tc.durationMs,
-                retryCount: tc.retryCount,
-                errorMessage: tc.errorMessage ?? null,
-                commitSha: result.headSha,
-                variant: tc.variant ?? null,
-                createdAt: new Date(result.startedAt),
-              })));
+              await store.insertTestResults(
+                testCases.map((tc) =>
+                  toStoredTestResult(tc, {
+                    workflowRunId: runId,
+                    commitSha: result.headSha,
+                    createdAt: new Date(result.startedAt),
+                  }),
+                ),
+              );
               console.log(`Imported ${testCases.length} test results from actrun run ${result.runId}`);
             }
             // Run eval mini-report
@@ -292,14 +368,19 @@ program
           }
           return;
         }
-        await runTests({
+        const runResult = await runTests({
           store,
-          command: config.runner.command,
+          runner: createRunner(config.runner),
           mode: opts.strategy as "random" | "weighted",
           count: opts.count ? Number(opts.count) : undefined,
           percentage: opts.percentage ? Number(opts.percentage) : undefined,
           skipQuarantined: opts.skipQuarantined,
+          quarantineManifestEntries: manifest?.entries,
+          cwd: process.cwd(),
         });
+        if (runResult.exitCode !== 0) {
+          process.exit(1);
+        }
       } finally {
         await store.close();
       }
@@ -324,7 +405,7 @@ program
   });
 
 // --- quarantine ---
-program
+const quarantineCommand = program
   .command("quarantine")
   .description("Manage quarantined tests")
   .option("--add <suite:testName>", "Add a test to quarantine (suite:testName)")
@@ -389,6 +470,105 @@ program
       }
     },
   );
+
+quarantineCommand
+  .command("check")
+  .description("Validate the repo-tracked quarantine manifest")
+  .option("--manifest <path>", "Override manifest path")
+  .action(async (opts: { manifest?: string }) => {
+    const cwd = process.cwd();
+    const config = loadConfig(cwd);
+    const store = new DuckDBStore(resolve(config.storage.path));
+    await store.initialize();
+
+    try {
+      const manifestPath = resolveQuarantineManifestPath({
+        cwd,
+        manifestPath: opts.manifest,
+      });
+      if (!manifestPath) {
+        console.error("Error: quarantine manifest not found");
+        process.exit(1);
+      }
+
+      const manifest = loadQuarantineManifest({
+        cwd,
+        manifestPath,
+      });
+      const knownTaskIds = await collectKnownQuarantineTaskIds(
+        cwd,
+        store,
+        config.runner,
+      );
+      const report = validateQuarantineManifest({
+        cwd,
+        manifest,
+        manifestPath,
+        knownTaskIds,
+      });
+
+      if (report.errors.length > 0) {
+        console.error(formatQuarantineManifestReport(report, "markdown"));
+        process.exit(1);
+      }
+      console.log(formatQuarantineManifestReport(report, "markdown"));
+    } finally {
+      await store.close();
+    }
+  });
+
+quarantineCommand
+  .command("report")
+  .description("Render a quarantine manifest report")
+  .option("--manifest <path>", "Override manifest path")
+  .option("--json", "Output JSON report")
+  .option("--markdown", "Output Markdown report")
+  .action(async (opts: { manifest?: string; json?: boolean; markdown?: boolean }) => {
+    if (opts.json && opts.markdown) {
+      console.error("Error: choose either --json or --markdown");
+      process.exit(1);
+    }
+
+    const cwd = process.cwd();
+    const config = loadConfig(cwd);
+    const store = new DuckDBStore(resolve(config.storage.path));
+    await store.initialize();
+
+    try {
+      const manifestPath = resolveQuarantineManifestPath({
+        cwd,
+        manifestPath: opts.manifest,
+      });
+      if (!manifestPath) {
+        console.error("Error: quarantine manifest not found");
+        process.exit(1);
+      }
+
+      const manifest = loadQuarantineManifest({
+        cwd,
+        manifestPath,
+      });
+      const knownTaskIds = await collectKnownQuarantineTaskIds(
+        cwd,
+        store,
+        config.runner,
+      );
+      const report = validateQuarantineManifest({
+        cwd,
+        manifest,
+        manifestPath,
+        knownTaskIds,
+      });
+      console.log(
+        formatQuarantineManifestReport(
+          report,
+          opts.json ? "json" : "markdown",
+        ),
+      );
+    } finally {
+      await store.close();
+    }
+  });
 
 // --- eval ---
 program

--- a/src/cli/quarantine-manifest.ts
+++ b/src/cli/quarantine-manifest.ts
@@ -1,0 +1,394 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { resolveTestIdentity } from "./identity.js";
+
+export type QuarantineMode = "skip" | "allow_flaky" | "allow_failure";
+export type QuarantineScope =
+  | "environment"
+  | "flaky"
+  | "expected_failure";
+
+export interface QuarantineManifestEntry {
+  id: string;
+  taskId: string;
+  spec: string;
+  titlePattern: string;
+  mode: QuarantineMode;
+  scope: QuarantineScope;
+  owner: string;
+  reason: string;
+  condition: string;
+  introducedAt: string;
+  expiresAt: string;
+  trackingIssue?: string;
+}
+
+export interface QuarantineManifest {
+  entries: QuarantineManifestEntry[];
+}
+
+export interface QuarantineManifestProblem {
+  code: string;
+  entryId: string;
+  message: string;
+}
+
+export interface QuarantineManifestReport {
+  manifestPath: string;
+  entries: QuarantineManifestEntry[];
+  errors: QuarantineManifestProblem[];
+  warnings: QuarantineManifestProblem[];
+  summary: {
+    totalEntries: number;
+    errorCount: number;
+    warningCount: number;
+    expiredCount: number;
+    nearExpiryCount: number;
+  };
+}
+
+export interface QuarantineManifestSelector {
+  suite: string;
+  testName: string;
+  taskId?: string | null;
+}
+
+interface FindMatchingManifestEntryOpts {
+  modes?: QuarantineMode[];
+}
+
+interface LoadQuarantineManifestOpts {
+  cwd: string;
+  manifestPath?: string;
+}
+
+interface ValidateQuarantineManifestOpts {
+  cwd: string;
+  manifest: QuarantineManifest;
+  manifestPath: string;
+  knownTaskIds?: string[];
+  now?: Date;
+  expiringWithinDays?: number;
+}
+
+const DEFAULT_MANIFEST_FILES = [
+  "flaker.quarantine.json",
+  "flaker-quarantine.json",
+] as const;
+
+const QUARANTINE_MODES = new Set<QuarantineMode>([
+  "skip",
+  "allow_flaky",
+  "allow_failure",
+]);
+const QUARANTINE_SCOPES = new Set<QuarantineScope>([
+  "environment",
+  "flaky",
+  "expected_failure",
+]);
+
+export function resolveQuarantineManifestPath(
+  opts: LoadQuarantineManifestOpts,
+): string | null {
+  if (opts.manifestPath) {
+    return resolve(opts.cwd, opts.manifestPath);
+  }
+
+  for (const fileName of DEFAULT_MANIFEST_FILES) {
+    const candidate = join(opts.cwd, fileName);
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function parseManifestFile(manifestPath: string): QuarantineManifest {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(manifestPath, "utf-8"));
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "unknown parse error";
+    throw new Error(
+      `Failed to parse quarantine manifest at ${manifestPath}: ${message}`,
+    );
+  }
+
+  if (
+    !parsed ||
+    typeof parsed !== "object" ||
+    !("entries" in parsed) ||
+    !Array.isArray((parsed as { entries?: unknown }).entries)
+  ) {
+    throw new Error(
+      `Invalid quarantine manifest at ${manifestPath}: expected {"entries": []}`,
+    );
+  }
+
+  return {
+    entries: (parsed as { entries: QuarantineManifestEntry[] }).entries,
+  };
+}
+
+function normalizeSpecPath(spec: string): string {
+  return spec.replaceAll("\\", "/");
+}
+
+function parseDate(value: string): Date | null {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export function loadQuarantineManifest(
+  opts: LoadQuarantineManifestOpts,
+): QuarantineManifest {
+  const manifestPath = resolveQuarantineManifestPath(opts);
+  if (!manifestPath) {
+    throw new Error(`Quarantine manifest not found in ${opts.cwd}`);
+  }
+  return parseManifestFile(manifestPath);
+}
+
+export function loadQuarantineManifestIfExists(
+  opts: LoadQuarantineManifestOpts,
+): QuarantineManifest | null {
+  const manifestPath = resolveQuarantineManifestPath(opts);
+  if (!manifestPath) {
+    return null;
+  }
+  return parseManifestFile(manifestPath);
+}
+
+export function validateQuarantineManifest(
+  opts: ValidateQuarantineManifestOpts,
+): QuarantineManifestReport {
+  const errors: QuarantineManifestProblem[] = [];
+  const warnings: QuarantineManifestProblem[] = [];
+  const knownTaskIds = new Set(opts.knownTaskIds ?? []);
+  const now = opts.now ?? new Date();
+  const expiringWithinDays = opts.expiringWithinDays ?? 7;
+  const seenIds = new Set<string>();
+  let expiredCount = 0;
+  let nearExpiryCount = 0;
+
+  for (const [index, entry] of opts.manifest.entries.entries()) {
+    const entryId =
+      isNonEmptyString(entry?.id) ? entry.id : `entry-${index + 1}`;
+
+    const pushError = (code: string, message: string) => {
+      errors.push({ code, entryId, message });
+    };
+    const pushWarning = (code: string, message: string) => {
+      warnings.push({ code, entryId, message });
+    };
+
+    if (!isNonEmptyString(entry?.id)) {
+      pushError("invalid-id", "Entry id is required.");
+    } else if (seenIds.has(entry.id)) {
+      pushError("duplicate-id", `Duplicate entry id: ${entry.id}`);
+    } else {
+      seenIds.add(entry.id);
+    }
+
+    if (!isNonEmptyString(entry?.taskId)) {
+      pushError("invalid-task", "taskId is required.");
+    } else if (knownTaskIds.size > 0 && !knownTaskIds.has(entry.taskId)) {
+      pushError("unknown-task", `Unknown taskId: ${entry.taskId}`);
+    }
+
+    if (!isNonEmptyString(entry?.spec)) {
+      pushError("invalid-spec", "spec is required.");
+    } else {
+      const specPath = resolve(opts.cwd, entry.spec);
+      if (!existsSync(specPath)) {
+        pushError("missing-spec", `Spec does not exist: ${entry.spec}`);
+      }
+    }
+
+    if (!isNonEmptyString(entry?.titlePattern)) {
+      pushError("invalid-pattern", "titlePattern is required.");
+    } else {
+      try {
+        new RegExp(entry.titlePattern);
+      } catch {
+        pushError("invalid-pattern", `Invalid titlePattern: ${entry.titlePattern}`);
+      }
+    }
+
+    if (!isNonEmptyString(entry?.mode) || !QUARANTINE_MODES.has(entry.mode)) {
+      pushError("invalid-mode", `Unsupported mode: ${String(entry?.mode)}`);
+    }
+
+    if (
+      !isNonEmptyString(entry?.scope) ||
+      !QUARANTINE_SCOPES.has(entry.scope)
+    ) {
+      pushError("invalid-scope", `Unsupported scope: ${String(entry?.scope)}`);
+    }
+
+    for (const field of ["owner", "reason", "condition"] as const) {
+      if (!isNonEmptyString(entry?.[field])) {
+        pushError(`invalid-${field}`, `${field} is required.`);
+      }
+    }
+
+    const introducedAt = isNonEmptyString(entry?.introducedAt)
+      ? parseDate(entry.introducedAt)
+      : null;
+    if (!introducedAt) {
+      pushError(
+        "invalid-introduced-at",
+        `Invalid introducedAt: ${String(entry?.introducedAt)}`,
+      );
+    }
+
+    const expiresAt = isNonEmptyString(entry?.expiresAt)
+      ? parseDate(entry.expiresAt)
+      : null;
+    if (!expiresAt) {
+      pushError(
+        "invalid-expires-at",
+        `Invalid expiresAt: ${String(entry?.expiresAt)}`,
+      );
+    } else {
+      const diffDays = Math.ceil(
+        (expiresAt.getTime() - now.getTime()) / (24 * 60 * 60 * 1000),
+      );
+      if (expiresAt.getTime() < now.getTime()) {
+        expiredCount++;
+        pushError(
+          "expired-entry",
+          `Entry expired on ${entry.expiresAt}.`,
+        );
+      } else if (diffDays <= expiringWithinDays) {
+        nearExpiryCount++;
+        pushWarning(
+          "near-expiry",
+          `Near expiry: ${entry.expiresAt}.`,
+        );
+      }
+    }
+  }
+
+  return {
+    manifestPath: opts.manifestPath,
+    entries: opts.manifest.entries,
+    errors,
+    warnings,
+    summary: {
+      totalEntries: opts.manifest.entries.length,
+      errorCount: errors.length,
+      warningCount: warnings.length,
+      expiredCount,
+      nearExpiryCount,
+    },
+  };
+}
+
+function matchesManifestEntry(
+  entry: QuarantineManifestEntry,
+  selector: QuarantineManifestSelector,
+  opts?: FindMatchingManifestEntryOpts,
+): boolean {
+  if (opts?.modes && !opts.modes.includes(entry.mode)) {
+    return false;
+  }
+
+  const resolved = resolveTestIdentity({
+    suite: selector.suite,
+    testName: selector.testName,
+    taskId: selector.taskId,
+  });
+
+  if (entry.taskId !== resolved.taskId) {
+    return false;
+  }
+  if (normalizeSpecPath(entry.spec) !== normalizeSpecPath(resolved.suite)) {
+    return false;
+  }
+
+  try {
+    return new RegExp(entry.titlePattern).test(resolved.testName);
+  } catch {
+    return false;
+  }
+}
+
+export function findMatchingManifestEntry(
+  entries: QuarantineManifestEntry[],
+  selector: QuarantineManifestSelector,
+  opts?: FindMatchingManifestEntryOpts,
+): QuarantineManifestEntry | undefined {
+  return entries.find((entry) => matchesManifestEntry(entry, selector, opts));
+}
+
+export function isManifestQuarantined(
+  entries: QuarantineManifestEntry[],
+  selector: QuarantineManifestSelector,
+): boolean {
+  return findMatchingManifestEntry(entries, selector, {
+    modes: ["skip"],
+  }) != null;
+}
+
+export function formatQuarantineManifestReport(
+  report: QuarantineManifestReport,
+  format: "json" | "markdown",
+): string {
+  if (format === "json") {
+    return JSON.stringify(report, null, 2);
+  }
+
+  const lines = [
+    "# Quarantine Manifest Report",
+    "",
+    `- Manifest: \`${report.manifestPath}\``,
+    `- Entries: ${report.summary.totalEntries}`,
+    `- Errors: ${report.summary.errorCount}`,
+    `- Warnings: ${report.summary.warningCount}`,
+    "",
+    "## Entries",
+    "",
+    "| ID | Task | Spec | Mode | Scope | Expires At | Owner |",
+    "| --- | --- | --- | --- | --- | --- | --- |",
+    ...report.entries.map(
+      (entry) =>
+        `| ${entry.id} | ${entry.taskId} | ${entry.spec} | ${entry.mode} | ${entry.scope} | ${entry.expiresAt} | ${entry.owner} |`,
+    ),
+  ];
+
+  if (report.errors.length > 0) {
+    lines.push(
+      "",
+      "## Errors",
+      "",
+      "| ID | Code | Message |",
+      "| --- | --- | --- |",
+      ...report.errors.map(
+        (error) => `| ${error.entryId} | ${error.code} | ${error.message} |`,
+      ),
+    );
+  }
+
+  if (report.warnings.length > 0) {
+    lines.push(
+      "",
+      "## Warnings",
+      "",
+      "| ID | Code | Message |",
+      "| --- | --- | --- |",
+      ...report.warnings.map(
+        (warning) =>
+          `| ${warning.entryId} | ${warning.code} | ${warning.message} |`,
+      ),
+    );
+  }
+
+  return lines.join("\n");
+}

--- a/src/cli/runners/index.ts
+++ b/src/cli/runners/index.ts
@@ -38,3 +38,4 @@ export type {
 export { orchestrate } from "./orchestrator.js";
 export type { OrchestrateOpts } from "./orchestrator.js";
 export { executeWithRetry, type RetryResult } from "./retry.js";
+export { withQuarantineRuntime, isBlockingFailure } from "./quarantine-runtime.js";

--- a/src/cli/runners/playwright.ts
+++ b/src/cli/runners/playwright.ts
@@ -33,18 +33,24 @@ interface PlaywrightListOutput {
 
 function collectSpecs(
   suite: PlaywrightListSuite,
-  parentTitle: string | null,
+  currentFile: string | null,
+  currentTaskId: string | null,
   out: TestId[],
 ): void {
-  const currentTitle = parentTitle ?? suite.title;
+  const nextFile = suite.file ?? currentFile ?? suite.title;
+  const nextTaskId = currentTaskId ?? suite.title;
   if (suite.specs) {
     for (const spec of suite.specs) {
-      out.push({ suite: currentTitle, testName: spec.title });
+      out.push({
+        suite: spec.file ?? nextFile,
+        testName: spec.title,
+        taskId: nextTaskId,
+      });
     }
   }
   if (suite.suites) {
     for (const child of suite.suites) {
-      collectSpecs(child, child.title, out);
+      collectSpecs(child, nextFile, child.title, out);
     }
   }
 }
@@ -53,7 +59,7 @@ export function parsePlaywrightList(stdout: string): TestId[] {
   const data: PlaywrightListOutput = JSON.parse(stdout);
   const ids: TestId[] = [];
   for (const suite of data.suites) {
-    collectSpecs(suite, null, ids);
+    collectSpecs(suite, suite.file ?? null, suite.title, ids);
   }
   return ids;
 }

--- a/src/cli/runners/quarantine-runtime.ts
+++ b/src/cli/runners/quarantine-runtime.ts
@@ -1,0 +1,189 @@
+import type { TestCaseResult } from "../adapters/types.js";
+import { normalizeVariant, resolveTestIdentity } from "../identity.js";
+import {
+  findMatchingManifestEntry,
+  type QuarantineManifestEntry,
+} from "../quarantine-manifest.js";
+import type {
+  ExecuteOpts,
+  ExecuteResult,
+  RunnerAdapter,
+  TestId,
+} from "./types.js";
+
+function formatQuarantineMessage(entry: QuarantineManifestEntry): string {
+  return `[quarantine:${entry.id}] mode=${entry.mode} owner=${entry.owner} reason=${entry.reason}`;
+}
+
+function appendQuarantineMessage(
+  errorMessage: string | undefined,
+  entry: QuarantineManifestEntry,
+): string {
+  const quarantineMessage = formatQuarantineMessage(entry);
+  if (!errorMessage) {
+    return quarantineMessage;
+  }
+  if (errorMessage.includes(quarantineMessage)) {
+    return errorMessage;
+  }
+  return `${errorMessage}\n${quarantineMessage}`;
+}
+
+function annotateResult(
+  result: TestCaseResult,
+  entry: QuarantineManifestEntry,
+): TestCaseResult {
+  const shouldAnnotateMessage =
+    result.status === "failed" ||
+    result.status === "flaky" ||
+    result.status === "skipped";
+
+  return {
+    ...result,
+    quarantine: entry,
+    errorMessage: shouldAnnotateMessage
+      ? appendQuarantineMessage(result.errorMessage, entry)
+      : result.errorMessage,
+  };
+}
+
+function createSkippedResult(
+  test: TestId,
+  entry: QuarantineManifestEntry,
+): TestCaseResult {
+  const resolved = resolveTestIdentity(test);
+  return {
+    suite: resolved.suite,
+    testName: resolved.testName,
+    taskId: resolved.taskId,
+    filter: resolved.filter,
+    variant: resolved.variant,
+    testId: resolved.testId,
+    status: "skipped",
+    durationMs: 0,
+    retryCount: 0,
+    errorMessage: formatQuarantineMessage(entry),
+    quarantine: entry,
+  };
+}
+
+function buildLookupKey(input: {
+  suite: string;
+  testName: string;
+  filter?: string | null;
+  variant?: Record<string, string> | null;
+}): string {
+  return JSON.stringify({
+    suite: input.suite,
+    testName: input.testName,
+    filter: input.filter ?? null,
+    variant: normalizeVariant(input.variant),
+  });
+}
+
+function createRequestedIdentityLookup(tests: TestId[]): Map<string, TestId> {
+  const lookup = new Map<string, TestId>();
+  for (const test of tests) {
+    lookup.set(buildLookupKey(test), resolveTestIdentity(test));
+  }
+  return lookup;
+}
+
+function resolveRuntimeIdentity(
+  result: TestCaseResult,
+  requestedLookup: Map<string, TestId>,
+): TestCaseResult {
+  const fallback = requestedLookup.get(buildLookupKey(result));
+  return resolveTestIdentity({
+    ...result,
+    taskId: result.taskId ?? fallback?.taskId,
+    filter: result.filter ?? fallback?.filter,
+    variant: result.variant ?? fallback?.variant,
+    testId: result.testId ?? fallback?.testId,
+  });
+}
+
+export function isBlockingFailure(result: TestCaseResult): boolean {
+  return (
+    result.status === "failed" &&
+    result.quarantine?.mode !== "allow_failure"
+  );
+}
+
+function annotateRuntimeResults(
+  results: TestCaseResult[],
+  tests: TestId[],
+  entries: QuarantineManifestEntry[],
+): TestCaseResult[] {
+  const requestedLookup = createRequestedIdentityLookup(tests);
+  return results.map((result) => {
+    const resolved = resolveRuntimeIdentity(result, requestedLookup);
+    const entry = findMatchingManifestEntry(entries, resolved);
+    if (!entry) {
+      return resolved;
+    }
+    return annotateResult(resolved, entry);
+  });
+}
+
+function computeExitCode(results: TestCaseResult[], fallbackExitCode: number): number {
+  if (results.some(isBlockingFailure)) {
+    return 1;
+  }
+  if (results.length === 0) {
+    return fallbackExitCode;
+  }
+  return 0;
+}
+
+export function withQuarantineRuntime(
+  runner: RunnerAdapter,
+  entries: QuarantineManifestEntry[],
+): RunnerAdapter {
+  if (entries.length === 0) {
+    return runner;
+  }
+
+  return {
+    ...runner,
+    name: `${runner.name}+quarantine`,
+    async execute(tests: TestId[], opts?: ExecuteOpts): Promise<ExecuteResult> {
+      const runnable: TestId[] = [];
+      const skipped: TestCaseResult[] = [];
+
+      for (const test of tests) {
+        const entry = findMatchingManifestEntry(entries, test, {
+          modes: ["skip"],
+        });
+        if (entry) {
+          skipped.push(createSkippedResult(test, entry));
+          continue;
+        }
+        runnable.push(test);
+      }
+
+      const baseResult =
+        runnable.length > 0
+          ? await runner.execute(runnable, opts)
+          : {
+              exitCode: 0,
+              results: [],
+              durationMs: 0,
+              stdout: "",
+              stderr: "",
+            };
+
+      const annotated = annotateRuntimeResults(baseResult.results, runnable, entries);
+      const results = [...skipped, ...annotated];
+
+      return {
+        ...baseResult,
+        results,
+        exitCode: computeExitCode(results, baseResult.exitCode),
+      };
+    },
+    async listTests(opts?: ExecuteOpts): Promise<TestId[]> {
+      return runner.listTests(opts);
+    },
+  };
+}

--- a/src/cli/runners/retry.ts
+++ b/src/cli/runners/retry.ts
@@ -1,5 +1,7 @@
 import type { RunnerAdapter, TestId, ExecuteOpts, ExecuteResult } from "./types.js";
 import type { TestCaseResult } from "../adapters/types.js";
+import { resolveTestIdentity } from "../identity.js";
+import { isBlockingFailure } from "./quarantine-runtime.js";
 
 interface RetryOpts extends ExecuteOpts {
   maxRetries: number;
@@ -34,8 +36,8 @@ export async function executeWithRetry(
   const allResults = new Map<string, TestCaseResult[]>();
   // Track results per test
   for (const r of firstResult.results) {
-    const key = `${r.suite}\0${r.testName}`;
-    allResults.set(key, [r]);
+    const resolved = resolveTestIdentity(r);
+    allResults.set(resolved.testId, [resolved]);
   }
 
   let retriedTests = 0;
@@ -46,8 +48,16 @@ export async function executeWithRetry(
     // Find tests to retry based on the latest results
     const testsToRetry: TestId[] = [];
     for (const r of lastResult.results) {
-      if (r.status === "failed") {
-        testsToRetry.push({ suite: r.suite, testName: r.testName });
+      const resolved = resolveTestIdentity(r);
+      if (isBlockingFailure(resolved)) {
+        testsToRetry.push({
+          suite: resolved.suite,
+          testName: resolved.testName,
+          taskId: resolved.taskId,
+          filter: resolved.filter,
+          variant: resolved.variant,
+          testId: resolved.testId,
+        });
       }
     }
 
@@ -63,9 +73,10 @@ export async function executeWithRetry(
 
     // Merge results
     for (const r of retryResult.results) {
-      const key = `${r.suite}\0${r.testName}`;
+      const resolved = resolveTestIdentity(r);
+      const key = resolved.testId;
       const history = allResults.get(key) ?? [];
-      history.push(r);
+      history.push(resolved);
       allResults.set(key, history);
     }
 
@@ -84,7 +95,14 @@ export async function executeWithRetry(
 
     if (hasFailure && lastPassed) {
       // Failed at first, passed on retry = flaky
-      flakyDetected.push({ suite: lastResultEntry.suite, testName: lastResultEntry.testName });
+      flakyDetected.push({
+        suite: lastResultEntry.suite,
+        testName: lastResultEntry.testName,
+        taskId: lastResultEntry.taskId,
+        filter: lastResultEntry.filter,
+        variant: lastResultEntry.variant,
+        testId: lastResultEntry.testId,
+      });
       finalResults.push({
         ...lastResultEntry,
         status: "flaky",
@@ -99,7 +117,7 @@ export async function executeWithRetry(
     }
   }
 
-  const exitCode = finalResults.some(r => r.status === "failed") ? 1 : 0;
+  const exitCode = finalResults.some(isBlockingFailure) ? 1 : 0;
 
   return {
     exitCode,

--- a/src/cli/runners/types.ts
+++ b/src/cli/runners/types.ts
@@ -3,6 +3,10 @@ import type { TestCaseResult } from "../adapters/types.js";
 export interface TestId {
   suite: string;
   testName: string;
+  taskId?: string | null;
+  filter?: string | null;
+  variant?: Record<string, string> | null;
+  testId?: string;
 }
 
 export interface RunnerCapabilities {

--- a/src/cli/storage/duckdb.ts
+++ b/src/cli/storage/duckdb.ts
@@ -1,4 +1,3 @@
-import duckdb from "duckdb";
 import { SCHEMA_DDL, FLAKY_QUERY } from "./schema.js";
 import type {
   MetricStore,
@@ -13,8 +12,8 @@ import type {
 } from "./types.js";
 
 export class DuckDBStore implements MetricStore {
-  private db: duckdb.Database | null = null;
-  private conn: duckdb.Connection | null = null;
+  private db: DuckDBDatabase | null = null;
+  private conn: DuckDBConnection | null = null;
   private dbPath: string;
 
   constructor(dbPath: string) {
@@ -22,14 +21,40 @@ export class DuckDBStore implements MetricStore {
   }
 
   async initialize(): Promise<void> {
-    this.db = await new Promise<duckdb.Database>((resolve, reject) => {
-      const db = new duckdb.Database(this.dbPath, (err: any) => {
-        if (err) reject(err);
-        else resolve(db);
-      });
+    let duckdb: DuckDBModule;
+    try {
+      duckdb = await this.loadDuckDBModule();
+    } catch (error) {
+      throw this.buildDuckDBLoadError(error);
+    }
+    this.db = await new Promise<DuckDBDatabase>((resolve, reject) => {
+      try {
+        const db = new duckdb.Database(this.dbPath, (err: any) => {
+          if (err) reject(err);
+          else resolve(db);
+        });
+      } catch (err) {
+        reject(err);
+      }
     });
     this.conn = this.db.connect();
     await this.exec(SCHEMA_DDL);
+  }
+
+  private async loadDuckDBModule(): Promise<DuckDBModule> {
+    const mod = (await import("duckdb")) as unknown as { default?: DuckDBModule } & DuckDBModule;
+    return mod.default ?? mod;
+  }
+
+  private buildDuckDBLoadError(error: unknown): Error {
+    return new Error(
+      [
+        "Failed to load DuckDB native binding.",
+        "Install/rebuild dependencies and ensure the runtime can load native modules.",
+        "Try: npm_config_nodedir=$(dirname $(dirname $(which node))) pnpm rebuild duckdb",
+        `Original error: ${error instanceof Error ? error.message : String(error)}`,
+      ].join(" ")
+    );
   }
 
   async close(): Promise<void> {
@@ -277,3 +302,18 @@ export class DuckDBStore implements MetricStore {
     });
   }
 }
+
+type DuckDBModule = {
+  Database: new (...args: unknown[]) => DuckDBDatabase;
+};
+
+type DuckDBDatabase = {
+  connect: () => DuckDBConnection;
+  close: (callback: (err: unknown) => void) => void;
+};
+
+type DuckDBConnection = {
+  all: (sql: string, ...params: unknown[]) => void;
+  run: (sql: string, ...params: unknown[]) => void;
+  exec: (sql: string, callback: (err: unknown) => void) => void;
+};

--- a/src/cli/storage/duckdb.ts
+++ b/src/cli/storage/duckdb.ts
@@ -1,4 +1,5 @@
 import { SCHEMA_DDL, FLAKY_QUERY } from "./schema.js";
+import { createStableTestId, resolveTestIdentity } from "../identity.js";
 import type {
   MetricStore,
   WorkflowRun,
@@ -9,6 +10,7 @@ import type {
   TrendEntry,
   TrueFlakyScore,
   VariantFlakyScore,
+  TestSelector,
 } from "./types.js";
 
 export class DuckDBStore implements MetricStore {
@@ -39,6 +41,7 @@ export class DuckDBStore implements MetricStore {
     });
     this.conn = this.db.connect();
     await this.exec(SCHEMA_DDL);
+    await this.backfillLegacyQuarantineEntries();
   }
 
   private async loadDuckDBModule(): Promise<DuckDBModule> {
@@ -89,20 +92,25 @@ export class DuckDBStore implements MetricStore {
 
   async insertTestResults(results: TestResult[]): Promise<void> {
     for (const r of results) {
+      const resolved = resolveTestIdentity(r);
       await this.run(
-        `INSERT INTO test_results (id, workflow_run_id, suite, test_name, status, duration_ms, retry_count, error_message, commit_sha, variant, created_at)
-         VALUES (nextval('test_results_id_seq'), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO test_results (id, workflow_run_id, test_id, task_id, suite, test_name, filter_text, status, duration_ms, retry_count, error_message, commit_sha, variant, quarantine, created_at)
+         VALUES (nextval('test_results_id_seq'), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         [
-          r.workflowRunId,
-          r.suite,
-          r.testName,
-          r.status,
-          r.durationMs,
-          r.retryCount,
-          r.errorMessage,
-          r.commitSha,
-          r.variant ? JSON.stringify(r.variant) : null,
-          r.createdAt,
+          resolved.workflowRunId,
+          resolved.testId,
+          resolved.taskId,
+          resolved.suite,
+          resolved.testName,
+          resolved.filter,
+          resolved.status,
+          resolved.durationMs,
+          resolved.retryCount,
+          resolved.errorMessage,
+          resolved.commitSha,
+          resolved.variant ? JSON.stringify(resolved.variant) : null,
+          resolved.quarantine ? JSON.stringify(resolved.quarantine) : null,
+          resolved.createdAt,
         ]
       );
     }
@@ -111,17 +119,30 @@ export class DuckDBStore implements MetricStore {
   async queryFlakyTests(opts: FlakyQueryOpts): Promise<FlakyScore[]> {
     const windowDays = opts.windowDays ?? 30;
     const rows = await this.all(FLAKY_QUERY, [windowDays.toString()]);
-    return rows.map((row: any) => ({
-      suite: row.suite,
-      testName: row.test_name,
-      variant: row.variant ? JSON.parse(row.variant) : null,
-      totalRuns: row.total_runs,
-      failCount: row.fail_count,
-      flakyRetryCount: row.flaky_retry_count,
-      flakyRate: row.flaky_rate,
-      lastFlakyAt: row.last_flaky_at ? new Date(row.last_flaky_at) : null,
-      firstSeenAt: new Date(row.first_seen_at),
-    }));
+    return rows.map((row: any) => {
+      const resolved = resolveTestIdentity({
+        suite: row.suite,
+        testName: row.test_name,
+        taskId: row.task_id,
+        filter: row.filter_text,
+        variant: row.variant ? JSON.parse(row.variant) : null,
+        testId: row.test_id || undefined,
+      });
+      return {
+        testId: resolved.testId,
+        suite: resolved.suite,
+        testName: resolved.testName,
+        taskId: resolved.taskId,
+        filter: resolved.filter,
+        variant: resolved.variant,
+        totalRuns: row.total_runs,
+        failCount: row.fail_count,
+        flakyRetryCount: row.flaky_retry_count,
+        flakyRate: row.flaky_rate,
+        lastFlakyAt: row.last_flaky_at ? new Date(row.last_flaky_at) : null,
+        firstSeenAt: new Date(row.first_seen_at),
+      };
+    });
   }
 
   async queryTestHistory(
@@ -132,42 +153,62 @@ export class DuckDBStore implements MetricStore {
       `SELECT * FROM test_results WHERE suite = ? AND test_name = ? ORDER BY created_at DESC`,
       [suite, testName]
     );
-    return rows.map((row: any) => ({
-      id: row.id,
-      workflowRunId: row.workflow_run_id,
-      suite: row.suite,
-      testName: row.test_name,
-      status: row.status,
-      durationMs: row.duration_ms,
-      retryCount: row.retry_count,
-      errorMessage: row.error_message,
-      commitSha: row.commit_sha,
-      variant: row.variant ? JSON.parse(row.variant) : null,
-      createdAt: new Date(row.created_at),
-    }));
+    return rows.map((row: any) => {
+      const resolved = resolveTestIdentity({
+        suite: row.suite,
+        testName: row.test_name,
+        taskId: row.task_id,
+        filter: row.filter_text,
+        variant: row.variant ? JSON.parse(row.variant) : null,
+        testId: row.test_id || undefined,
+      });
+      return {
+        id: row.id,
+        workflowRunId: row.workflow_run_id,
+        suite: resolved.suite,
+        testName: resolved.testName,
+        taskId: resolved.taskId,
+        filter: resolved.filter,
+        status: row.status,
+        durationMs: row.duration_ms,
+        retryCount: row.retry_count,
+        errorMessage: row.error_message,
+        commitSha: row.commit_sha,
+        variant: resolved.variant,
+        testId: resolved.testId,
+        quarantine: row.quarantine ? JSON.parse(row.quarantine) : null,
+        createdAt: new Date(row.created_at),
+      };
+    });
   }
 
   async queryTrueFlakyTests(opts?: { top?: number }): Promise<TrueFlakyScore[]> {
     let sql = `
       WITH commit_results AS (
         SELECT
-          suite, test_name, commit_sha,
+          COALESCE(test_id, '') AS test_id,
+          suite,
+          test_name,
+          commit_sha,
           COUNT(DISTINCT status) FILTER (WHERE status IN ('passed', 'failed')) AS distinct_statuses
         FROM test_results
-        GROUP BY suite, test_name, commit_sha
+        GROUP BY test_id, suite, test_name, commit_sha
       )
       SELECT
-        suite, test_name,
+        test_id,
+        suite,
+        test_name,
         COUNT(*)::INTEGER AS commits_tested,
         COUNT(*) FILTER (WHERE distinct_statuses > 1)::INTEGER AS flaky_commits,
         ROUND(COUNT(*) FILTER (WHERE distinct_statuses > 1) * 100.0 / COUNT(*), 2)::DOUBLE AS true_flaky_rate
       FROM commit_results
-      GROUP BY suite, test_name
+      GROUP BY test_id, suite, test_name
       HAVING flaky_commits > 0
       ORDER BY true_flaky_rate DESC`;
     if (opts?.top) sql += ` LIMIT ${opts.top}`;
     const rows = await this.all(sql);
     return rows.map((r: any) => ({
+      testId: r.test_id || createStableTestId({ suite: r.suite, testName: r.test_name }),
       suite: r.suite,
       testName: r.test_name,
       commitsTested: r.commits_tested,
@@ -178,15 +219,17 @@ export class DuckDBStore implements MetricStore {
 
   async queryFlakyTrend(suite: string, testName: string): Promise<TrendEntry[]> {
     const rows = await this.all(
-      `SELECT suite, test_name,
+      `SELECT COALESCE(test_id, '') AS test_id,
+        suite, test_name,
         DATE_TRUNC('week', created_at)::VARCHAR AS week,
         COUNT(*)::INTEGER AS runs,
         ROUND(COUNT(*) FILTER (WHERE status = 'failed') * 100.0 / COUNT(*), 2)::DOUBLE AS flaky_rate
       FROM test_results WHERE suite = ? AND test_name = ?
-      GROUP BY suite, test_name, week ORDER BY week`,
+      GROUP BY test_id, suite, test_name, week ORDER BY week`,
       [suite, testName]
     );
     return rows.map((r: any) => ({
+      testId: r.test_id || createStableTestId({ suite: r.suite, testName: r.test_name }),
       suite: r.suite, testName: r.test_name, week: r.week, runs: r.runs, flakyRate: r.flaky_rate,
     }));
   }
@@ -205,68 +248,95 @@ export class DuckDBStore implements MetricStore {
     const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
     let sql = `
       SELECT
+        COALESCE(test_id, '') AS test_id,
+        COALESCE(task_id, suite) AS task_id,
         suite,
         test_name,
+        filter_text,
         variant,
         COUNT(*)::INTEGER AS total_runs,
         COUNT(*) FILTER (WHERE status = 'failed')::INTEGER AS fail_count,
         ROUND(COUNT(*) FILTER (WHERE status = 'failed') * 100.0 / COUNT(*), 2)::DOUBLE AS flaky_rate
       FROM test_results
       ${where}
-      GROUP BY suite, test_name, variant
+      GROUP BY test_id, task_id, suite, test_name, filter_text, variant
       ORDER BY flaky_rate DESC`;
     if (opts?.top) sql += ` LIMIT ${opts.top}`;
     const rows = await this.all(sql, params);
-    return rows.map((r: any) => ({
-      suite: r.suite,
-      testName: r.test_name,
-      variant: JSON.parse(r.variant),
-      totalRuns: r.total_runs,
-      failCount: r.fail_count,
-      flakyRate: r.flaky_rate,
-    }));
+    return rows.map((r: any) => {
+      const resolved = resolveTestIdentity({
+        suite: r.suite,
+        testName: r.test_name,
+        taskId: r.task_id,
+        filter: r.filter_text,
+        variant: JSON.parse(r.variant),
+        testId: r.test_id || undefined,
+      });
+      return {
+        testId: resolved.testId,
+        suite: resolved.suite,
+        testName: resolved.testName,
+        taskId: resolved.taskId,
+        filter: resolved.filter,
+        variant: resolved.variant!,
+        totalRuns: r.total_runs,
+        failCount: r.fail_count,
+        flakyRate: r.flaky_rate,
+      };
+    });
   }
 
   async raw<T = unknown>(sql: string, params?: unknown[]): Promise<T[]> {
     return this.all(sql, params ?? []) as Promise<T[]>;
   }
 
-  async addQuarantine(
-    suite: string,
-    testName: string,
-    reason: string,
-  ): Promise<void> {
+  async addQuarantine(test: TestSelector, reason: string): Promise<void> {
+    const resolved = resolveTestIdentity(test);
     await this.run(
-      `INSERT INTO quarantined_tests (suite, test_name, reason)
-       VALUES (?, ?, ?)
-       ON CONFLICT (suite, test_name) DO UPDATE SET reason = EXCLUDED.reason`,
-      [suite, testName, reason],
+      `INSERT INTO quarantined_test_identities (test_id, task_id, suite, test_name, filter_text, reason)
+       VALUES (?, ?, ?, ?, ?, ?)
+       ON CONFLICT (test_id) DO UPDATE SET reason = EXCLUDED.reason`,
+      [
+        resolved.testId,
+        resolved.taskId,
+        resolved.suite,
+        resolved.testName,
+        resolved.filter,
+        reason,
+      ],
     );
   }
 
-  async removeQuarantine(suite: string, testName: string): Promise<void> {
+  async removeQuarantine(test: TestSelector): Promise<void> {
+    const resolved = resolveTestIdentity(test);
     await this.run(
-      `DELETE FROM quarantined_tests WHERE suite = ? AND test_name = ?`,
-      [suite, testName],
+      `DELETE FROM quarantined_test_identities WHERE test_id = ?`,
+      [resolved.testId],
     );
   }
 
   async queryQuarantined(): Promise<QuarantinedTest[]> {
     const rows = await this.all(
-      `SELECT suite, test_name, reason, created_at FROM quarantined_tests ORDER BY created_at DESC`,
+      `SELECT test_id, task_id, suite, test_name, filter_text, reason, created_at
+       FROM quarantined_test_identities
+       ORDER BY created_at DESC`,
     );
     return rows.map((row: any) => ({
+      testId: row.test_id,
+      taskId: row.task_id,
       suite: row.suite,
       testName: row.test_name,
+      filter: row.filter_text,
       reason: row.reason,
       createdAt: new Date(row.created_at),
     }));
   }
 
-  async isQuarantined(suite: string, testName: string): Promise<boolean> {
+  async isQuarantined(test: TestSelector): Promise<boolean> {
+    const resolved = resolveTestIdentity(test);
     const rows = await this.all(
-      `SELECT 1 FROM quarantined_tests WHERE suite = ? AND test_name = ?`,
-      [suite, testName],
+      `SELECT 1 FROM quarantined_test_identities WHERE test_id = ?`,
+      [resolved.testId],
     );
     return rows.length > 0;
   }
@@ -300,6 +370,32 @@ export class DuckDBStore implements MetricStore {
         else resolve();
       });
     });
+  }
+
+  private async backfillLegacyQuarantineEntries(): Promise<void> {
+    const rows = await this.all(
+      `SELECT suite, test_name, reason, created_at FROM quarantined_tests`,
+    );
+    for (const row of rows) {
+      const resolved = resolveTestIdentity({
+        suite: row.suite,
+        testName: row.test_name,
+      });
+      await this.run(
+        `INSERT INTO quarantined_test_identities (test_id, task_id, suite, test_name, filter_text, reason, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT (test_id) DO NOTHING`,
+        [
+          resolved.testId,
+          resolved.taskId,
+          resolved.suite,
+          resolved.testName,
+          resolved.filter,
+          row.reason,
+          row.created_at,
+        ],
+      );
+    }
   }
 }
 

--- a/src/cli/storage/schema.ts
+++ b/src/cli/storage/schema.ts
@@ -13,14 +13,18 @@ CREATE TABLE IF NOT EXISTS workflow_runs (
 CREATE TABLE IF NOT EXISTS test_results (
   id              INTEGER PRIMARY KEY,
   workflow_run_id BIGINT REFERENCES workflow_runs(id),
+  test_id         VARCHAR,
+  task_id         VARCHAR,
   suite           VARCHAR NOT NULL,
   test_name       VARCHAR NOT NULL,
+  filter_text     VARCHAR,
   status          VARCHAR NOT NULL,
   duration_ms     INTEGER,
   retry_count     INTEGER DEFAULT 0,
   error_message   VARCHAR,
   commit_sha      VARCHAR NOT NULL,
   variant         JSON,
+  quarantine      JSON,
   created_at      TIMESTAMP
 );
 
@@ -33,6 +37,21 @@ CREATE TABLE IF NOT EXISTS quarantined_tests (
   created_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (suite, test_name)
 );
+
+ALTER TABLE test_results ADD COLUMN IF NOT EXISTS test_id VARCHAR;
+ALTER TABLE test_results ADD COLUMN IF NOT EXISTS task_id VARCHAR;
+ALTER TABLE test_results ADD COLUMN IF NOT EXISTS filter_text VARCHAR;
+ALTER TABLE test_results ADD COLUMN IF NOT EXISTS quarantine JSON;
+
+CREATE TABLE IF NOT EXISTS quarantined_test_identities (
+  test_id      VARCHAR PRIMARY KEY,
+  task_id      VARCHAR NOT NULL,
+  suite        VARCHAR NOT NULL,
+  test_name    VARCHAR NOT NULL,
+  filter_text  VARCHAR,
+  reason       VARCHAR NOT NULL DEFAULT 'manual',
+  created_at   TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
 `;
 
 export const FLAKY_QUERY = `
@@ -41,7 +60,12 @@ WITH recent AS (
   WHERE created_at > CURRENT_TIMESTAMP - INTERVAL (? || ' days')
 )
 SELECT
-  suite, test_name, variant,
+  COALESCE(test_id, '') AS test_id,
+  COALESCE(task_id, suite) AS task_id,
+  suite,
+  test_name,
+  filter_text,
+  variant,
   COUNT(*)::INTEGER AS total_runs,
   COUNT(*) FILTER (WHERE status = 'failed')::INTEGER AS fail_count,
   COUNT(*) FILTER (WHERE status = 'flaky' OR (retry_count > 0 AND status = 'passed'))::INTEGER AS flaky_retry_count,
@@ -49,7 +73,7 @@ SELECT
   MAX(created_at) FILTER (WHERE status IN ('failed', 'flaky')) AS last_flaky_at,
   MIN(created_at) AS first_seen_at
 FROM recent
-GROUP BY suite, test_name, variant
+GROUP BY test_id, task_id, suite, test_name, filter_text, variant
 HAVING flaky_rate > 0
 ORDER BY flaky_rate DESC
 `;

--- a/src/cli/storage/test-result-mapper.ts
+++ b/src/cli/storage/test-result-mapper.ts
@@ -1,0 +1,30 @@
+import type { TestCaseResult } from "../adapters/types.js";
+import type { TestResult } from "./types.js";
+
+interface StoredTestResultBase {
+  workflowRunId: number;
+  commitSha: string;
+  createdAt: Date;
+}
+
+export function toStoredTestResult(
+  testCase: TestCaseResult,
+  base: StoredTestResultBase,
+): TestResult {
+  return {
+    workflowRunId: base.workflowRunId,
+    suite: testCase.suite,
+    testName: testCase.testName,
+    taskId: testCase.taskId,
+    filter: testCase.filter,
+    status: testCase.status,
+    durationMs: testCase.durationMs,
+    retryCount: testCase.retryCount,
+    errorMessage: testCase.errorMessage ?? null,
+    commitSha: base.commitSha,
+    variant: testCase.variant ?? null,
+    testId: testCase.testId,
+    quarantine: testCase.quarantine ?? null,
+    createdAt: base.createdAt,
+  };
+}

--- a/src/cli/storage/types.ts
+++ b/src/cli/storage/types.ts
@@ -1,3 +1,6 @@
+import type { TestIdentityFields } from "../identity.js";
+import type { QuarantineManifestEntry } from "../quarantine-manifest.js";
+
 export interface WorkflowRun {
   id: number;
   repo: string;
@@ -14,18 +17,25 @@ export interface TestResult {
   workflowRunId: number;
   suite: string;
   testName: string;
+  taskId?: string | null;
+  filter?: string | null;
   status: string;
   durationMs: number | null;
   retryCount: number;
   errorMessage: string | null;
   commitSha: string;
   variant: Record<string, string> | null;
+  testId?: string;
+  quarantine?: QuarantineManifestEntry | null;
   createdAt: Date;
 }
 
 export interface FlakyScore {
+  testId: string;
   suite: string;
   testName: string;
+  taskId: string;
+  filter: string | null;
   variant: Record<string, string> | null;
   totalRuns: number;
   failCount: number;
@@ -36,13 +46,17 @@ export interface FlakyScore {
 }
 
 export interface QuarantinedTest {
+  testId: string;
   suite: string;
   testName: string;
+  taskId: string;
+  filter: string | null;
   reason: string;
   createdAt: Date;
 }
 
 export interface TrendEntry {
+  testId: string;
   suite: string;
   testName: string;
   week: string;
@@ -51,6 +65,7 @@ export interface TrendEntry {
 }
 
 export interface TrueFlakyScore {
+  testId: string;
   suite: string;
   testName: string;
   commitsTested: number;
@@ -59,8 +74,11 @@ export interface TrueFlakyScore {
 }
 
 export interface VariantFlakyScore {
+  testId: string;
   suite: string;
   testName: string;
+  taskId: string;
+  filter: string | null;
   variant: Record<string, string>;
   totalRuns: number;
   failCount: number;
@@ -74,6 +92,11 @@ export interface FlakyQueryOpts {
   windowDays?: number;
 }
 
+export interface TestSelector extends TestIdentityFields {
+  suite: string;
+  testName: string;
+}
+
 export interface MetricStore {
   initialize(): Promise<void>;
   close(): Promise<void>;
@@ -85,8 +108,8 @@ export interface MetricStore {
   queryTrueFlakyTests(opts?: { top?: number }): Promise<TrueFlakyScore[]>;
   queryFlakyByVariant(opts?: { suite?: string; testName?: string; top?: number }): Promise<VariantFlakyScore[]>;
   raw<T = unknown>(sql: string, params?: unknown[]): Promise<T[]>;
-  addQuarantine(suite: string, testName: string, reason: string): Promise<void>;
-  removeQuarantine(suite: string, testName: string): Promise<void>;
+  addQuarantine(test: TestSelector, reason: string): Promise<void>;
+  removeQuarantine(test: TestSelector): Promise<void>;
   queryQuarantined(): Promise<QuarantinedTest[]>;
-  isQuarantined(suite: string, testName: string): Promise<boolean>;
+  isQuarantined(test: TestSelector): Promise<boolean>;
 }

--- a/src/core/src/affected/affected.mbt
+++ b/src/core/src/affected/affected.mbt
@@ -13,7 +13,8 @@ pub fn resolve_affected(
   let ir = parse_result.ir
 
   // Get task IDs that directly match changed paths via srcs/outs patterns
-  let targets = @wf.entry_targets_for_changed_paths(ir, changed_paths)
+  let normalized_changed_paths = changed_paths.map(normalize_path)
+  let targets = @wf.entry_targets_for_changed_paths(ir, normalized_changed_paths)
 
   // Build task-level graph nodes from task needs for expansion
   let task_nodes : Array[@wf.FlowNode] = []
@@ -33,4 +34,8 @@ pub fn resolve_affected(
     result.push(key)
   }
   result
+}
+
+fn normalize_path(path : String) -> String {
+  path.replace_all(old="\\", new="/")
 }

--- a/src/core/src/affected/affected_test.mbt
+++ b/src/core/src/affected/affected_test.mbt
@@ -39,3 +39,14 @@ test "resolve_affected expands transitive dependencies" {
   // "app" depends on "lib", so it should also be affected
   assert_true(affected.contains("app"))
 }
+
+///|
+test "resolve_affected normalizes windows path separators" {
+  let workflow =
+    #|workflow(name="ci")
+    #|node(id="auth", depends_on=[])
+    #|task(id="test-auth", node="auth", cmd="test", needs=[], srcs=["src/auth/**"])
+  let changed = ["src\\auth\\login.ts"]
+  let affected = resolve_affected(workflow, changed)
+  assert_true(affected.contains("test-auth"))
+}

--- a/tests/adapters/junit.test.ts
+++ b/tests/adapters/junit.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { junitAdapter } from "../../src/cli/adapters/junit.js";
+import { createStableTestId } from "../../src/cli/identity.js";
 
 const fixtureXml = readFileSync(
   join(import.meta.dirname, "../fixtures/junit-report.xml"),
@@ -21,13 +22,22 @@ describe("junitAdapter", () => {
   it("parses passing test", () => {
     const results = junitAdapter.parse(fixtureXml);
     const passed = results.find((r) => r.testName === "should display form");
-    expect(passed).toEqual({
+    expect(passed).toMatchObject({
       suite: "tests/login.spec.ts",
       testName: "should display form",
       status: "passed",
       durationMs: 1200,
       retryCount: 0,
     });
+    expect(passed?.taskId).toBe("tests/login.spec.ts");
+    expect(passed?.filter).toBeNull();
+    expect(passed?.variant).toBeNull();
+    expect(passed?.testId).toBe(
+      createStableTestId({
+        suite: "tests/login.spec.ts",
+        testName: "should display form",
+      }),
+    );
   });
 
   it("parses failed test with error message", () => {
@@ -35,7 +45,7 @@ describe("junitAdapter", () => {
     const failed = results.find(
       (r) => r.testName === "should redirect after login",
     );
-    expect(failed).toEqual({
+    expect(failed).toMatchObject({
       suite: "tests/login.spec.ts",
       testName: "should redirect after login",
       status: "failed",
@@ -43,6 +53,12 @@ describe("junitAdapter", () => {
       retryCount: 0,
       errorMessage: "Timeout waiting for element",
     });
+    expect(failed?.testId).toBe(
+      createStableTestId({
+        suite: "tests/login.spec.ts",
+        testName: "should redirect after login",
+      }),
+    );
   });
 
   it("parses skipped test", () => {
@@ -50,13 +66,19 @@ describe("junitAdapter", () => {
     const skipped = results.find(
       (r) => r.testName === "should skip on mobile",
     );
-    expect(skipped).toEqual({
+    expect(skipped).toMatchObject({
       suite: "tests/login.spec.ts",
       testName: "should skip on mobile",
       status: "skipped",
       durationMs: 0,
       retryCount: 0,
     });
+    expect(skipped?.testId).toBe(
+      createStableTestId({
+        suite: "tests/login.spec.ts",
+        testName: "should skip on mobile",
+      }),
+    );
   });
 
   it("suite name comes from testsuite name attribute", () => {

--- a/tests/adapters/playwright.test.ts
+++ b/tests/adapters/playwright.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { playwrightAdapter } from "../../src/cli/adapters/playwright.js";
+import { createStableTestId } from "../../src/cli/identity.js";
 
 const fixtureJson = readFileSync(
   join(import.meta.dirname, "../fixtures/playwright-report.json"),
@@ -21,14 +22,25 @@ describe("playwrightAdapter", () => {
   it("parses passing test", () => {
     const results = playwrightAdapter.parse(fixtureJson);
     const passed = results.find((r) => r.testName === "should display form");
-    expect(passed).toEqual({
-      suite: "login page",
+    expect(passed).toMatchObject({
+      suite: "tests/login.spec.ts",
       testName: "should display form",
+      taskId: "login page",
       status: "passed",
       durationMs: 1200,
       retryCount: 0,
       variant: { project: "chromium" },
     });
+    expect(passed?.taskId).toBe("login page");
+    expect(passed?.filter).toBeNull();
+    expect(passed?.testId).toBe(
+      createStableTestId({
+        suite: "tests/login.spec.ts",
+        testName: "should display form",
+        taskId: "login page",
+        variant: { project: "chromium" },
+      }),
+    );
   });
 
   it("parses flaky test (retry passed)", () => {
@@ -36,15 +48,24 @@ describe("playwrightAdapter", () => {
     const flaky = results.find(
       (r) => r.testName === "should redirect after login",
     );
-    expect(flaky).toEqual({
-      suite: "login page",
+    expect(flaky).toMatchObject({
+      suite: "tests/login.spec.ts",
       testName: "should redirect after login",
+      taskId: "login page",
       status: "flaky",
       durationMs: 1500,
       retryCount: 1,
       errorMessage: "Timeout",
       variant: { project: "chromium" },
     });
+    expect(flaky?.testId).toBe(
+      createStableTestId({
+        suite: "tests/login.spec.ts",
+        testName: "should redirect after login",
+        taskId: "login page",
+        variant: { project: "chromium" },
+      }),
+    );
   });
 
   it("parses failed test", () => {
@@ -52,15 +73,24 @@ describe("playwrightAdapter", () => {
     const failed = results.find(
       (r) => r.testName === "should show error on invalid credentials",
     );
-    expect(failed).toEqual({
-      suite: "login page",
+    expect(failed).toMatchObject({
+      suite: "tests/login.spec.ts",
       testName: "should show error on invalid credentials",
+      taskId: "login page",
       status: "failed",
       durationMs: 2000,
       retryCount: 0,
       errorMessage: "Element not found",
       variant: { project: "chromium" },
     });
+    expect(failed?.testId).toBe(
+      createStableTestId({
+        suite: "tests/login.spec.ts",
+        testName: "should show error on invalid credentials",
+        taskId: "login page",
+        variant: { project: "chromium" },
+      }),
+    );
   });
 
   it("parses skipped test", () => {
@@ -68,13 +98,22 @@ describe("playwrightAdapter", () => {
     const skipped = results.find(
       (r) => r.testName === "should skip on mobile",
     );
-    expect(skipped).toEqual({
-      suite: "login page",
+    expect(skipped).toMatchObject({
+      suite: "tests/login.spec.ts",
       testName: "should skip on mobile",
+      taskId: "login page",
       status: "skipped",
       durationMs: 0,
       retryCount: 0,
       variant: { project: "chromium" },
     });
+    expect(skipped?.testId).toBe(
+      createStableTestId({
+        suite: "tests/login.spec.ts",
+        testName: "should skip on mobile",
+        taskId: "login page",
+        variant: { project: "chromium" },
+      }),
+    );
   });
 });

--- a/tests/commands/collect-local.test.ts
+++ b/tests/commands/collect-local.test.ts
@@ -63,6 +63,16 @@ describe("collect-local command", () => {
 
     const tests = await store.raw<{ cnt: number }>("SELECT COUNT(*)::INTEGER AS cnt FROM test_results");
     expect(tests[0].cnt).toBe(4);
+
+    const taskIds = await store.raw<{ task_id: string }>(
+      "SELECT task_id FROM test_results ORDER BY task_id",
+    );
+    expect(taskIds.map((row) => row.task_id)).toEqual([
+      "build/compile",
+      "build/compile",
+      "test/unit",
+      "test/unit",
+    ]);
   });
 
   it("skips already imported runs", async () => {

--- a/tests/commands/doctor.test.ts
+++ b/tests/commands/doctor.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { runDoctor, formatDoctorReport } from "../../src/cli/commands/doctor.js";
+
+describe("runDoctor", () => {
+  it("reports success when all checks pass", async () => {
+    const report = await runDoctor(process.cwd(), {
+      canLoadConfig: () => true,
+      hasMoonBitBuild: async () => false,
+      createStore: () => ({
+        initialize: async () => {},
+        close: async () => {},
+      }),
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.checks.find((c) => c.name === "config")?.ok).toBe(true);
+    expect(report.checks.find((c) => c.name === "duckdb")?.ok).toBe(true);
+    expect(report.checks.find((c) => c.name === "moonbit")?.detail).toContain("TypeScript fallback");
+  });
+
+  it("reports failure when duckdb cannot initialize", async () => {
+    const report = await runDoctor(process.cwd(), {
+      canLoadConfig: () => true,
+      hasMoonBitBuild: async () => true,
+      createStore: () => ({
+        initialize: async () => {
+          throw new Error("duckdb missing");
+        },
+        close: async () => {},
+      }),
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.checks.find((c) => c.name === "duckdb")?.ok).toBe(false);
+    expect(formatDoctorReport(report)).toContain("Doctor checks failed.");
+  });
+});

--- a/tests/commands/quarantine.test.ts
+++ b/tests/commands/quarantine.test.ts
@@ -33,7 +33,7 @@ describe("quarantine command", () => {
   });
 
   it("removes a test from quarantine", async () => {
-    await store.addQuarantine("suite-a", "test-1", "manual");
+    await store.addQuarantine({ suite: "suite-a", testName: "test-1" }, "manual");
     await runQuarantine({
       store,
       action: "remove",
@@ -45,8 +45,8 @@ describe("quarantine command", () => {
   });
 
   it("lists quarantined tests", async () => {
-    await store.addQuarantine("suite-a", "test-1", "flaky");
-    await store.addQuarantine("suite-b", "test-2", "manual");
+    await store.addQuarantine({ suite: "suite-a", testName: "test-1" }, "flaky");
+    await store.addQuarantine({ suite: "suite-b", testName: "test-2" }, "manual");
     const result = await runQuarantine({ store, action: "list" });
     expect(result).toHaveLength(2);
     const table = formatQuarantineTable(result!);

--- a/tests/commands/run.test.ts
+++ b/tests/commands/run.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { DuckDBStore } from "../../src/cli/storage/duckdb.js";
+import { runTests } from "../../src/cli/commands/run.js";
+import type { RunnerAdapter, TestId } from "../../src/cli/runners/types.js";
+import type { QuarantineManifestEntry } from "../../src/cli/quarantine-manifest.js";
+
+describe("run command", () => {
+  let store: DuckDBStore;
+
+  beforeEach(async () => {
+    store = new DuckDBStore(":memory:");
+    await store.initialize();
+    await store.insertWorkflowRun({
+      id: 1,
+      repo: "test/repo",
+      branch: "main",
+      commitSha: "abc",
+      event: "push",
+      status: "completed",
+      createdAt: new Date(),
+      durationMs: 1000,
+    });
+    await store.insertTestResults([
+      {
+        workflowRunId: 1,
+        suite: "tests/paint-vrt.spec.ts",
+        testName: "optional snapshot asset",
+        status: "passed",
+        durationMs: 100,
+        retryCount: 0,
+        errorMessage: null,
+        commitSha: "abc",
+        variant: null,
+        createdAt: new Date(),
+      },
+    ]);
+  });
+
+  afterEach(async () => {
+    await store.close();
+  });
+
+  it("enriches sampled tests via listTests and applies runtime quarantine", async () => {
+    const calls: TestId[][] = [];
+    const runner: RunnerAdapter = {
+      name: "mock",
+      capabilities: { nativeParallel: false },
+      async listTests() {
+        return [
+          {
+            suite: "tests/paint-vrt.spec.ts",
+            testName: "optional snapshot asset",
+            taskId: "paint-vrt",
+          },
+        ];
+      },
+      async execute(tests) {
+        calls.push([...tests]);
+        return {
+          exitCode: 0,
+          results: tests.map((test) => ({
+            suite: test.suite,
+            testName: test.testName,
+            taskId: test.taskId,
+            status: "passed",
+            durationMs: 10,
+            retryCount: 0,
+          })),
+          durationMs: 10,
+          stdout: "",
+          stderr: "",
+        };
+      },
+    };
+    const manifestEntries: QuarantineManifestEntry[] = [
+      {
+        id: "paint-vrt-local-assets",
+        taskId: "paint-vrt",
+        spec: "tests/paint-vrt.spec.ts",
+        titlePattern: "^optional snapshot asset$",
+        mode: "skip",
+        scope: "environment",
+        owner: "@mizchi",
+        reason: "local-only asset",
+        condition: "asset not installed",
+        introducedAt: "2026-04-01",
+        expiresAt: "2026-04-30",
+      },
+    ];
+
+    const result = await runTests({
+      store,
+      runner,
+      mode: "random",
+      count: 1,
+      quarantineManifestEntries: manifestEntries,
+    });
+
+    expect(calls).toHaveLength(0);
+    expect(result.exitCode).toBe(0);
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]).toMatchObject({
+      suite: "tests/paint-vrt.spec.ts",
+      testName: "optional snapshot asset",
+      status: "skipped",
+      quarantine: {
+        id: "paint-vrt-local-assets",
+      },
+    });
+  });
+});

--- a/tests/commands/skip-quarantined.test.ts
+++ b/tests/commands/skip-quarantined.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { DuckDBStore } from "../../src/cli/storage/duckdb.js";
 import { runSample } from "../../src/cli/commands/sample.js";
+import type { QuarantineManifestEntry } from "../../src/cli/quarantine-manifest.js";
 
 describe("--skip-quarantined", () => {
   let store: DuckDBStore;
@@ -22,7 +23,10 @@ describe("--skip-quarantined", () => {
         }]);
       }
     }
-    await store.addQuarantine("tests/test_0.spec.ts", "test_0", "manual");
+    await store.addQuarantine(
+      { suite: "tests/test_0.spec.ts", testName: "test_0" },
+      "manual",
+    );
   });
 
   afterEach(async () => { await store.close(); });
@@ -39,5 +43,85 @@ describe("--skip-quarantined", () => {
     const suites = result.map((r) => r.suite);
     expect(suites).toContain("tests/test_0.spec.ts");
     expect(result.length).toBe(5);
+  });
+
+  it("excludes repo-tracked skip entries but keeps non-skip modes", async () => {
+    const manifestEntries: QuarantineManifestEntry[] = [
+      {
+        id: "skip-test-1",
+        taskId: "tests/test_1.spec.ts",
+        spec: "tests/test_1.spec.ts",
+        titlePattern: "^test_1$",
+        mode: "skip",
+        scope: "environment",
+        owner: "@mizchi",
+        reason: "local-only asset",
+        condition: "asset not installed",
+        introducedAt: "2026-04-01",
+        expiresAt: "2026-04-30",
+      },
+      {
+        id: "allow-failure-test-2",
+        taskId: "tests/test_2.spec.ts",
+        spec: "tests/test_2.spec.ts",
+        titlePattern: "^test_2$",
+        mode: "allow_failure",
+        scope: "expected_failure",
+        owner: "@mizchi",
+        reason: "known bug",
+        condition: "waiting for fix",
+        introducedAt: "2026-04-01",
+        expiresAt: "2026-04-30",
+      },
+    ];
+
+    const result = await runSample({
+      store,
+      mode: "random",
+      count: 10,
+      skipQuarantined: true,
+      quarantineManifestEntries: manifestEntries,
+    });
+    const suites = result.map((r) => r.suite);
+    expect(suites).not.toContain("tests/test_0.spec.ts");
+    expect(suites).not.toContain("tests/test_1.spec.ts");
+    expect(suites).toContain("tests/test_2.spec.ts");
+    expect(result.length).toBe(3);
+  });
+
+  it("uses listed task ids when matching manifest skip entries", async () => {
+    const manifestEntries: QuarantineManifestEntry[] = [
+      {
+        id: "paint-vrt-local-assets",
+        taskId: "paint-vrt",
+        spec: "tests/test_1.spec.ts",
+        titlePattern: "^test_1$",
+        mode: "skip",
+        scope: "environment",
+        owner: "@mizchi",
+        reason: "local-only asset",
+        condition: "asset not installed",
+        introducedAt: "2026-04-01",
+        expiresAt: "2026-04-30",
+      },
+    ];
+
+    const result = await runSample({
+      store,
+      mode: "random",
+      count: 10,
+      skipQuarantined: true,
+      quarantineManifestEntries: manifestEntries,
+      listedTests: [
+        {
+          suite: "tests/test_1.spec.ts",
+          testName: "test_1",
+          taskId: "paint-vrt",
+        },
+      ],
+    });
+
+    const suites = result.map((r) => r.suite);
+    expect(suites).not.toContain("tests/test_1.spec.ts");
   });
 });

--- a/tests/core/resolve-affected-glob-parity.test.ts
+++ b/tests/core/resolve-affected-glob-parity.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { loadCoreSync } from "../../src/cli/core/loader.js";
+
+describe("resolveAffectedFallback glob parity", () => {
+  const core = loadCoreSync();
+
+  it("treats * as single path segment", () => {
+    const workflow = [
+      'workflow(name="ci")',
+      'node(id="auth", depends_on=[])',
+      'task(id="test-auth", node="auth", cmd="test", needs=[], srcs=["src/*/index.ts"])',
+    ].join("\n");
+
+    expect(core.resolveAffected(workflow, ["src/auth/index.ts"])).toContain("test-auth");
+    expect(core.resolveAffected(workflow, ["src/auth/ui/index.ts"])).toEqual([]);
+  });
+
+  it("treats ** as multi-segment wildcard", () => {
+    const workflow = [
+      'workflow(name="ci")',
+      'node(id="auth", depends_on=[])',
+      'task(id="test-auth", node="auth", cmd="test", needs=[], srcs=["src/**/index.ts"])',
+    ].join("\n");
+
+    expect(core.resolveAffected(workflow, ["src/auth/index.ts"])).toContain("test-auth");
+    expect(core.resolveAffected(workflow, ["src/auth/ui/index.ts"])).toContain("test-auth");
+  });
+
+  it("supports mixed quote style in src arrays", () => {
+    const workflow = [
+      "workflow(name='ci')",
+      "node(id='auth', depends_on=[])",
+      "task(id='test-auth', node='auth', cmd='test', needs=[], srcs=['src/auth/**', \"src/shared/**\"])",
+    ].join("\n");
+
+    expect(core.resolveAffected(workflow, ["src/shared/util.ts"])).toContain("test-auth");
+  });
+});

--- a/tests/identity/stable-test-id.test.ts
+++ b/tests/identity/stable-test-id.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  createStableTestId,
+  resolveTestIdentity,
+} from "../../src/cli/identity.js";
+
+describe("stable test identity", () => {
+  it("normalizes variant key order", () => {
+    const a = createStableTestId({
+      suite: "tests/login.spec.ts",
+      testName: "should login",
+      variant: { browser: "chromium", os: "linux" },
+    });
+    const b = createStableTestId({
+      suite: "tests/login.spec.ts",
+      testName: "should login",
+      variant: { os: "linux", browser: "chromium" },
+    });
+
+    expect(a).toBe(b);
+  });
+
+  it("treats filter as part of the identity", () => {
+    const smoke = createStableTestId({
+      suite: "tests/login.spec.ts",
+      testName: "should login",
+      filter: "@smoke",
+    });
+    const regression = createStableTestId({
+      suite: "tests/login.spec.ts",
+      testName: "should login",
+      filter: "@regression",
+    });
+
+    expect(smoke).not.toBe(regression);
+  });
+
+  it("defaults taskId to suite and fills normalized fields", () => {
+    const resolved = resolveTestIdentity({
+      suite: "tests/login.spec.ts",
+      testName: "should login",
+    });
+
+    expect(resolved.taskId).toBe("tests/login.spec.ts");
+    expect(resolved.filter).toBeNull();
+    expect(resolved.variant).toBeNull();
+    expect(resolved.testId).toBe(
+      createStableTestId({
+        suite: "tests/login.spec.ts",
+        testName: "should login",
+      }),
+    );
+  });
+});

--- a/tests/integration-phase2.test.ts
+++ b/tests/integration-phase2.test.ts
@@ -49,7 +49,10 @@ describe("Phase 2 integration", () => {
   });
 
   it("hybrid sample with skip-quarantined", async () => {
-    await store.addQuarantine("tests/module_0/test.spec.ts", "test_0", "auto");
+    await store.addQuarantine(
+      { suite: "tests/module_0/test.spec.ts", testName: "test_0" },
+      "auto",
+    );
     const resolver = new SimpleResolver();
     const result = await runSample({
       store, mode: "hybrid", count: 5,

--- a/tests/quarantine-manifest.test.ts
+++ b/tests/quarantine-manifest.test.ts
@@ -1,0 +1,264 @@
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  formatQuarantineManifestReport,
+  isManifestQuarantined,
+  loadQuarantineManifest,
+  validateQuarantineManifest,
+  type QuarantineManifestEntry,
+} from "../src/cli/quarantine-manifest.js";
+
+function writeManifest(
+  dir: string,
+  entries: QuarantineManifestEntry[],
+): string {
+  const manifestPath = join(dir, "flaker.quarantine.json");
+  writeFileSync(
+    manifestPath,
+    JSON.stringify({ entries }, null, 2),
+  );
+  return manifestPath;
+}
+
+describe("quarantine manifest", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("loads and validates a repo-tracked manifest", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "flaker-quarantine-"));
+    tempDirs.push(cwd);
+    mkdirSync(join(cwd, "tests"), { recursive: true });
+    writeFileSync(join(cwd, "tests", "paint-vrt.spec.ts"), "");
+
+    const manifestPath = writeManifest(cwd, [
+      {
+        id: "paint-vrt-local-assets",
+        taskId: "paint-vrt",
+        spec: "tests/paint-vrt.spec.ts",
+        titlePattern: "optional snapshot asset",
+        mode: "skip",
+        scope: "environment",
+        owner: "@mizchi",
+        reason: "optional asset is absent on local runs",
+        condition: "missing local snapshot asset",
+        introducedAt: "2026-04-01",
+        expiresAt: "2026-04-30",
+      },
+    ]);
+
+    const manifest = loadQuarantineManifest({
+      cwd,
+      manifestPath,
+    });
+    const report = validateQuarantineManifest({
+      cwd,
+      manifest,
+      manifestPath,
+      knownTaskIds: ["paint-vrt"],
+      now: new Date("2026-04-02T00:00:00Z"),
+    });
+
+    expect(manifest.entries).toHaveLength(1);
+    expect(report.errors).toHaveLength(0);
+    expect(report.warnings).toHaveLength(0);
+  });
+
+  it("reports unknown tasks, invalid patterns, missing specs, and expiry problems", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "flaker-quarantine-"));
+    tempDirs.push(cwd);
+    mkdirSync(join(cwd, "tests"), { recursive: true });
+    writeFileSync(join(cwd, "tests", "paint-vrt.spec.ts"), "");
+    writeFileSync(join(cwd, "tests", "flaky.spec.ts"), "");
+    writeFileSync(join(cwd, "tests", "soon-expiring.spec.ts"), "");
+
+    const manifestPath = writeManifest(cwd, [
+      {
+        id: "unknown-task",
+        taskId: "missing-task",
+        spec: "tests/paint-vrt.spec.ts",
+        titlePattern: "paints",
+        mode: "skip",
+        scope: "environment",
+        owner: "@mizchi",
+        reason: "task drift",
+        condition: "task was renamed",
+        introducedAt: "2026-04-01",
+        expiresAt: "2026-04-30",
+      },
+      {
+        id: "missing-spec",
+        taskId: "paint-vrt",
+        spec: "tests/missing.spec.ts",
+        titlePattern: "missing",
+        mode: "skip",
+        scope: "environment",
+        owner: "@mizchi",
+        reason: "spec drift",
+        condition: "spec was deleted",
+        introducedAt: "2026-04-01",
+        expiresAt: "2026-04-30",
+      },
+      {
+        id: "invalid-pattern",
+        taskId: "paint-vrt",
+        spec: "tests/flaky.spec.ts",
+        titlePattern: "[invalid",
+        mode: "allow_flaky",
+        scope: "flaky",
+        owner: "@mizchi",
+        reason: "regex typo",
+        condition: "pattern is broken",
+        introducedAt: "2026-04-01",
+        expiresAt: "2026-04-30",
+      },
+      {
+        id: "expired-entry",
+        taskId: "paint-vrt",
+        spec: "tests/flaky.spec.ts",
+        titlePattern: "expired",
+        mode: "allow_failure",
+        scope: "expected_failure",
+        owner: "@mizchi",
+        reason: "expired quarantine",
+        condition: "known bug",
+        introducedAt: "2026-03-01",
+        expiresAt: "2026-04-01",
+      },
+      {
+        id: "near-expiry",
+        taskId: "paint-vrt",
+        spec: "tests/soon-expiring.spec.ts",
+        titlePattern: "soon",
+        mode: "skip",
+        scope: "environment",
+        owner: "@mizchi",
+        reason: "temporary local condition",
+        condition: "waiting for CI image update",
+        introducedAt: "2026-04-01",
+        expiresAt: "2026-04-05",
+      },
+    ]);
+
+    const report = validateQuarantineManifest({
+      cwd,
+      manifest: loadQuarantineManifest({ cwd, manifestPath }),
+      manifestPath,
+      knownTaskIds: ["paint-vrt"],
+      now: new Date("2026-04-02T00:00:00Z"),
+      expiringWithinDays: 7,
+    });
+
+    expect(report.errors.map((error) => error.code)).toEqual([
+      "unknown-task",
+      "missing-spec",
+      "invalid-pattern",
+      "expired-entry",
+    ]);
+    expect(report.warnings.map((warning) => warning.code)).toEqual([
+      "near-expiry",
+    ]);
+  });
+
+  it("formats JSON and Markdown reports", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "flaker-quarantine-"));
+    tempDirs.push(cwd);
+    mkdirSync(join(cwd, "tests"), { recursive: true });
+    writeFileSync(join(cwd, "tests", "paint-vrt.spec.ts"), "");
+
+    const manifestPath = writeManifest(cwd, [
+      {
+        id: "paint-vrt-local-assets",
+        taskId: "paint-vrt",
+        spec: "tests/paint-vrt.spec.ts",
+        titlePattern: "optional snapshot asset",
+        mode: "skip",
+        scope: "environment",
+        owner: "@mizchi",
+        reason: "optional asset is absent on local runs",
+        condition: "missing local snapshot asset",
+        introducedAt: "2026-04-01",
+        expiresAt: "2026-04-05",
+      },
+    ]);
+
+    const report = validateQuarantineManifest({
+      cwd,
+      manifest: loadQuarantineManifest({ cwd, manifestPath }),
+      manifestPath,
+      knownTaskIds: ["paint-vrt"],
+      now: new Date("2026-04-02T00:00:00Z"),
+      expiringWithinDays: 7,
+    });
+
+    const json = formatQuarantineManifestReport(report, "json");
+    const markdown = formatQuarantineManifestReport(report, "markdown");
+
+    expect(JSON.parse(json)).toMatchObject({
+      manifestPath,
+      summary: {
+        totalEntries: 1,
+        errorCount: 0,
+        warningCount: 1,
+      },
+    });
+    expect(markdown).toContain("# Quarantine Manifest Report");
+    expect(markdown).toContain("paint-vrt-local-assets");
+    expect(markdown).toContain("Near expiry");
+  });
+
+  it("matches only skip entries against sampled tests", () => {
+    const skipEntry: QuarantineManifestEntry = {
+      id: "paint-vrt-local-assets",
+      taskId: "paint-vrt",
+      spec: "tests/paint-vrt.spec.ts",
+      titlePattern: "optional snapshot asset",
+      mode: "skip",
+      scope: "environment",
+      owner: "@mizchi",
+      reason: "optional asset is absent on local runs",
+      condition: "missing local snapshot asset",
+      introducedAt: "2026-04-01",
+      expiresAt: "2026-04-30",
+    };
+    const allowFailureEntry: QuarantineManifestEntry = {
+      ...skipEntry,
+      id: "known-bug",
+      mode: "allow_failure",
+      titlePattern: "known bug",
+    };
+
+    expect(
+      isManifestQuarantined([skipEntry], {
+        suite: "tests/paint-vrt.spec.ts",
+        testName: "optional snapshot asset on local",
+        taskId: "paint-vrt",
+      }),
+    ).toBe(true);
+    expect(
+      isManifestQuarantined([skipEntry], {
+        suite: "tests/paint-vrt.spec.ts",
+        testName: "different title",
+        taskId: "paint-vrt",
+      }),
+    ).toBe(false);
+    expect(
+      isManifestQuarantined([allowFailureEntry], {
+        suite: "tests/paint-vrt.spec.ts",
+        testName: "known bug",
+        taskId: "paint-vrt",
+      }),
+    ).toBe(false);
+  });
+});

--- a/tests/resolvers/bitflow-native.test.ts
+++ b/tests/resolvers/bitflow-native.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { loadCore } from "../../src/cli/core/loader.js";
 
 describe("BitflowNativeResolver", () => {
@@ -56,5 +56,45 @@ describe("BitflowNativeResolver", () => {
     const allTestFiles = new Set(["test-auth"]);
     const filtered = affectedTargets.filter(t => allTestFiles.has(t));
     expect(filtered).toEqual(["test-auth"]);
+  });
+
+  it("supports multi-line task definitions in TS fallback parser", async () => {
+    const core = await loadCore();
+    const workflow = [
+      'workflow(name="ci")',
+      'node(id="auth", depends_on=[])',
+      "task(",
+      '  id="test-auth",',
+      '  node="auth",',
+      '  cmd="test",',
+      '  needs=[],',
+      '  srcs=["src/auth/**"]',
+      ")",
+    ].join("\n");
+
+    const result = core.resolveAffected(workflow, ["src/auth/login.ts"]);
+    expect(result).toContain("test-auth");
+  });
+
+  it("supports single-quoted workflow values in TS fallback parser", async () => {
+    const core = await loadCore();
+    const workflow = [
+      "workflow(name='ci')",
+      "node(id='auth', depends_on=[])",
+      "task(id='test-auth', node='auth', cmd='test', needs=[], srcs=['src/auth/**'])",
+    ].join("\n");
+    const result = core.resolveAffected(workflow, ["src/auth/login.ts"]);
+    expect(result).toContain("test-auth");
+  });
+
+  it("matches changed paths with Windows separators", async () => {
+    const core = await loadCore();
+    const workflow = [
+      'workflow(name="ci")',
+      'node(id="auth", depends_on=[])',
+      'task(id="test-auth", node="auth", cmd="test", needs=[], srcs=["src/auth/**"])',
+    ].join("\n");
+    const result = core.resolveAffected(workflow, ["src\\auth\\login.ts"]);
+    expect(result).toContain("test-auth");
   });
 });

--- a/tests/runners/quarantine-runtime.test.ts
+++ b/tests/runners/quarantine-runtime.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from "vitest";
+import type {
+  RunnerAdapter,
+  ExecuteResult,
+  TestId,
+} from "../../src/cli/runners/types.js";
+import type { QuarantineManifestEntry } from "../../src/cli/quarantine-manifest.js";
+import { withQuarantineRuntime } from "../../src/cli/runners/quarantine-runtime.js";
+
+function makeRunner(
+  executeImpl: (tests: TestId[]) => Promise<ExecuteResult>,
+): RunnerAdapter & { calls: TestId[][] } {
+  const calls: TestId[][] = [];
+  return {
+    name: "mock",
+    capabilities: { nativeParallel: false },
+    calls,
+    async execute(tests) {
+      calls.push([...tests]);
+      return executeImpl(tests);
+    },
+    async listTests() {
+      return [];
+    },
+  };
+}
+
+describe("withQuarantineRuntime", () => {
+  it("skips matched tests before execution and annotates the synthetic result", async () => {
+    const baseRunner = makeRunner(async (tests) => ({
+      exitCode: 0,
+      results: tests.map((test) => ({
+        suite: test.suite,
+        testName: test.testName,
+        taskId: test.taskId,
+        status: "passed",
+        durationMs: 100,
+        retryCount: 0,
+      })),
+      durationMs: 100,
+      stdout: "ok",
+      stderr: "",
+    }));
+
+    const entry: QuarantineManifestEntry = {
+      id: "paint-vrt-local-assets",
+      taskId: "paint-vrt",
+      spec: "tests/paint-vrt.spec.ts",
+      titlePattern: "^optional snapshot asset$",
+      mode: "skip",
+      scope: "environment",
+      owner: "@mizchi",
+      reason: "optional asset is absent on local runs",
+      condition: "missing local snapshot asset",
+      introducedAt: "2026-04-01",
+      expiresAt: "2026-04-30",
+    };
+
+    const runner = withQuarantineRuntime(baseRunner, [entry]);
+    const result = await runner.execute([
+      {
+        suite: "tests/paint-vrt.spec.ts",
+        testName: "optional snapshot asset",
+        taskId: "paint-vrt",
+      },
+      {
+        suite: "tests/paint-vrt.spec.ts",
+        testName: "renders baseline",
+        taskId: "paint-vrt",
+      },
+    ]);
+
+    expect(baseRunner.calls).toEqual([
+      [
+        {
+          suite: "tests/paint-vrt.spec.ts",
+          testName: "renders baseline",
+          taskId: "paint-vrt",
+        },
+      ],
+    ]);
+    expect(
+      result.results.find(
+        (row) => row.testName === "optional snapshot asset",
+      ),
+    ).toMatchObject({
+      status: "skipped",
+      quarantine: {
+        id: "paint-vrt-local-assets",
+        mode: "skip",
+        owner: "@mizchi",
+      },
+    });
+    expect(
+      result.results.find(
+        (row) => row.testName === "optional snapshot asset",
+      )?.errorMessage,
+    ).toContain("paint-vrt-local-assets");
+  });
+
+  it("annotates allow_failure results and removes them from the blocking exit code", async () => {
+    const baseRunner = makeRunner(async () => ({
+      exitCode: 1,
+      results: [
+        {
+          suite: "tests/known-bugs.spec.ts",
+          testName: "fails on safari",
+          taskId: "browser-e2e",
+          status: "failed",
+          durationMs: 100,
+          retryCount: 0,
+          errorMessage: "AssertionError",
+        },
+      ],
+      durationMs: 100,
+      stdout: "",
+      stderr: "failed",
+    }));
+
+    const entry: QuarantineManifestEntry = {
+      id: "known-safari-bug",
+      taskId: "browser-e2e",
+      spec: "tests/known-bugs.spec.ts",
+      titlePattern: "^fails on safari$",
+      mode: "allow_failure",
+      scope: "expected_failure",
+      owner: "@mizchi",
+      reason: "upstream browser bug",
+      condition: "Safari 18 canvas regression",
+      introducedAt: "2026-04-01",
+      expiresAt: "2026-04-30",
+    };
+
+    const runner = withQuarantineRuntime(baseRunner, [entry]);
+    const result = await runner.execute([
+      {
+        suite: "tests/known-bugs.spec.ts",
+        testName: "fails on safari",
+        taskId: "browser-e2e",
+      },
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.results[0]).toMatchObject({
+      status: "failed",
+      quarantine: {
+        id: "known-safari-bug",
+        mode: "allow_failure",
+      },
+    });
+    expect(result.results[0].errorMessage).toContain("known-safari-bug");
+  });
+});

--- a/tests/runners/retry.test.ts
+++ b/tests/runners/retry.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 import type { RunnerAdapter, TestId, ExecuteResult } from "../../src/cli/runners/types.js";
 import type { TestCaseResult } from "../../src/cli/adapters/types.js";
 import { executeWithRetry } from "../../src/cli/runners/retry.js";
+import { withQuarantineRuntime } from "../../src/cli/runners/quarantine-runtime.js";
+import type { QuarantineManifestEntry } from "../../src/cli/quarantine-manifest.js";
 
 function createMockRunner(resultSequence: ExecuteResult[]): RunnerAdapter {
   let callIndex = 0;
@@ -17,12 +19,20 @@ function createMockRunner(resultSequence: ExecuteResult[]): RunnerAdapter {
   };
 }
 
-function makeResult(testResults: Array<{ suite: string; testName: string; status: "passed" | "failed" }>): ExecuteResult {
+function makeResult(
+  testResults: Array<{
+    suite: string;
+    testName: string;
+    status: "passed" | "failed";
+    filter?: string;
+  }>,
+): ExecuteResult {
   return {
     exitCode: testResults.some(r => r.status === "failed") ? 1 : 0,
     results: testResults.map(r => ({
       suite: r.suite,
       testName: r.testName,
+      filter: r.filter,
       status: r.status,
       durationMs: 100,
       retryCount: 0,
@@ -56,7 +66,7 @@ describe("executeWithRetry", () => {
     });
     expect(result.totalAttempts).toBe(2);
     expect(result.flakyDetected).toHaveLength(1);
-    expect(result.flakyDetected[0]).toEqual({ suite: "a", testName: "t1" });
+    expect(result.flakyDetected[0]).toMatchObject({ suite: "a", testName: "t1" });
     expect(result.results[0].status).toBe("flaky");
     expect(result.results[0].retryCount).toBe(1);
     expect(result.exitCode).toBe(0);
@@ -164,5 +174,160 @@ describe("executeWithRetry", () => {
     expect(good.status).toBe("passed");
 
     expect(result.exitCode).toBe(1); // broken_test still fails
+  });
+
+  it("keeps retries separate when suite/testName match but filters differ", async () => {
+    let callCount = 0;
+    const runner: RunnerAdapter = {
+      name: "mock",
+      capabilities: { nativeParallel: false },
+      async execute() {
+        callCount++;
+        if (callCount === 1) {
+          return makeResult([
+            { suite: "a", testName: "shared_test", status: "failed", filter: "@smoke" },
+            { suite: "a", testName: "shared_test", status: "passed", filter: "@regression" },
+          ]);
+        }
+        return makeResult([
+          { suite: "a", testName: "shared_test", status: "passed", filter: "@smoke" },
+        ]);
+      },
+      async listTests() { return []; },
+    };
+
+    const tests = [
+      { suite: "a", testName: "shared_test", filter: "@smoke" },
+      { suite: "a", testName: "shared_test", filter: "@regression" },
+    ];
+    const result = await executeWithRetry(runner, tests, {
+      maxRetries: 1, retryFailedOnly: true,
+    });
+
+    expect(result.flakyDetected).toHaveLength(1);
+    expect(result.flakyDetected[0].filter).toBe("@smoke");
+    expect(result.results).toHaveLength(2);
+    expect(
+      result.results.find(
+        (r) => r.testName === "shared_test" && r.filter === "@regression",
+      )?.status,
+    ).toBe("passed");
+    expect(
+      result.results.find(
+        (r) => r.testName === "shared_test" && r.filter === "@smoke",
+      )?.status,
+    ).toBe("flaky");
+  });
+
+  it("does not retry failed tests covered by allow_failure", async () => {
+    let callCount = 0;
+    const baseRunner: RunnerAdapter = {
+      name: "mock",
+      capabilities: { nativeParallel: false },
+      async execute() {
+        callCount++;
+        return makeResult([
+          {
+            suite: "tests/known-bugs.spec.ts",
+            testName: "fails on safari",
+            status: "failed",
+          },
+        ]);
+      },
+      async listTests() { return []; },
+    };
+    const entry: QuarantineManifestEntry = {
+      id: "known-safari-bug",
+      taskId: "browser-e2e",
+      spec: "tests/known-bugs.spec.ts",
+      titlePattern: "^fails on safari$",
+      mode: "allow_failure",
+      scope: "expected_failure",
+      owner: "@mizchi",
+      reason: "upstream browser bug",
+      condition: "Safari 18 canvas regression",
+      introducedAt: "2026-04-01",
+      expiresAt: "2026-04-30",
+    };
+    const runner = withQuarantineRuntime(baseRunner, [entry]);
+
+    const result = await executeWithRetry(
+      runner,
+      [{
+        suite: "tests/known-bugs.spec.ts",
+        testName: "fails on safari",
+        taskId: "browser-e2e",
+      }],
+      {
+        maxRetries: 3,
+        retryFailedOnly: true,
+      },
+    );
+
+    expect(callCount).toBe(1);
+    expect(result.totalAttempts).toBe(1);
+    expect(result.retriedTests).toBe(0);
+    expect(result.exitCode).toBe(0);
+    expect(result.results[0].quarantine?.id).toBe("known-safari-bug");
+  });
+
+  it("preserves allow_flaky annotations when a retried test becomes flaky", async () => {
+    let callCount = 0;
+    const baseRunner: RunnerAdapter = {
+      name: "mock",
+      capabilities: { nativeParallel: false },
+      async execute() {
+        callCount++;
+        if (callCount === 1) {
+          return makeResult([
+            {
+              suite: "tests/flaky.spec.ts",
+              testName: "sometimes times out",
+              status: "failed",
+            },
+          ]);
+        }
+        return makeResult([
+          {
+            suite: "tests/flaky.spec.ts",
+            testName: "sometimes times out",
+            status: "passed",
+          },
+        ]);
+      },
+      async listTests() { return []; },
+    };
+    const entry: QuarantineManifestEntry = {
+      id: "known-flake",
+      taskId: "browser-e2e",
+      spec: "tests/flaky.spec.ts",
+      titlePattern: "^sometimes times out$",
+      mode: "allow_flaky",
+      scope: "flaky",
+      owner: "@mizchi",
+      reason: "network timing variance",
+      condition: "sporadic CDN timeout",
+      introducedAt: "2026-04-01",
+      expiresAt: "2026-04-30",
+    };
+    const runner = withQuarantineRuntime(baseRunner, [entry]);
+
+    const result = await executeWithRetry(
+      runner,
+      [{
+        suite: "tests/flaky.spec.ts",
+        testName: "sometimes times out",
+        taskId: "browser-e2e",
+      }],
+      {
+        maxRetries: 2,
+        retryFailedOnly: true,
+      },
+    );
+
+    expect(result.totalAttempts).toBe(2);
+    expect(result.exitCode).toBe(0);
+    expect(result.results[0].status).toBe("flaky");
+    expect(result.results[0].quarantine?.id).toBe("known-flake");
   });
 });

--- a/tests/runners/runner-adapters.test.ts
+++ b/tests/runners/runner-adapters.test.ts
@@ -171,6 +171,7 @@ describe("PlaywrightRunner", () => {
     suites: [
       {
         title: "login.spec.ts",
+        file: "tests/login.spec.ts",
         specs: [
           {
             title: "logs in",
@@ -214,6 +215,8 @@ describe("PlaywrightRunner", () => {
 
     expect(result.results).toHaveLength(1);
     expect(result.results[0]).toMatchObject({
+      suite: "tests/login.spec.ts",
+      taskId: "login.spec.ts",
       testName: "logs in",
       status: "passed",
     });
@@ -240,7 +243,9 @@ describe("PlaywrightRunner", () => {
     expect(capturedCmd).toBe(
       "pnpm exec playwright test --list --reporter json",
     );
-    expect(ids).toEqual([{ suite: "app.spec.ts", testName: "renders" }]);
+    expect(ids).toEqual([
+      { suite: "app.spec.ts", testName: "renders", taskId: "app.spec.ts" },
+    ]);
   });
 });
 
@@ -262,7 +267,13 @@ describe("parsePlaywrightList", () => {
       ],
     });
     const ids = parsePlaywrightList(json);
-    expect(ids).toEqual([{ suite: "group", testName: "works" }]);
+    expect(ids).toEqual([
+      {
+        suite: "file.spec.ts",
+        testName: "works",
+        taskId: "group",
+      },
+    ]);
   });
 });
 

--- a/tests/storage/duckdb-load.test.ts
+++ b/tests/storage/duckdb-load.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from "vitest";
+import { DuckDBStore } from "../../src/cli/storage/duckdb.js";
+
+describe("DuckDBStore module loading", () => {
+  it("wraps module load failures with actionable error message", async () => {
+    const store = new DuckDBStore(":memory:");
+    (store as any).loadDuckDBModule = async () => {
+      throw new Error("cannot find duckdb.node");
+    };
+
+    await expect(store.initialize()).rejects.toThrow("Failed to load DuckDB native binding.");
+  });
+});

--- a/tests/storage/duckdb.test.ts
+++ b/tests/storage/duckdb.test.ts
@@ -4,6 +4,7 @@ import type {
   WorkflowRun,
   TestResult,
 } from "../../src/cli/storage/types.js";
+import { createStableTestId } from "../../src/cli/identity.js";
 
 describe("DuckDBStore", () => {
   let store: DuckDBStore;
@@ -154,6 +155,65 @@ describe("DuckDBStore", () => {
     expect(flaky[0].flakyRate).toBe(50.0);
   });
 
+  it("keeps same suite/testName separate when filter differs", async () => {
+    const run: WorkflowRun = {
+      id: 301,
+      repo: "owner/repo",
+      branch: "main",
+      commitSha: "split123",
+      event: "push",
+      status: "completed",
+      createdAt: new Date(),
+      durationMs: 1000,
+    };
+    await store.insertWorkflowRun(run);
+
+    const now = new Date();
+    const results: TestResult[] = [];
+    for (let i = 0; i < 5; i++) {
+      results.push({
+        workflowRunId: 301,
+        suite: "integration",
+        testName: "shared-test",
+        filter: "@smoke",
+        status: "failed",
+        durationMs: 100,
+        retryCount: 0,
+        errorMessage: "flaky failure",
+        commitSha: "split123",
+        variant: null,
+        createdAt: now,
+      });
+      results.push({
+        workflowRunId: 301,
+        suite: "integration",
+        testName: "shared-test",
+        filter: "@regression",
+        status: "passed",
+        durationMs: 100,
+        retryCount: 0,
+        errorMessage: null,
+        commitSha: "split123",
+        variant: null,
+        createdAt: now,
+      });
+    }
+    await store.insertTestResults(results);
+
+    const flaky = await store.queryFlakyTests({ windowDays: 30 });
+    expect(flaky).toHaveLength(1);
+    expect(flaky[0].suite).toBe("integration");
+    expect(flaky[0].testName).toBe("shared-test");
+    expect(flaky[0].filter).toBe("@smoke");
+    expect(flaky[0].testId).toBe(
+      createStableTestId({
+        suite: "integration",
+        testName: "shared-test",
+        filter: "@smoke",
+      }),
+    );
+  });
+
   it("queries test history", async () => {
     const run: WorkflowRun = {
       id: 400,
@@ -199,6 +259,55 @@ describe("DuckDBStore", () => {
     expect(history).toHaveLength(2);
     expect(history[0].suite).toBe("e2e");
     expect(history[0].testName).toBe("login-test");
+  });
+
+  it("persists quarantine metadata with stored test results", async () => {
+    const run: WorkflowRun = {
+      id: 401,
+      repo: "owner/repo",
+      branch: "main",
+      commitSha: "quarantine123",
+      event: "push",
+      status: "completed",
+      createdAt: new Date(),
+      durationMs: 1000,
+    };
+    await store.insertWorkflowRun(run);
+
+    await store.insertTestResults([
+      {
+        workflowRunId: 401,
+        suite: "e2e",
+        testName: "known broken flow",
+        status: "failed",
+        durationMs: 200,
+        retryCount: 0,
+        errorMessage: "AssertionError",
+        commitSha: "quarantine123",
+        variant: null,
+        quarantine: {
+          id: "known-bug",
+          taskId: "browser-e2e",
+          spec: "tests/known-bugs.spec.ts",
+          titlePattern: "^known broken flow$",
+          mode: "allow_failure",
+          scope: "expected_failure",
+          owner: "@mizchi",
+          reason: "known browser issue",
+          condition: "waiting for upstream fix",
+          introducedAt: "2026-04-01",
+          expiresAt: "2026-04-30",
+        },
+        createdAt: new Date("2025-01-03T00:00:00Z"),
+      },
+    ]);
+
+    const history = await store.queryTestHistory("e2e", "known broken flow");
+    expect(history[0].quarantine).toMatchObject({
+      id: "known-bug",
+      mode: "allow_failure",
+      owner: "@mizchi",
+    });
   });
 
   it("executes raw SQL", async () => {

--- a/tests/storage/quarantine.test.ts
+++ b/tests/storage/quarantine.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { DuckDBStore } from "../../src/cli/storage/duckdb.js";
+import { createStableTestId } from "../../src/cli/identity.js";
 
 describe("Quarantine Storage", () => {
   let store: DuckDBStore;
@@ -14,7 +15,7 @@ describe("Quarantine Storage", () => {
   });
 
   it("adds a test to quarantine", async () => {
-    await store.addQuarantine("suite-a", "test-1", "flaky");
+    await store.addQuarantine({ suite: "suite-a", testName: "test-1" }, "flaky");
     const all = await store.queryQuarantined();
     expect(all).toHaveLength(1);
     expect(all[0].suite).toBe("suite-a");
@@ -24,23 +25,68 @@ describe("Quarantine Storage", () => {
   });
 
   it("removes a test from quarantine", async () => {
-    await store.addQuarantine("suite-a", "test-1", "flaky");
-    await store.removeQuarantine("suite-a", "test-1");
+    await store.addQuarantine({ suite: "suite-a", testName: "test-1" }, "flaky");
+    await store.removeQuarantine({ suite: "suite-a", testName: "test-1" });
     const all = await store.queryQuarantined();
     expect(all).toHaveLength(0);
   });
 
   it("checks if a test is quarantined", async () => {
-    await store.addQuarantine("suite-a", "test-1", "flaky");
-    expect(await store.isQuarantined("suite-a", "test-1")).toBe(true);
-    expect(await store.isQuarantined("suite-a", "test-2")).toBe(false);
+    await store.addQuarantine({ suite: "suite-a", testName: "test-1" }, "flaky");
+    expect(await store.isQuarantined({ suite: "suite-a", testName: "test-1" })).toBe(true);
+    expect(await store.isQuarantined({ suite: "suite-a", testName: "test-2" })).toBe(false);
   });
 
   it("does not duplicate entries (ON CONFLICT updates reason)", async () => {
-    await store.addQuarantine("suite-a", "test-1", "flaky");
-    await store.addQuarantine("suite-a", "test-1", "manual");
+    await store.addQuarantine({ suite: "suite-a", testName: "test-1" }, "flaky");
+    await store.addQuarantine({ suite: "suite-a", testName: "test-1" }, "manual");
     const all = await store.queryQuarantined();
     expect(all).toHaveLength(1);
     expect(all[0].reason).toBe("manual");
+  });
+
+  it("treats filtered variants as distinct quarantine identities", async () => {
+    await store.addQuarantine(
+      { suite: "suite-a", testName: "test-1", filter: "@smoke" },
+      "manual",
+    );
+    await store.addQuarantine(
+      { suite: "suite-a", testName: "test-1", filter: "@regression" },
+      "manual",
+    );
+
+    const all = await store.queryQuarantined();
+    expect(all).toHaveLength(2);
+    expect(new Set(all.map((entry) => entry.testId)).size).toBe(2);
+    expect(
+      all.map((entry) => entry.testId).sort(),
+    ).toEqual(
+      [
+        createStableTestId({
+          suite: "suite-a",
+          testName: "test-1",
+          filter: "@regression",
+        }),
+        createStableTestId({
+          suite: "suite-a",
+          testName: "test-1",
+          filter: "@smoke",
+        }),
+      ].sort(),
+    );
+    expect(
+      await store.isQuarantined({
+        suite: "suite-a",
+        testName: "test-1",
+        filter: "@smoke",
+      }),
+    ).toBe(true);
+    expect(
+      await store.isQuarantined({
+        suite: "suite-a",
+        testName: "test-1",
+        filter: "@other",
+      }),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
### Motivation

- Ensure the CLI continues to resolve affected targets even when the MoonBit JS build is not present by providing a TypeScript fallback parser for `task(...)` blocks and glob matching.
- Improve robustness and developer feedback when native `duckdb` bindings are missing by lazy-loading the module and surfacing an actionable error message.
- Provide a quick runtime diagnosis command and CI coverage for both MoonBit-present and MoonBit-absent scenarios.

### Description

- Implemented a TypeScript fallback in `src/cli/core/loader.ts` that parses multi-line `task(...)` blocks, supports single/double quotes, expands `needs` transitively, and matches `*`/`**` globs via `globToRegex`, plus added `hasMoonBitJsBuild` and centralized build path constant `MOONBIT_JS_BUILD_URL`.
- Made `src/cli/storage/duckdb.ts` resilient by dynamically importing `duckdb`, exposing `loadDuckDBModule`, and wrapping load failures with an actionable error message and rebuild hint; added lightweight DuckDB module/connection types.
- Added a `doctor` command and library in `src/cli/commands/doctor.ts` with `runDoctor` and `formatDoctorReport`, and wired the CLI in `src/cli/main.ts` to run it; also normalized GitHub list mapping in `main.ts` to a minimal shape consumed by the collector.
- Added CI workflow `.github/workflows/core-fallback-matrix.yml` to run tests in two modes (`with_moonbit_build` and `without_moonbit_build`) and updated `package.json` to include `pnpm.onlyBuiltDependencies: ["duckdb"]`; created docs and TODO notes to aid debugging and roadmap.
- Minor typing and utility tweaks: changed `deepMerge` generic signature in `src/cli/config.ts` and exported `loadCoreSync` behavior remains unchanged for synchronous contexts.
- Added unit tests: `tests/core/resolve-affected-glob-parity.test.ts`, `tests/resolvers/bitflow-native.test.ts` (extended), `tests/storage/duckdb-load.test.ts`, and `tests/commands/doctor.test.ts`.

### Testing

- Ran targeted unit tests with Vitest via `pnpm vitest run` covering resolver parity, fallback parsing, `doctor` behavior, and DuckDB load error wrapping, and all tests passed. 
- Ran TypeScript typecheck using `pnpm -s tsc --noEmit` with no type errors reported. 
- Added CI workflow `.github/workflows/core-fallback-matrix.yml` to exercise both MoonBit present/absent scenarios in automated runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd01d919c4832d8006b2b54f224a88)