### PR TITLE
Add config ownership check command

### DIFF
--- a/src/cli/commands/check.ts
+++ b/src/cli/commands/check.ts
@@ -1,0 +1,389 @@
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+} from "node:fs";
+import { isAbsolute, join, relative } from "node:path";
+import type { TestId } from "../runners/types.js";
+import { parseBitflowWorkflowTasks } from "../resolvers/bitflow-workflow.js";
+
+export interface TaskDefinition {
+  taskId: string;
+  node: string | null;
+  needs: string[];
+  srcs: string[];
+}
+
+export interface OwnershipClaim {
+  taskId: string;
+  filter: string | null;
+  testCount: number;
+}
+
+export interface OwnershipEntry {
+  spec: string;
+  kind: "owned" | "split" | "duplicate";
+  owners: OwnershipClaim[];
+}
+
+export interface ConfigCheckIssue {
+  code: "duplicate-ownership" | "unmanaged-spec";
+  spec: string;
+  detail: string;
+}
+
+export interface TaskSummary {
+  taskId: string;
+  node: string | null;
+  specCount: number;
+  testCount: number;
+  filterCount: number;
+  needsCount: number;
+  srcCount: number;
+}
+
+export interface ConfigCheckReport {
+  summary: {
+    taskCount: number;
+    specCount: number;
+    duplicateOwnershipCount: number;
+    splitOwnershipCount: number;
+    unmanagedSpecCount: number;
+    errorCount: number;
+    warningCount: number;
+  };
+  ownership: OwnershipEntry[];
+  tasks: TaskSummary[];
+  errors: ConfigCheckIssue[];
+  warnings: ConfigCheckIssue[];
+}
+
+export interface RunConfigCheckOpts {
+  listedTests: TestId[];
+  discoveredSpecs: string[];
+  taskDefinitions?: TaskDefinition[];
+}
+
+function normalizePath(path: string): string {
+  return path.replaceAll("\\", "/");
+}
+
+function compareNullable(a: string | null, b: string | null): number {
+  return (a ?? "").localeCompare(b ?? "");
+}
+
+function sortClaims(claims: OwnershipClaim[]): OwnershipClaim[] {
+  return [...claims].sort((a, b) => {
+    const byTaskId = a.taskId.localeCompare(b.taskId);
+    if (byTaskId !== 0) return byTaskId;
+    return compareNullable(a.filter, b.filter);
+  });
+}
+
+function claimKey(claim: { taskId: string; filter: string | null }): string {
+  return `${claim.taskId}\0${claim.filter ?? ""}`;
+}
+
+function classifyOwnership(claims: OwnershipClaim[]): OwnershipEntry["kind"] {
+  if (claims.length <= 1) return "owned";
+
+  const filters = new Set<string>();
+  for (const claim of claims) {
+    if (claim.filter == null) {
+      return "duplicate";
+    }
+
+    if (filters.has(claim.filter)) {
+      return "duplicate";
+    }
+    filters.add(claim.filter);
+  }
+
+  return "split";
+}
+
+export function runConfigCheck(opts: RunConfigCheckOpts): ConfigCheckReport {
+  const ownershipIndex = new Map<string, Map<string, OwnershipClaim>>();
+  const taskSpecs = new Map<string, Set<string>>();
+  const taskFilters = new Map<string, Set<string>>();
+  const taskTestCounts = new Map<string, number>();
+  const taskDefinitions = new Map(
+    (opts.taskDefinitions ?? []).map((task) => [task.taskId, task]),
+  );
+
+  for (const test of opts.listedTests) {
+    const spec = normalizePath(test.suite);
+    const taskId = test.taskId ?? spec;
+    const filter = test.filter ?? null;
+
+    let claimsByKey = ownershipIndex.get(spec);
+    if (!claimsByKey) {
+      claimsByKey = new Map<string, OwnershipClaim>();
+      ownershipIndex.set(spec, claimsByKey);
+    }
+
+    const key = claimKey({ taskId, filter });
+    const existingClaim = claimsByKey.get(key);
+    if (existingClaim) {
+      existingClaim.testCount += 1;
+    } else {
+      claimsByKey.set(key, {
+        taskId,
+        filter,
+        testCount: 1,
+      });
+    }
+
+    let specs = taskSpecs.get(taskId);
+    if (!specs) {
+      specs = new Set<string>();
+      taskSpecs.set(taskId, specs);
+    }
+    specs.add(spec);
+
+    let filters = taskFilters.get(taskId);
+    if (!filters) {
+      filters = new Set<string>();
+      taskFilters.set(taskId, filters);
+    }
+    if (filter != null) {
+      filters.add(filter);
+    }
+
+    taskTestCounts.set(taskId, (taskTestCounts.get(taskId) ?? 0) + 1);
+  }
+
+  const ownership = [...ownershipIndex.entries()]
+    .map(([spec, claimsByKey]) => {
+      const owners = sortClaims([...claimsByKey.values()]);
+      return {
+        spec,
+        kind: classifyOwnership(owners),
+        owners,
+      } satisfies OwnershipEntry;
+    })
+    .sort((a, b) => a.spec.localeCompare(b.spec));
+
+  const errors = ownership
+    .filter((entry) => entry.kind === "duplicate")
+    .map((entry) => ({
+      code: "duplicate-ownership",
+      spec: entry.spec,
+      detail: entry.owners
+        .map((owner) => `${owner.taskId}${owner.filter ? ` (${owner.filter})` : ""}`)
+        .join(", "),
+    }) satisfies ConfigCheckIssue);
+
+  const managedSpecs = new Set(ownership.map((entry) => entry.spec));
+  const warnings = [...new Set(opts.discoveredSpecs.map(normalizePath))]
+    .filter((spec) => !managedSpecs.has(spec))
+    .sort((a, b) => a.localeCompare(b))
+    .map((spec) => ({
+      code: "unmanaged-spec",
+      spec,
+      detail: "Spec exists on disk but is not claimed by any task",
+    }) satisfies ConfigCheckIssue);
+
+  const taskIds = new Set<string>([
+    ...taskTestCounts.keys(),
+    ...taskDefinitions.keys(),
+  ]);
+  const tasks = [...taskIds]
+    .map((taskId) => {
+      const definition = taskDefinitions.get(taskId);
+      return {
+        taskId,
+        node: definition?.node ?? null,
+        specCount: taskSpecs.get(taskId)?.size ?? 0,
+        testCount: taskTestCounts.get(taskId) ?? 0,
+        filterCount: taskFilters.get(taskId)?.size ?? 0,
+        needsCount: definition?.needs.length ?? 0,
+        srcCount: definition?.srcs.length ?? 0,
+      } satisfies TaskSummary;
+    })
+    .sort((a, b) => a.taskId.localeCompare(b.taskId));
+
+  return {
+    summary: {
+      taskCount: tasks.length,
+      specCount: ownership.length,
+      duplicateOwnershipCount: errors.length,
+      splitOwnershipCount: ownership.filter((entry) => entry.kind === "split")
+        .length,
+      unmanagedSpecCount: warnings.length,
+      errorCount: errors.length,
+      warningCount: warnings.length,
+    },
+    ownership,
+    tasks,
+    errors,
+    warnings,
+  };
+}
+
+function formatSummaryList(report: ConfigCheckReport): string[] {
+  return [
+    `- Tasks: ${report.summary.taskCount}`,
+    `- Managed specs: ${report.summary.specCount}`,
+    `- Duplicate ownership: ${report.summary.duplicateOwnershipCount}`,
+    `- Split ownership: ${report.summary.splitOwnershipCount}`,
+    `- Unmanaged specs: ${report.summary.unmanagedSpecCount}`,
+    `- Errors: ${report.summary.errorCount}`,
+    `- Warnings: ${report.summary.warningCount}`,
+  ];
+}
+
+function formatIssues(
+  title: string,
+  issues: ConfigCheckIssue[],
+): string[] {
+  const lines = [`## ${title}`, ""];
+  if (issues.length === 0) {
+    lines.push("_None_", "");
+    return lines;
+  }
+
+  for (const issue of issues) {
+    lines.push(`- ${issue.spec}: ${issue.detail}`);
+  }
+  lines.push("");
+  return lines;
+}
+
+function formatOwnershipTable(entries: OwnershipEntry[]): string[] {
+  const lines = ["## Ownership", ""];
+  if (entries.length === 0) {
+    lines.push("_None_", "");
+    return lines;
+  }
+
+  lines.push(
+    "| spec | kind | owners |",
+    "| --- | --- | --- |",
+  );
+  for (const entry of entries) {
+    const owners = entry.owners
+      .map((owner) => `${owner.taskId}${owner.filter ? ` (${owner.filter})` : ""}`)
+      .join(", ");
+    lines.push(`| ${entry.spec} | ${entry.kind} | ${owners} |`);
+  }
+  lines.push("");
+  return lines;
+}
+
+function formatTaskTable(tasks: TaskSummary[]): string[] {
+  const lines = ["## Tasks", ""];
+  if (tasks.length === 0) {
+    lines.push("_None_", "");
+    return lines;
+  }
+
+  lines.push(
+    "| taskId | node | specs | tests | filters | needs | srcs |",
+    "| --- | --- | --- | --- | --- | --- | --- |",
+  );
+  for (const task of tasks) {
+    lines.push(
+      `| ${task.taskId} | ${task.node ?? "-"} | ${task.specCount} | ${task.testCount} | ${task.filterCount} | ${task.needsCount} | ${task.srcCount} |`,
+    );
+  }
+  lines.push("");
+  return lines;
+}
+
+export function formatConfigCheckReport(
+  report: ConfigCheckReport,
+  format: "json" | "markdown",
+): string {
+  if (format === "json") {
+    return JSON.stringify(report, null, 2);
+  }
+
+  return [
+    "# Config Check Report",
+    "",
+    ...formatSummaryList(report),
+    "",
+    ...formatIssues("Errors", report.errors),
+    ...formatIssues("Warnings", report.warnings),
+    ...formatOwnershipTable(report.ownership),
+    ...formatTaskTable(report.tasks),
+  ].join("\n");
+}
+
+export function discoverTestSpecsForCheck(
+  cwd: string,
+  runnerType: string,
+): string[] {
+  const results: string[] = [];
+  walkSpecs(cwd, cwd, runnerType, results);
+  return [...new Set(results)].sort((a, b) => a.localeCompare(b));
+}
+
+function walkSpecs(
+  rootDir: string,
+  currentDir: string,
+  runnerType: string,
+  out: string[],
+): void {
+  for (const entry of readdirSync(currentDir)) {
+    if (
+      entry === "node_modules" ||
+      entry === ".git" ||
+      entry === ".flaker" ||
+      entry === "_build" ||
+      entry === "target" ||
+      entry === ".mooncakes"
+    ) {
+      continue;
+    }
+
+    const fullPath = join(currentDir, entry);
+    const stat = statSync(fullPath);
+    if (stat.isDirectory()) {
+      walkSpecs(rootDir, fullPath, runnerType, out);
+      continue;
+    }
+
+    if (!isRecognizedSpec(entry, runnerType)) {
+      continue;
+    }
+
+    out.push(normalizePath(relative(rootDir, fullPath)));
+  }
+}
+
+function isRecognizedSpec(fileName: string, runnerType: string): boolean {
+  if (runnerType === "moontest") {
+    return fileName.endsWith("_test.mbt");
+  }
+
+  return /\.(spec|test)\.(ts|tsx|js|jsx|mts|mjs|cts|cjs)$/.test(fileName);
+}
+
+export function loadTaskDefinitionsForCheck(opts: {
+  cwd: string;
+  resolverName: string;
+  resolverConfig?: string;
+}): TaskDefinition[] {
+  if (opts.resolverName !== "bitflow" || !opts.resolverConfig) {
+    return [];
+  }
+
+  const configPath = isAbsolute(opts.resolverConfig)
+    ? opts.resolverConfig
+    : join(opts.cwd, opts.resolverConfig);
+  if (!existsSync(configPath)) {
+    return [];
+  }
+
+  return parseBitflowWorkflowTasks(readFileSync(configPath, "utf-8")).map(
+    (task) => ({
+      taskId: task.id,
+      node: task.node,
+      needs: [...task.needs],
+      srcs: [...task.srcs],
+    }),
+  );
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -28,6 +28,12 @@ import {
   runAffected,
   formatAffectedReport,
 } from "./commands/affected.js";
+import {
+  discoverTestSpecsForCheck,
+  formatConfigCheckReport,
+  loadTaskDefinitionsForCheck,
+  runConfigCheck,
+} from "./commands/check.js";
 import { DuckDBStore } from "./storage/duckdb.js";
 import { createRunner } from "./runners/index.js";
 import { resolveTestIdentity } from "./identity.js";
@@ -440,6 +446,39 @@ program
       );
     },
   );
+
+// --- query ---
+program
+  .command("check")
+  .description("Validate test spec ownership and config drift")
+  .option("--json", "Output JSON report")
+  .option("--markdown", "Output Markdown report")
+  .action(async (opts: { json?: boolean; markdown?: boolean }) => {
+    if (opts.json && opts.markdown) {
+      console.error("Error: choose either --json or --markdown");
+      process.exit(1);
+    }
+
+    const cwd = process.cwd();
+    const config = loadConfig(cwd);
+    const listedTests = await listRunnerTests(cwd, config.runner);
+    const discoveredSpecs = discoverTestSpecsForCheck(cwd, config.runner.type);
+    const taskDefinitions = loadTaskDefinitionsForCheck({
+      cwd,
+      resolverName: config.affected.resolver,
+      resolverConfig: config.affected.config,
+    });
+
+    const report = runConfigCheck({
+      listedTests,
+      discoveredSpecs,
+      taskDefinitions,
+    });
+    console.log(
+      formatConfigCheckReport(report, opts.json ? "json" : "markdown"),
+    );
+    process.exit(report.errors.length > 0 ? 1 : 0);
+  });
 
 // --- query ---
 program

--- a/src/cli/resolvers/bitflow-workflow.ts
+++ b/src/cli/resolvers/bitflow-workflow.ts
@@ -1,5 +1,6 @@
 export interface BitflowTaskDefinition {
   id: string;
+  node: string | null;
   needs: string[];
   srcs: string[];
 }
@@ -16,6 +17,7 @@ export function parseBitflowWorkflowTasks(
 
     tasks.push({
       id,
+      node: getQuotedValue(block, "node"),
       needs: getQuotedArrayValue(block, "needs"),
       srcs: getQuotedArrayValue(block, "srcs"),
     });

--- a/tests/commands/check.test.ts
+++ b/tests/commands/check.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  formatConfigCheckReport,
+  loadTaskDefinitionsForCheck,
+  runConfigCheck,
+} from "../../src/cli/commands/check.js";
+
+describe("check command", () => {
+  it("detects duplicate ownership, allows filtered split ownership, and reports unmanaged specs", () => {
+    const report = runConfigCheck({
+      listedTests: [
+        {
+          suite: "tests/auth/login.spec.ts",
+          testName: "renders login form",
+          taskId: "auth-login",
+        },
+        {
+          suite: "tests/auth/login.spec.ts",
+          testName: "submits login form",
+          taskId: "auth-login",
+        },
+        {
+          suite: "tests/website-loading.spec.ts",
+          testName: "desktop loading",
+          taskId: "website-loading",
+          filter: "@desktop",
+        },
+        {
+          suite: "tests/website-loading.spec.ts",
+          testName: "mobile loading",
+          taskId: "website-loading",
+          filter: "@mobile",
+        },
+        {
+          suite: "tests/duplicate.spec.ts",
+          testName: "owner a",
+          taskId: "dup-a",
+        },
+        {
+          suite: "tests/duplicate.spec.ts",
+          testName: "owner b",
+          taskId: "dup-b",
+        },
+      ],
+      discoveredSpecs: [
+        "tests/auth/login.spec.ts",
+        "tests/website-loading.spec.ts",
+        "tests/duplicate.spec.ts",
+        "tests/unmanaged.spec.ts",
+      ],
+      taskDefinitions: [
+        {
+          taskId: "auth-login",
+          node: "auth",
+          needs: [],
+          srcs: ["src/auth/**"],
+        },
+        {
+          taskId: "website-loading",
+          node: "web",
+          needs: ["auth-login"],
+          srcs: ["src/website/**", "src/shared/**"],
+        },
+      ],
+    });
+
+    expect(report.errors).toEqual([
+      expect.objectContaining({
+        code: "duplicate-ownership",
+        spec: "tests/duplicate.spec.ts",
+      }),
+    ]);
+    expect(report.warnings).toEqual([
+      expect.objectContaining({
+        code: "unmanaged-spec",
+        spec: "tests/unmanaged.spec.ts",
+      }),
+    ]);
+    expect(
+      report.ownership.find(
+        (entry) => entry.spec === "tests/website-loading.spec.ts",
+      ),
+    ).toMatchObject({
+      kind: "split",
+      owners: [
+        { taskId: "website-loading", filter: "@desktop" },
+        { taskId: "website-loading", filter: "@mobile" },
+      ],
+    });
+    expect(
+      report.tasks.find((task) => task.taskId === "website-loading"),
+    ).toMatchObject({
+      taskId: "website-loading",
+      specCount: 1,
+      testCount: 2,
+      filterCount: 2,
+      node: "web",
+      needsCount: 1,
+      srcCount: 2,
+    });
+    expect(report.summary).toMatchObject({
+      taskCount: 4,
+      specCount: 3,
+      duplicateOwnershipCount: 1,
+      splitOwnershipCount: 1,
+      unmanagedSpecCount: 1,
+      errorCount: 1,
+      warningCount: 1,
+    });
+
+    const json = formatConfigCheckReport(report, "json");
+    const markdown = formatConfigCheckReport(report, "markdown");
+
+    expect(JSON.parse(json)).toMatchObject({
+      summary: {
+        duplicateOwnershipCount: 1,
+        unmanagedSpecCount: 1,
+      },
+    });
+    expect(markdown).toContain("# Config Check Report");
+    expect(markdown).toContain("tests/unmanaged.spec.ts");
+    expect(markdown).toContain("tests/duplicate.spec.ts");
+    expect(markdown).toContain("website-loading");
+    expect(markdown).toContain("@desktop");
+  });
+
+  it("loads bitflow task definitions from affected config", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "config-check-"));
+    try {
+      const workflowPath = join(cwd, "flaker.star");
+      writeFileSync(
+        workflowPath,
+        [
+          'workflow(name="ci")',
+          'node(id="web", depends_on=["core"])',
+          'task(id="website-loading", node="web", cmd="test", needs=["auth-login"], srcs=["src/website/**", "src/shared/**"])',
+          'task(id="auth-login", node="core", cmd="test", needs=[], srcs=["src/auth/**"])',
+        ].join("\n"),
+      );
+
+      expect(
+        loadTaskDefinitionsForCheck({
+          cwd,
+          resolverName: "bitflow",
+          resolverConfig: "flaker.star",
+        }),
+      ).toEqual([
+        {
+          taskId: "website-loading",
+          node: "web",
+          needs: ["auth-login"],
+          srcs: ["src/website/**", "src/shared/**"],
+        },
+        {
+          taskId: "auth-login",
+          node: "core",
+          needs: [],
+          srcs: ["src/auth/**"],
+        },
+      ]);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
### Motivation

- Add a validation entrypoint for test spec ownership and config drift so repositories can review task coverage without running tests.
- Surface unmanaged specs, duplicate ownership, and filtered split ownership in a CI-friendly report.

### Description

- Added `flaker check` with JSON and Markdown output for ownership validation and task summary reporting.
- Implemented unmanaged spec detection, duplicate ownership errors, and split ownership allowance when the same spec is partitioned by distinct filters.
- Added on-disk spec discovery based on runner type and optional Bitflow task-definition loading to enrich task summaries with `node`, `needs`, and `srcs` counts.
- Extended Bitflow workflow parsing to preserve `node` metadata and added command tests for the new report contract.

### Testing

- `pnpm vitest run`
- `pnpm -s tsc --noEmit`

Closes #4