### PR TITLE
Add affected explain command

### DIFF
--- a/src/cli/commands/affected.ts
+++ b/src/cli/commands/affected.ts
@@ -1,0 +1,114 @@
+import {
+  buildAffectedReport,
+  createAffectedSelection,
+  dedupeAffectedTargets,
+} from "../resolvers/affected-report.js";
+import type {
+  AffectedReport,
+  AffectedSelection,
+  DependencyResolver,
+} from "../resolvers/types.js";
+import type { TestId } from "../runners/types.js";
+
+export interface RunAffectedOpts {
+  resolverName: string;
+  resolver: DependencyResolver;
+  changedFiles: string[];
+  listedTests: TestId[];
+}
+
+function toAffectedTarget(test: TestId) {
+  return {
+    spec: test.suite,
+    taskId: test.taskId ?? test.suite,
+    filter: test.filter ?? null,
+  };
+}
+
+function normalizeAffectedReport(
+  report: AffectedReport,
+  resolverName: string,
+): AffectedReport {
+  return {
+    ...report,
+    resolver: resolverName,
+  };
+}
+
+function formatSelectionRow(entry: AffectedSelection): string {
+  const filter = entry.filter ?? "-";
+  const includedBy = entry.includedBy.length > 0 ? entry.includedBy.join(", ") : "-";
+  const reasons = entry.matchReasons.length > 0 ? entry.matchReasons.join(", ") : "-";
+  const matchedPaths = entry.matchedPaths.length > 0 ? entry.matchedPaths.join(", ") : "-";
+  return `| ${entry.taskId} | ${entry.spec} | ${filter} | ${entry.direct ? "direct" : "transitive"} | ${includedBy} | ${reasons} | ${matchedPaths} |`;
+}
+
+function formatSelectionSection(
+  title: string,
+  entries: AffectedSelection[],
+): string[] {
+  const lines = [`## ${title}`, ""];
+  if (entries.length === 0) {
+    lines.push("_None_", "");
+    return lines;
+  }
+
+  lines.push(
+    "| taskId | spec | filter | directness | includedBy | matchReasons | matchedPaths |",
+    "| --- | --- | --- | --- | --- | --- | --- |",
+    ...entries.map(formatSelectionRow),
+    "",
+  );
+  return lines;
+}
+
+export async function runAffected(opts: RunAffectedOpts): Promise<AffectedReport> {
+  const targets = dedupeAffectedTargets(opts.listedTests.map(toAffectedTarget));
+  if (opts.resolver.explain) {
+    const report = await opts.resolver.explain(opts.changedFiles, targets);
+    return normalizeAffectedReport(report, opts.resolverName);
+  }
+
+  const affectedSpecs = await opts.resolver.resolve(
+    opts.changedFiles,
+    targets.map((target) => target.spec),
+  );
+  const affectedSpecSet = new Set(affectedSpecs);
+  const selected = targets
+    .filter((target) => affectedSpecSet.has(target.spec))
+    .map((target) => createAffectedSelection(target, { direct: true }));
+
+  return buildAffectedReport(opts.resolverName, opts.changedFiles, selected, []);
+}
+
+export function formatAffectedReport(
+  report: AffectedReport,
+  format: "json" | "markdown",
+): string {
+  if (format === "json") {
+    return JSON.stringify(report, null, 2);
+  }
+
+  const lines = [
+    "# Affected Report",
+    "",
+    `- Resolver: ${report.resolver}`,
+    `- Changed files: ${report.changedFiles.length}`,
+    `- Matched: ${report.summary.matchedCount}`,
+    `- Selected: ${report.summary.selectedCount}`,
+    `- Unmatched: ${report.summary.unmatchedCount}`,
+    "",
+    ...formatSelectionSection("Matched", report.matched),
+    ...formatSelectionSection("Selected", report.selected),
+    "## Unmatched",
+    "",
+  ];
+
+  if (report.unmatched.length === 0) {
+    lines.push("_None_");
+  } else {
+    lines.push(...report.unmatched.map((path) => `- ${path}`));
+  }
+
+  return lines.join("\n");
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -24,10 +24,15 @@ import { runEval, formatEvalReport } from "./commands/eval.js";
 import { runReason, formatReasoningReport } from "./commands/reason.js";
 import { runSelfEval, formatSelfEvalReport } from "./commands/self-eval.js";
 import { runDoctor, formatDoctorReport } from "./commands/doctor.js";
+import {
+  runAffected,
+  formatAffectedReport,
+} from "./commands/affected.js";
 import { DuckDBStore } from "./storage/duckdb.js";
 import { createRunner } from "./runners/index.js";
 import { resolveTestIdentity } from "./identity.js";
 import { toStoredTestResult } from "./storage/test-result-mapper.js";
+import { createResolver } from "./resolvers/index.js";
 import {
   formatQuarantineManifestReport,
   loadQuarantineManifest,
@@ -384,6 +389,55 @@ program
       } finally {
         await store.close();
       }
+    },
+  );
+
+// --- affected ---
+program
+  .command("affected [paths...]")
+  .description("Explain affected test selection for changed files")
+  .option("--changed <files>", "Comma-separated list of changed files")
+  .option("--json", "Output JSON report")
+  .option("--markdown", "Output Markdown report")
+  .action(
+    async (
+      paths: string[],
+      opts: { changed?: string; json?: boolean; markdown?: boolean },
+    ) => {
+      if (opts.json && opts.markdown) {
+        console.error("Error: choose either --json or --markdown");
+        process.exit(1);
+      }
+
+      const changedFiles = [
+        ...paths,
+        ...(opts.changed
+          ? opts.changed
+              .split(",")
+              .map((value) => value.trim())
+              .filter(Boolean)
+          : []),
+      ];
+
+      if (changedFiles.length === 0) {
+        console.error("Error: at least one changed file is required");
+        process.exit(1);
+      }
+
+      const cwd = process.cwd();
+      const config = loadConfig(cwd);
+      const resolver = createResolver(config.affected, cwd);
+      const listedTests = await listRunnerTests(cwd, config.runner);
+      const report = await runAffected({
+        resolverName: config.affected.resolver,
+        resolver,
+        changedFiles,
+        listedTests,
+      });
+
+      console.log(
+        formatAffectedReport(report, opts.json ? "json" : "markdown"),
+      );
     },
   );
 

--- a/src/cli/resolvers/affected-report.ts
+++ b/src/cli/resolvers/affected-report.ts
@@ -1,0 +1,91 @@
+import type {
+  AffectedReport,
+  AffectedSelection,
+  AffectedTarget,
+} from "./types.js";
+
+function compareNullable(a: string | null, b: string | null): number {
+  return (a ?? "").localeCompare(b ?? "");
+}
+
+export function sortAffectedSelections(
+  entries: AffectedSelection[],
+): AffectedSelection[] {
+  return [...entries].sort((a, b) => {
+    const bySpec = a.spec.localeCompare(b.spec);
+    if (bySpec !== 0) return bySpec;
+    const byTaskId = a.taskId.localeCompare(b.taskId);
+    if (byTaskId !== 0) return byTaskId;
+    return compareNullable(a.filter, b.filter);
+  });
+}
+
+export function createAffectedSelection(
+  target: AffectedTarget,
+  opts: {
+    direct: boolean;
+    includedBy?: string[];
+    matchedPaths?: string[];
+    matchReasons?: string[];
+  },
+): AffectedSelection {
+  return {
+    taskId: target.taskId,
+    spec: target.spec,
+    filter: target.filter,
+    direct: opts.direct,
+    includedBy: [...(opts.includedBy ?? [])].sort(),
+    matchedPaths: [...(opts.matchedPaths ?? [])].sort(),
+    matchReasons: [...(opts.matchReasons ?? [])],
+  };
+}
+
+export function buildAffectedReport(
+  resolver: string,
+  changedFiles: string[],
+  selected: AffectedSelection[],
+  unmatched: string[],
+): AffectedReport {
+  const sortedSelected = sortAffectedSelections(selected);
+  const matched = sortedSelected.filter((entry) => entry.direct);
+  const sortedUnmatched = [...unmatched].sort();
+  return {
+    resolver,
+    changedFiles: [...changedFiles],
+    matched,
+    selected: sortedSelected,
+    unmatched: sortedUnmatched,
+    summary: {
+      matchedCount: matched.length,
+      selectedCount: sortedSelected.length,
+      unmatchedCount: sortedUnmatched.length,
+    },
+  };
+}
+
+export function dedupeAffectedTargets(
+  targets: AffectedTarget[],
+): AffectedTarget[] {
+  const byKey = new Map<string, AffectedTarget>();
+  for (const target of targets) {
+    const key = JSON.stringify({
+      spec: target.spec,
+      taskId: target.taskId,
+      filter: target.filter ?? null,
+    });
+    if (!byKey.has(key)) {
+      byKey.set(key, {
+        spec: target.spec,
+        taskId: target.taskId,
+        filter: target.filter ?? null,
+      });
+    }
+  }
+  return [...byKey.values()].sort((a, b) => {
+    const bySpec = a.spec.localeCompare(b.spec);
+    if (bySpec !== 0) return bySpec;
+    const byTaskId = a.taskId.localeCompare(b.taskId);
+    if (byTaskId !== 0) return byTaskId;
+    return compareNullable(a.filter, b.filter);
+  });
+}

--- a/src/cli/resolvers/bitflow-native.ts
+++ b/src/cli/resolvers/bitflow-native.ts
@@ -1,6 +1,19 @@
 import { readFileSync } from "node:fs";
 import { loadCore } from "../core/loader.js";
-import type { DependencyResolver } from "./types.js";
+import {
+  buildAffectedReport,
+  createAffectedSelection,
+} from "./affected-report.js";
+import {
+  buildBitflowDependents,
+  matchBitflowTaskPaths,
+  parseBitflowWorkflowTasks,
+} from "./bitflow-workflow.js";
+import type {
+  AffectedReport,
+  AffectedTarget,
+  DependencyResolver,
+} from "./types.js";
 
 export class BitflowNativeResolver implements DependencyResolver {
   private workflowText: string;
@@ -12,8 +25,83 @@ export class BitflowNativeResolver implements DependencyResolver {
   async resolve(changedFiles: string[], allTestFiles: string[]): Promise<string[]> {
     const core = await loadCore();
     const affectedTargets = core.resolveAffected(this.workflowText, changedFiles);
-    // Filter against known test files
     const testSet = new Set(allTestFiles);
-    return affectedTargets.filter(t => testSet.has(t));
+    return affectedTargets.filter((target) => testSet.has(target));
+  }
+
+  explain(changedFiles: string[], targets: AffectedTarget[]): AffectedReport {
+    const tasks = parseBitflowWorkflowTasks(this.workflowText);
+    const directMatches = new Map<
+      string,
+      { matchedPaths: string[]; matchReasons: string[] }
+    >();
+    const unmatched = new Set(changedFiles);
+
+    for (const task of tasks) {
+      const result = matchBitflowTaskPaths(task, changedFiles);
+      if (result.matchedPaths.length === 0) continue;
+
+      directMatches.set(task.id, result);
+      for (const matchedPath of result.matchedPaths) {
+        unmatched.delete(matchedPath);
+      }
+    }
+
+    const dependents = buildBitflowDependents(tasks);
+    const includedBy = new Map<string, Set<string>>();
+    const affected = new Set(directMatches.keys());
+    const queue = [...directMatches.keys()];
+
+    for (let index = 0; index < queue.length; index++) {
+      const current = queue[index];
+      for (const dependent of dependents.get(current) ?? []) {
+        let parents = includedBy.get(dependent);
+        if (!parents) {
+          parents = new Set<string>();
+          includedBy.set(dependent, parents);
+        }
+        parents.add(current);
+
+        if (!affected.has(dependent)) {
+          affected.add(dependent);
+          queue.push(dependent);
+        }
+      }
+    }
+
+    const targetsByTaskId = new Map<string, AffectedTarget[]>();
+    for (const target of targets) {
+      const existing = targetsByTaskId.get(target.taskId);
+      if (existing) {
+        existing.push(target);
+      } else {
+        targetsByTaskId.set(target.taskId, [target]);
+      }
+    }
+
+    const selected = [...affected].flatMap((taskId) => {
+      const matchedTargets = targetsByTaskId.get(taskId) ?? [];
+      const direct = directMatches.has(taskId);
+      const parents = [...(includedBy.get(taskId) ?? [])].sort();
+      const directMatch = directMatches.get(taskId);
+
+      return matchedTargets.map((target) =>
+        createAffectedSelection(target, {
+          direct,
+          includedBy: direct ? [] : parents,
+          matchedPaths: direct ? (directMatch?.matchedPaths ?? []) : [],
+          matchReasons: direct
+            ? (directMatch?.matchReasons ?? [])
+            : parents.map((parent) => `dependency:${parent}`),
+        }),
+      );
+    });
+
+    return buildAffectedReport(
+      "bitflow",
+      changedFiles,
+      selected,
+      [...unmatched],
+    );
   }
 }

--- a/src/cli/resolvers/bitflow-workflow.ts
+++ b/src/cli/resolvers/bitflow-workflow.ts
@@ -1,0 +1,170 @@
+export interface BitflowTaskDefinition {
+  id: string;
+  needs: string[];
+  srcs: string[];
+}
+
+export function parseBitflowWorkflowTasks(
+  workflowText: string,
+): BitflowTaskDefinition[] {
+  const blocks = extractTaskBlocks(workflowText);
+  const tasks: BitflowTaskDefinition[] = [];
+
+  for (const block of blocks) {
+    const id = getQuotedValue(block, "id");
+    if (!id) continue;
+
+    tasks.push({
+      id,
+      needs: getQuotedArrayValue(block, "needs"),
+      srcs: getQuotedArrayValue(block, "srcs"),
+    });
+  }
+
+  return tasks;
+}
+
+export function buildBitflowDependents(
+  tasks: BitflowTaskDefinition[],
+): Map<string, string[]> {
+  const dependents = new Map<string, string[]>();
+
+  for (const task of tasks) {
+    for (const need of task.needs) {
+      const existing = dependents.get(need);
+      if (existing) {
+        existing.push(task.id);
+      } else {
+        dependents.set(need, [task.id]);
+      }
+    }
+  }
+
+  return dependents;
+}
+
+export function matchBitflowTaskPaths(
+  task: BitflowTaskDefinition,
+  changedFiles: string[],
+): {
+  matchedPaths: string[];
+  matchReasons: string[];
+} {
+  const matchedPaths: string[] = [];
+  const matchReasons = new Set<string>();
+
+  for (const path of changedFiles) {
+    const matchedPatterns = task.srcs.filter((pattern) => matchGlob(pattern, path));
+    if (matchedPatterns.length === 0) continue;
+
+    matchedPaths.push(path);
+    for (const pattern of matchedPatterns) {
+      matchReasons.add(`glob:${normalizePath(pattern)}`);
+    }
+  }
+
+  return {
+    matchedPaths,
+    matchReasons: [...matchReasons],
+  };
+}
+
+function extractTaskBlocks(workflowText: string): string[] {
+  const blocks: string[] = [];
+  let index = 0;
+
+  while (index < workflowText.length) {
+    const start = workflowText.indexOf("task(", index);
+    if (start === -1) break;
+
+    let depth = 0;
+    let quoteChar: "'" | "\"" | null = null;
+    let end = start;
+
+    for (; end < workflowText.length; end++) {
+      const current = workflowText[end];
+      const previous = end > 0 ? workflowText[end - 1] : "";
+
+      if ((current === "\"" || current === "'") && previous !== "\\") {
+        if (quoteChar === null) {
+          quoteChar = current;
+        } else if (quoteChar === current) {
+          quoteChar = null;
+        }
+      }
+      if (quoteChar !== null) continue;
+
+      if (current === "(") depth++;
+      if (current === ")") {
+        depth--;
+        if (depth === 0) {
+          end++;
+          break;
+        }
+      }
+    }
+
+    if (end > start) {
+      blocks.push(workflowText.slice(start, end));
+      index = end;
+    } else {
+      index = start + 5;
+    }
+  }
+
+  return blocks;
+}
+
+function getQuotedValue(line: string, key: string): string | null {
+  const match = new RegExp(`${key}\\s*=\\s*(['"])(.*?)\\1`, "s").exec(line);
+  return match?.[2] ?? null;
+}
+
+function getQuotedArrayValue(line: string, key: string): string[] {
+  const match = new RegExp(`${key}\\s*=\\s*\\[(.*?)\\]`, "s").exec(line);
+  if (!match) return [];
+
+  const inner = match[1].trim();
+  if (!inner) return [];
+
+  const values: string[] = [];
+  const pattern = /(['"])(.*?)\1/g;
+  for (const captured of inner.matchAll(pattern)) {
+    values.push(captured[2]);
+  }
+  return values;
+}
+
+function matchGlob(pattern: string, target: string): boolean {
+  return globToRegex(normalizePath(pattern)).test(normalizePath(target));
+}
+
+function normalizePath(path: string): string {
+  return path.replaceAll("\\", "/");
+}
+
+function globToRegex(pattern: string): RegExp {
+  let out = "^";
+  for (let index = 0; index < pattern.length; index++) {
+    const current = pattern[index];
+    if (current === "*") {
+      const next = pattern[index + 1];
+      if (next === "*") {
+        out += ".*";
+        index++;
+      } else {
+        out += "[^/]*";
+      }
+      continue;
+    }
+
+    if (".+?^${}()|[]\\".includes(current)) {
+      out += `\\${current}`;
+    } else {
+      out += current;
+    }
+  }
+
+  out += "$";
+  return new RegExp(out);
+}

--- a/src/cli/resolvers/index.ts
+++ b/src/cli/resolvers/index.ts
@@ -20,6 +20,7 @@ export function createResolver(
   rootDir: string,
 ): DependencyResolver {
   switch (config.resolver) {
+    case "git":
     case "simple":
       return new SimpleResolver();
     case "bitflow":

--- a/src/cli/resolvers/moon.ts
+++ b/src/cli/resolvers/moon.ts
@@ -1,6 +1,14 @@
 import { readFileSync, existsSync, readdirSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
-import type { DependencyResolver } from "./types.js";
+import {
+  buildAffectedReport,
+  createAffectedSelection,
+} from "./affected-report.js";
+import type {
+  AffectedReport,
+  AffectedTarget,
+  DependencyResolver,
+} from "./types.js";
 
 interface MoonPackage {
   path: string;
@@ -133,10 +141,15 @@ export class MoonResolver implements DependencyResolver {
     return null;
   }
 
-  resolve(changedFiles: string[], allTestFiles: string[]): string[] {
-    // 1. Find packages containing changed files
-    const changedPackages = new Set<string>();
+  private matchChangedPackages(changedFiles: string[]): {
+    directMatches: Map<string, string[]>;
+    unmatched: string[];
+  } {
+    const directMatches = new Map<string, string[]>();
+    const unmatched: string[] = [];
+
     for (const file of changedFiles) {
+      const matchedPackages: string[] = [];
       for (const [path, pkg] of this.packages) {
         if (
           file.startsWith(path + "/") ||
@@ -144,26 +157,85 @@ export class MoonResolver implements DependencyResolver {
           pkg.sourceFiles.includes(file) ||
           pkg.testFiles.includes(file)
         ) {
-          changedPackages.add(path);
+          matchedPackages.push(path);
+        }
+      }
+
+      if (matchedPackages.length === 0) {
+        unmatched.push(file);
+        continue;
+      }
+
+      for (const path of matchedPackages) {
+        const existing = directMatches.get(path);
+        if (existing) {
+          existing.push(file);
+        } else {
+          directMatches.set(path, [file]);
         }
       }
     }
 
-    // 2. Build reverse dependency map
-    const dependents: Map<string, string[]> = new Map();
+    return {
+      directMatches,
+      unmatched,
+    };
+  }
+
+  private buildDependents(): Map<string, string[]> {
+    const dependents = new Map<string, string[]>();
     for (const [path, pkg] of this.packages) {
       for (const imp of pkg.imports) {
         const resolved = this.resolveImportToPath(imp);
-        if (resolved) {
-          if (!dependents.has(resolved)) dependents.set(resolved, []);
-          dependents.get(resolved)!.push(path);
+        if (!resolved) continue;
+
+        const existing = dependents.get(resolved);
+        if (existing) {
+          existing.push(path);
+        } else {
+          dependents.set(resolved, [path]);
+        }
+      }
+    }
+    return dependents;
+  }
+
+  private expandAffectedPackages(
+    directMatches: Map<string, string[]>,
+  ): Map<string, string[]> {
+    const dependents = this.buildDependents();
+    const affected = new Set(directMatches.keys());
+    const includedBy = new Map<string, Set<string>>();
+    const queue = [...directMatches.keys()];
+
+    for (let index = 0; index < queue.length; index++) {
+      const current = queue[index];
+      for (const dependent of dependents.get(current) ?? []) {
+        let parents = includedBy.get(dependent);
+        if (!parents) {
+          parents = new Set<string>();
+          includedBy.set(dependent, parents);
+        }
+        parents.add(current);
+
+        if (!affected.has(dependent)) {
+          affected.add(dependent);
+          queue.push(dependent);
         }
       }
     }
 
-    // 3. Expand transitively via reverse deps
-    const affected = new Set(changedPackages);
-    const queue = [...changedPackages];
+    return new Map(
+      [...includedBy.entries()].map(([key, value]) => [key, [...value].sort()]),
+    );
+  }
+
+  resolve(changedFiles: string[], allTestFiles: string[]): string[] {
+    const { directMatches } = this.matchChangedPackages(changedFiles);
+    const dependents = this.buildDependents();
+    const affected = new Set<string>(directMatches.keys());
+    const queue = [...directMatches.keys()];
+
     while (queue.length > 0) {
       const pkg = queue.pop()!;
       const deps = dependents.get(pkg) ?? [];
@@ -175,7 +247,6 @@ export class MoonResolver implements DependencyResolver {
       }
     }
 
-    // 4. Collect test files
     const affectedTests = new Set<string>();
     for (const path of affected) {
       const pkg = this.packages.get(path);
@@ -188,5 +259,42 @@ export class MoonResolver implements DependencyResolver {
 
     const testSet = new Set(allTestFiles);
     return Array.from(affectedTests).filter((t) => testSet.has(t));
+  }
+
+  explain(changedFiles: string[], targets: AffectedTarget[]): AffectedReport {
+    const { directMatches, unmatched } = this.matchChangedPackages(changedFiles);
+    const includedBy = this.expandAffectedPackages(directMatches);
+    const affectedPackages = new Set<string>([
+      ...directMatches.keys(),
+      ...includedBy.keys(),
+    ]);
+    const targetsByTaskId = new Map<string, AffectedTarget[]>();
+
+    for (const target of targets) {
+      const existing = targetsByTaskId.get(target.taskId);
+      if (existing) {
+        existing.push(target);
+      } else {
+        targetsByTaskId.set(target.taskId, [target]);
+      }
+    }
+
+    const selected = [...affectedPackages].flatMap((taskId) => {
+      const matchedTargets = targetsByTaskId.get(taskId) ?? [];
+      const direct = directMatches.has(taskId);
+      const parents = includedBy.get(taskId) ?? [];
+      return matchedTargets.map((target) =>
+        createAffectedSelection(target, {
+          direct,
+          includedBy: direct ? [] : parents,
+          matchedPaths: direct ? (directMatches.get(taskId) ?? []) : [],
+          matchReasons: direct
+            ? [`package:${taskId}`]
+            : parents.map((parent) => `dependency:${parent}`),
+        }),
+      );
+    });
+
+    return buildAffectedReport("moon", changedFiles, selected, unmatched);
   }
 }

--- a/src/cli/resolvers/simple.ts
+++ b/src/cli/resolvers/simple.ts
@@ -1,24 +1,80 @@
-import type { DependencyResolver } from "./types.js";
+import {
+  buildAffectedReport,
+  createAffectedSelection,
+} from "./affected-report.js";
+import type {
+  AffectedReport,
+  AffectedTarget,
+  DependencyResolver,
+} from "./types.js";
+
+function normalizePath(path: string): string {
+  return path.replaceAll("\\", "/");
+}
+
+function toChangedDir(file: string): string {
+  const stripped = normalizePath(file).replace(/^src\//, "");
+  const parts = stripped.split("/");
+  parts.pop();
+  return parts.join("/");
+}
+
+function toTargetDir(spec: string): string {
+  return normalizePath(spec).replace(/^tests\//, "").split("/").slice(0, -1).join("/");
+}
+
+function toDirectoryReason(dir: string): string {
+  return `directory:${dir ? `src/${dir}` : "src"}`;
+}
 
 export class SimpleResolver implements DependencyResolver {
   resolve(changedFiles: string[], allTestFiles: string[]): string[] {
-    const changedDirs = changedFiles.map((f) => {
-      // Strip "src/" prefix and get directory path
-      const stripped = f.replace(/^src\//, "");
-      const parts = stripped.split("/");
-      parts.pop(); // remove filename
-      return parts.join("/");
-    });
+    const changedDirs = changedFiles.map(toChangedDir);
 
     return allTestFiles.filter((testFile) => {
-      // Strip "tests/" prefix and get directory path
-      const stripped = testFile.replace(/^tests\//, "");
-      const testDir = stripped.split("/").slice(0, -1).join("/");
+      const testDir = toTargetDir(testFile);
 
       return changedDirs.some((changedDir) => {
-        // Match if the test file's directory starts with the changed file's directory
         return testDir === changedDir || testDir.startsWith(changedDir + "/");
       });
     });
+  }
+
+  explain(changedFiles: string[], targets: AffectedTarget[]): AffectedReport {
+    const matchedFiles = new Set<string>();
+    const selected = targets.flatMap((target) => {
+      const targetDir = toTargetDir(target.spec);
+      const directMatches = changedFiles.filter((file) => {
+        const changedDir = toChangedDir(file);
+        return (
+          targetDir === changedDir || targetDir.startsWith(changedDir + "/")
+        );
+      });
+
+      if (directMatches.length === 0) {
+        return [];
+      }
+
+      for (const file of directMatches) {
+        matchedFiles.add(file);
+      }
+
+      return [
+        createAffectedSelection(target, {
+          direct: true,
+          matchedPaths: directMatches,
+          matchReasons: Array.from(
+            new Set(directMatches.map((file) => toDirectoryReason(toChangedDir(file)))),
+          ),
+        }),
+      ];
+    });
+
+    return buildAffectedReport(
+      "simple",
+      changedFiles,
+      selected,
+      changedFiles.filter((file) => !matchedFiles.has(file)),
+    );
   }
 }

--- a/src/cli/resolvers/types.ts
+++ b/src/cli/resolvers/types.ts
@@ -1,3 +1,36 @@
+export interface AffectedTarget {
+  spec: string;
+  taskId: string;
+  filter: string | null;
+}
+
+export interface AffectedSelection {
+  taskId: string;
+  spec: string;
+  filter: string | null;
+  direct: boolean;
+  includedBy: string[];
+  matchedPaths: string[];
+  matchReasons: string[];
+}
+
+export interface AffectedReport {
+  resolver: string;
+  changedFiles: string[];
+  matched: AffectedSelection[];
+  selected: AffectedSelection[];
+  unmatched: string[];
+  summary: {
+    matchedCount: number;
+    selectedCount: number;
+    unmatchedCount: number;
+  };
+}
+
 export interface DependencyResolver {
   resolve(changedFiles: string[], allTestFiles: string[]): string[] | Promise<string[]>;
+  explain?(
+    changedFiles: string[],
+    targets: AffectedTarget[],
+  ): AffectedReport | Promise<AffectedReport>;
 }

--- a/src/cli/resolvers/workspace.ts
+++ b/src/cli/resolvers/workspace.ts
@@ -1,6 +1,14 @@
 import { readFileSync, existsSync, readdirSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
-import type { DependencyResolver } from "./types.js";
+import {
+  buildAffectedReport,
+  createAffectedSelection,
+} from "./affected-report.js";
+import type {
+  AffectedReport,
+  AffectedTarget,
+  DependencyResolver,
+} from "./types.js";
 
 interface PackageInfo {
   name: string;
@@ -116,35 +124,103 @@ export class WorkspaceResolver implements DependencyResolver {
     }
   }
 
-  resolve(changedFiles: string[], allTestFiles: string[]): string[] {
-    // 1. Find packages containing changed files
-    const changedPackages = new Set<string>();
+  private buildDependents(): Map<string, string[]> {
+    const dependents = new Map<string, string[]>();
+    for (const [name, pkg] of this.packages) {
+      for (const dep of pkg.dependencies) {
+        const existing = dependents.get(dep);
+        if (existing) {
+          existing.push(name);
+        } else {
+          dependents.set(dep, [name]);
+        }
+      }
+    }
+    return dependents;
+  }
+
+  private matchChangedPackages(changedFiles: string[]): {
+    directMatches: Map<string, string[]>;
+    unmatched: string[];
+  } {
+    const directMatches = new Map<string, string[]>();
+    const unmatched: string[] = [];
+
     for (const file of changedFiles) {
+      const matchedPackages: string[] = [];
       for (const [name, pkg] of this.packages) {
         if (file.startsWith(pkg.dir + "/") || file.startsWith(pkg.dir + "\\")) {
-          changedPackages.add(name);
+          matchedPackages.push(name);
+        }
+      }
+
+      if (matchedPackages.length === 0) {
+        unmatched.push(file);
+        continue;
+      }
+
+      for (const packageName of matchedPackages) {
+        const existing = directMatches.get(packageName);
+        if (existing) {
+          existing.push(file);
+        } else {
+          directMatches.set(packageName, [file]);
         }
       }
     }
 
-    // 2. Expand transitively: find all packages that depend on changed packages
-    const affected = new Set(changedPackages);
-    let expanded = true;
-    while (expanded) {
-      expanded = false;
-      for (const [name, pkg] of this.packages) {
-        if (affected.has(name)) continue;
-        for (const dep of pkg.dependencies) {
-          if (affected.has(dep)) {
-            affected.add(name);
-            expanded = true;
-            break;
-          }
+    return {
+      directMatches,
+      unmatched,
+    };
+  }
+
+  private expandAffectedPackages(
+    directMatches: Map<string, string[]>,
+  ): Map<string, string[]> {
+    const dependents = this.buildDependents();
+    const affected = new Set(directMatches.keys());
+    const includedBy = new Map<string, Set<string>>();
+    const queue = [...directMatches.keys()];
+
+    for (let index = 0; index < queue.length; index++) {
+      const current = queue[index];
+      for (const dependent of dependents.get(current) ?? []) {
+        let parents = includedBy.get(dependent);
+        if (!parents) {
+          parents = new Set<string>();
+          includedBy.set(dependent, parents);
+        }
+        parents.add(current);
+
+        if (!affected.has(dependent)) {
+          affected.add(dependent);
+          queue.push(dependent);
         }
       }
     }
 
-    // 3. Collect test files from affected packages
+    return new Map(
+      [...includedBy.entries()].map(([key, value]) => [key, [...value].sort()]),
+    );
+  }
+
+  resolve(changedFiles: string[], allTestFiles: string[]): string[] {
+    const { directMatches } = this.matchChangedPackages(changedFiles);
+    const affected = new Set<string>(directMatches.keys());
+    const queue = [...directMatches.keys()];
+    const dependents = this.buildDependents();
+
+    for (let index = 0; index < queue.length; index++) {
+      const current = queue[index];
+      for (const dependent of dependents.get(current) ?? []) {
+        if (!affected.has(dependent)) {
+          affected.add(dependent);
+          queue.push(dependent);
+        }
+      }
+    }
+
     const affectedTests = new Set<string>();
     for (const name of affected) {
       const pkg = this.packages.get(name);
@@ -155,8 +231,45 @@ export class WorkspaceResolver implements DependencyResolver {
       }
     }
 
-    // 4. Filter against allTestFiles
     const testSet = new Set(allTestFiles);
     return Array.from(affectedTests).filter((t) => testSet.has(t));
+  }
+
+  explain(changedFiles: string[], targets: AffectedTarget[]): AffectedReport {
+    const { directMatches, unmatched } = this.matchChangedPackages(changedFiles);
+    const includedBy = this.expandAffectedPackages(directMatches);
+    const affectedPackages = new Set<string>([
+      ...directMatches.keys(),
+      ...includedBy.keys(),
+    ]);
+    const targetsByTaskId = new Map<string, AffectedTarget[]>();
+
+    for (const target of targets) {
+      const existing = targetsByTaskId.get(target.taskId);
+      if (existing) {
+        existing.push(target);
+      } else {
+        targetsByTaskId.set(target.taskId, [target]);
+      }
+    }
+
+    const selected = [...affectedPackages].flatMap((taskId) => {
+      const matchedTargets = targetsByTaskId.get(taskId) ?? [];
+      const pkg = this.packages.get(taskId);
+      const direct = directMatches.has(taskId);
+      const parents = includedBy.get(taskId) ?? [];
+      return matchedTargets.map((target) =>
+        createAffectedSelection(target, {
+          direct,
+          includedBy: direct ? [] : parents,
+          matchedPaths: direct ? (directMatches.get(taskId) ?? []) : [],
+          matchReasons: direct
+            ? [`package:${pkg?.dir ?? taskId}`]
+            : parents.map((parent) => `dependency:${parent}`),
+        }),
+      );
+    });
+
+    return buildAffectedReport("workspace", changedFiles, selected, unmatched);
   }
 }

--- a/tests/commands/affected.test.ts
+++ b/tests/commands/affected.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { runAffected, formatAffectedReport } from "../../src/cli/commands/affected.js";
+import { SimpleResolver } from "../../src/cli/resolvers/simple.js";
+
+describe("affected command", () => {
+  it("reports split ownership, match reasons, and unmatched paths", async () => {
+    const report = await runAffected({
+      resolverName: "simple",
+      resolver: new SimpleResolver(),
+      changedFiles: [
+        "src/website-loading/home.ts",
+        "docs/notes.md",
+      ],
+      listedTests: [
+        {
+          suite: "tests/website-loading/test.spec.ts",
+          testName: "desktop loading",
+          taskId: "website-loading",
+          filter: "@desktop",
+        },
+        {
+          suite: "tests/website-loading/test.spec.ts",
+          testName: "mobile loading",
+          taskId: "website-loading",
+          filter: "@mobile",
+        },
+        {
+          suite: "tests/paint-vrt/test.spec.ts",
+          testName: "paint",
+          taskId: "paint-vrt",
+        },
+      ],
+    });
+
+    expect(report.matched).toHaveLength(2);
+    expect(report.selected).toHaveLength(2);
+    expect(report.selected.map((entry) => entry.filter)).toEqual([
+      "@desktop",
+      "@mobile",
+    ]);
+    expect(report.selected.every((entry) => entry.direct)).toBe(true);
+    expect(report.unmatched).toEqual(["docs/notes.md"]);
+    expect(report.selected[0].matchReasons[0]).toContain(
+      "directory:src/website-loading",
+    );
+
+    const json = formatAffectedReport(report, "json");
+    const markdown = formatAffectedReport(report, "markdown");
+
+    expect(JSON.parse(json)).toMatchObject({
+      resolver: "simple",
+      summary: {
+        matchedCount: 2,
+        selectedCount: 2,
+        unmatchedCount: 1,
+      },
+    });
+    expect(markdown).toContain("# Affected Report");
+    expect(markdown).toContain("website-loading");
+    expect(markdown).toContain("@desktop");
+    expect(markdown).toContain("docs/notes.md");
+  });
+});

--- a/tests/resolvers/bitflow-native.test.ts
+++ b/tests/resolvers/bitflow-native.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { loadCore } from "../../src/cli/core/loader.js";
+import { BitflowNativeResolver } from "../../src/cli/resolvers/bitflow-native.js";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 
 describe("BitflowNativeResolver", () => {
   it("resolves affected targets via MoonBit core (no CLI)", async () => {
@@ -96,5 +100,41 @@ describe("BitflowNativeResolver", () => {
     ].join("\n");
     const result = core.resolveAffected(workflow, ["src\\auth\\login.ts"]);
     expect(result).toContain("test-auth");
+  });
+
+  it("explains direct and dependency-expanded bitflow tasks", async () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "bitflow-native-"));
+    try {
+      const configPath = join(tmpDir, "workflow.star");
+      writeFileSync(
+        configPath,
+        [
+          'workflow(name="ci")',
+          'node(id="lib", depends_on=[])',
+          'node(id="app", depends_on=["lib"])',
+          'task(id="lib", node="lib", cmd="test", needs=[], srcs=["src/lib/**"])',
+          'task(id="app", node="app", cmd="test", needs=["lib"], srcs=["src/app/**"])',
+        ].join("\n"),
+      );
+      const resolver = new BitflowNativeResolver(configPath);
+      const report = await resolver.explain?.(
+        ["src/lib/core.ts", "docs/notes.md"],
+        [
+          { spec: "tests/lib.spec.ts", taskId: "lib", filter: null },
+          { spec: "tests/app.spec.ts", taskId: "app", filter: null },
+        ],
+      );
+
+      expect(report?.matched.map((entry) => entry.taskId)).toEqual(["lib"]);
+      expect(
+        report?.selected.find((entry) => entry.taskId === "app"),
+      ).toMatchObject({
+        direct: false,
+        includedBy: ["lib"],
+      });
+      expect(report?.unmatched).toEqual(["docs/notes.md"]);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/resolvers/moon.test.ts
+++ b/tests/resolvers/moon.test.ts
@@ -119,4 +119,45 @@ describe("MoonResolver", () => {
       "src/extra/extra_test.mbt",
     ]);
   });
+
+  it("explains direct and transitive moon package selection", async () => {
+    const resolver = new MoonResolver(tmpDir);
+    const report = await resolver.explain?.(
+      ["src/types/types.mbt", "README.md"],
+      [
+        {
+          spec: "src/types/types_test.mbt",
+          taskId: "src/types",
+          filter: null,
+        },
+        {
+          spec: "src/core/core_test.mbt",
+          taskId: "src/core",
+          filter: null,
+        },
+        {
+          spec: "src/app/app_test.mbt",
+          taskId: "src/app",
+          filter: null,
+        },
+      ],
+    );
+
+    expect(report?.matched.map((entry) => entry.taskId)).toEqual([
+      "src/types",
+    ]);
+    expect(
+      report?.selected.find((entry) => entry.taskId === "src/core"),
+    ).toMatchObject({
+      direct: false,
+      includedBy: ["src/types"],
+    });
+    expect(
+      report?.selected.find((entry) => entry.taskId === "src/app"),
+    ).toMatchObject({
+      direct: false,
+      includedBy: ["src/core"],
+    });
+    expect(report?.unmatched).toEqual(["README.md"]);
+  });
 });

--- a/tests/resolvers/simple.test.ts
+++ b/tests/resolvers/simple.test.ts
@@ -45,4 +45,30 @@ describe("SimpleResolver", () => {
     expect(result).toContain("tests/auth/oauth/github.spec.ts");
     expect(result).not.toContain("tests/core/utils.spec.ts");
   });
+
+  it("explains direct matches and unmatched paths", async () => {
+    const resolver = new SimpleResolver();
+    const report = await resolver.explain?.(
+      ["src/auth/login.ts", "docs/notes.md"],
+      [
+        {
+          spec: "tests/auth/login.spec.ts",
+          taskId: "auth-login",
+          filter: null,
+        },
+        {
+          spec: "tests/auth/register.spec.ts",
+          taskId: "auth-register",
+          filter: null,
+        },
+      ],
+    );
+
+    expect(report?.matched.map((entry) => entry.taskId)).toEqual([
+      "auth-login",
+      "auth-register",
+    ]);
+    expect(report?.selected.every((entry) => entry.direct)).toBe(true);
+    expect(report?.unmatched).toEqual(["docs/notes.md"]);
+  });
 });

--- a/tests/resolvers/workspace.test.ts
+++ b/tests/resolvers/workspace.test.ts
@@ -140,4 +140,45 @@ describe("WorkspaceResolver", () => {
     const result = resolver.resolve(["packages/core/src/index.ts"], allTests);
     expect(result.sort()).toEqual(allTests.sort());
   });
+
+  it("explains direct and transitive package selection", async () => {
+    const resolver = new WorkspaceResolver(tmpDir);
+    const report = await resolver.explain?.(
+      ["packages/core/src/index.ts", "README.md"],
+      [
+        {
+          spec: "packages/core/tests/core.test.ts",
+          taskId: "@app/core",
+          filter: null,
+        },
+        {
+          spec: "packages/utils/tests/utils.test.ts",
+          taskId: "@app/utils",
+          filter: null,
+        },
+        {
+          spec: "packages/app/tests/app.test.ts",
+          taskId: "@app/app",
+          filter: null,
+        },
+      ],
+    );
+
+    expect(
+      report?.matched.map((entry) => entry.taskId),
+    ).toEqual(["@app/core"]);
+    expect(
+      report?.selected.find((entry) => entry.taskId === "@app/utils"),
+    ).toMatchObject({
+      direct: false,
+      includedBy: ["@app/core"],
+    });
+    expect(
+      report?.selected.find((entry) => entry.taskId === "@app/app"),
+    ).toMatchObject({
+      direct: false,
+      includedBy: ["@app/utils"],
+    });
+    expect(report?.unmatched).toEqual(["README.md"]);
+  });
 });


### PR DESCRIPTION
### Motivation

- Add a pure inspect mode for affected test selection so changed paths can be explained without running tests.
- Surface direct matches, dependency-expanded selections, and unmatched paths in a form that is usable in CI summaries and local debugging.

### Description

- Added `flaker affected [paths...]` with JSON and Markdown output, including `matched`, `selected`, `unmatched`, `includedBy`, and `matchReasons`.
- Extended `simple`, `workspace`, `moon`, and `bitflow` resolvers with `explain(...)` support and introduced shared affected-report helpers.
- Added a Bitflow workflow parser helper for match reasons and accepted `git` as an alias of the simple resolver.
- Added command and resolver tests covering direct matches, transitive inclusion, split ownership via filters, and unmatched paths.

### Testing

- `pnpm vitest run`
- `pnpm -s tsc --noEmit`

Closes #3