### PR TITLE
Add report summary and diff commands

### DIFF
--- a/src/cli/commands/report.ts
+++ b/src/cli/commands/report.ts
@@ -1,0 +1,438 @@
+import type { TestCaseResult } from "../adapters/types.js";
+import { junitAdapter } from "../adapters/junit.js";
+import { playwrightAdapter } from "../adapters/playwright.js";
+import { normalizeVariant, resolveTestIdentity } from "../identity.js";
+
+export interface ReportTotals {
+  total: number;
+  passed: number;
+  failed: number;
+  flaky: number;
+  skipped: number;
+  retries: number;
+  durationMs: number;
+}
+
+export interface ReportTestSummary {
+  testId: string;
+  suite: string;
+  testName: string;
+  taskId: string;
+  filter: string | null;
+  variant: Record<string, string> | null;
+  status: TestCaseResult["status"];
+  durationMs: number;
+  retryCount: number;
+  errorMessage?: string;
+}
+
+export interface ReportFileSummary {
+  suite: string;
+  totals: ReportTotals;
+}
+
+export interface NormalizedReportSummary {
+  adapter: string;
+  totals: ReportTotals;
+  files: ReportFileSummary[];
+  unstable: ReportTestSummary[];
+  tests: ReportTestSummary[];
+}
+
+export interface ReportDiffEntry {
+  testId: string;
+  suite: string;
+  testName: string;
+  taskId: string;
+  filter: string | null;
+  variant: Record<string, string> | null;
+  baseStatus: TestCaseResult["status"] | null;
+  headStatus: TestCaseResult["status"] | null;
+}
+
+export interface ReportDiff {
+  baseAdapter: string;
+  headAdapter: string;
+  summary: {
+    newFailureCount: number;
+    newFlakyCount: number;
+    resolvedFailureCount: number;
+    resolvedFlakyCount: number;
+    persistentFlakyCount: number;
+  };
+  regressions: {
+    newFailures: ReportDiffEntry[];
+    newFlaky: ReportDiffEntry[];
+  };
+  improvements: {
+    resolvedFailures: ReportDiffEntry[];
+    resolvedFlaky: ReportDiffEntry[];
+  };
+  persistent: {
+    persistentFlaky: ReportDiffEntry[];
+  };
+}
+
+function emptyTotals(): ReportTotals {
+  return {
+    total: 0,
+    passed: 0,
+    failed: 0,
+    flaky: 0,
+    skipped: 0,
+    retries: 0,
+    durationMs: 0,
+  };
+}
+
+function compareNullable(a: string | null, b: string | null): number {
+  return (a ?? "").localeCompare(b ?? "");
+}
+
+function variantLabel(variant: Record<string, string> | null): string {
+  return JSON.stringify(variant ?? {});
+}
+
+function sortTests<T extends { suite: string; testName: string; taskId: string; filter: string | null; variant: Record<string, string> | null }>(
+  entries: T[],
+): T[] {
+  return [...entries].sort((a, b) => {
+    const bySuite = a.suite.localeCompare(b.suite);
+    if (bySuite !== 0) return bySuite;
+    const byName = a.testName.localeCompare(b.testName);
+    if (byName !== 0) return byName;
+    const byTask = a.taskId.localeCompare(b.taskId);
+    if (byTask !== 0) return byTask;
+    const byFilter = compareNullable(a.filter, b.filter);
+    if (byFilter !== 0) return byFilter;
+    return variantLabel(a.variant).localeCompare(variantLabel(b.variant));
+  });
+}
+
+function addToTotals(
+  totals: ReportTotals,
+  entry: Pick<ReportTestSummary, "status" | "retryCount" | "durationMs">,
+): void {
+  totals.total += 1;
+  totals[entry.status] += 1;
+  totals.retries += entry.retryCount;
+  totals.durationMs += entry.durationMs;
+}
+
+function summarizeTest(result: TestCaseResult): ReportTestSummary {
+  const resolved = resolveTestIdentity({
+    suite: result.suite,
+    testName: result.testName,
+    taskId: result.taskId,
+    filter: result.filter,
+    variant: result.variant,
+  });
+
+  return {
+    testId: resolved.testId,
+    suite: resolved.suite,
+    testName: resolved.testName,
+    taskId: resolved.taskId,
+    filter: resolved.filter,
+    variant: normalizeVariant(resolved.variant),
+    status: result.status,
+    durationMs: result.durationMs,
+    retryCount: result.retryCount,
+    ...(result.errorMessage ? { errorMessage: result.errorMessage } : {}),
+  };
+}
+
+export function summarizeResults(
+  results: TestCaseResult[],
+  adapter: string,
+): NormalizedReportSummary {
+  const tests = sortTests(results.map(summarizeTest));
+  const totals = emptyTotals();
+  const fileTotals = new Map<string, ReportTotals>();
+
+  for (const test of tests) {
+    addToTotals(totals, test);
+    const existing = fileTotals.get(test.suite);
+    if (existing) {
+      addToTotals(existing, test);
+    } else {
+      const next = emptyTotals();
+      addToTotals(next, test);
+      fileTotals.set(test.suite, next);
+    }
+  }
+
+  return {
+    adapter,
+    totals,
+    files: [...fileTotals.entries()]
+      .map(([suite, totals]) => ({ suite, totals }))
+      .sort((a, b) => a.suite.localeCompare(b.suite)),
+    unstable: tests.filter((test) => test.status === "failed" || test.status === "flaky"),
+    tests,
+  };
+}
+
+function parseAdapterReport(
+  adapter: string,
+  input: string,
+): TestCaseResult[] {
+  switch (adapter) {
+    case "playwright":
+      return playwrightAdapter.parse(input);
+    case "junit":
+      return junitAdapter.parse(input);
+    default:
+      throw new Error(`Unsupported adapter: ${adapter}`);
+  }
+}
+
+export function runReportSummarize(opts: {
+  adapter: string;
+  input: string;
+}): NormalizedReportSummary {
+  return summarizeResults(parseAdapterReport(opts.adapter, opts.input), opts.adapter);
+}
+
+export function parseReportSummary(input: string): NormalizedReportSummary {
+  return JSON.parse(input) as NormalizedReportSummary;
+}
+
+function toDiffEntry(
+  base: ReportTestSummary | null,
+  head: ReportTestSummary | null,
+): ReportDiffEntry {
+  const source = head ?? base;
+  if (!source) {
+    throw new Error("Diff entry requires either base or head");
+  }
+
+  return {
+    testId: source.testId,
+    suite: source.suite,
+    testName: source.testName,
+    taskId: source.taskId,
+    filter: source.filter,
+    variant: source.variant,
+    baseStatus: base?.status ?? null,
+    headStatus: head?.status ?? null,
+  };
+}
+
+export function runReportDiff(opts: {
+  base: NormalizedReportSummary;
+  head: NormalizedReportSummary;
+}): ReportDiff {
+  const baseById = new Map(opts.base.tests.map((test) => [test.testId, test]));
+  const headById = new Map(opts.head.tests.map((test) => [test.testId, test]));
+  const allIds = new Set<string>([
+    ...baseById.keys(),
+    ...headById.keys(),
+  ]);
+
+  const newFailures: ReportDiffEntry[] = [];
+  const newFlaky: ReportDiffEntry[] = [];
+  const resolvedFailures: ReportDiffEntry[] = [];
+  const resolvedFlaky: ReportDiffEntry[] = [];
+  const persistentFlaky: ReportDiffEntry[] = [];
+
+  for (const testId of allIds) {
+    const base = baseById.get(testId) ?? null;
+    const head = headById.get(testId) ?? null;
+    const baseStatus = base?.status ?? null;
+    const headStatus = head?.status ?? null;
+
+    if (headStatus === "failed" && baseStatus !== "failed") {
+      newFailures.push(toDiffEntry(base, head));
+    }
+
+    if (headStatus === "flaky") {
+      if (baseStatus === "flaky") {
+        persistentFlaky.push(toDiffEntry(base, head));
+      } else if (baseStatus !== "failed") {
+        newFlaky.push(toDiffEntry(base, head));
+      }
+    }
+
+    if (baseStatus === "failed" && headStatus !== "failed" && headStatus !== null) {
+      resolvedFailures.push(toDiffEntry(base, head));
+    }
+
+    if (baseStatus === "flaky" && headStatus !== "flaky" && headStatus !== null) {
+      resolvedFlaky.push(toDiffEntry(base, head));
+    }
+  }
+
+  return {
+    baseAdapter: opts.base.adapter,
+    headAdapter: opts.head.adapter,
+    summary: {
+      newFailureCount: newFailures.length,
+      newFlakyCount: newFlaky.length,
+      resolvedFailureCount: resolvedFailures.length,
+      resolvedFlakyCount: resolvedFlaky.length,
+      persistentFlakyCount: persistentFlaky.length,
+    },
+    regressions: {
+      newFailures: sortTests(newFailures),
+      newFlaky: sortTests(newFlaky),
+    },
+    improvements: {
+      resolvedFailures: sortTests(resolvedFailures),
+      resolvedFlaky: sortTests(resolvedFlaky),
+    },
+    persistent: {
+      persistentFlaky: sortTests(persistentFlaky),
+    },
+  };
+}
+
+function formatTotals(totals: ReportTotals): string[] {
+  return [
+    `- Total: ${totals.total}`,
+    `- Passed: ${totals.passed}`,
+    `- Failed: ${totals.failed}`,
+    `- Flaky: ${totals.flaky}`,
+    `- Skipped: ${totals.skipped}`,
+    `- Retries: ${totals.retries}`,
+    `- DurationMs: ${totals.durationMs}`,
+  ];
+}
+
+function formatTestRows(
+  entries: Array<Pick<ReportDiffEntry, "suite" | "testName" | "taskId" | "filter" | "baseStatus" | "headStatus">>,
+): string[] {
+  return entries.map(
+    (entry) =>
+      `| ${entry.suite} | ${entry.testName} | ${entry.taskId} | ${entry.filter ?? "-"} | ${entry.baseStatus ?? "-"} | ${entry.headStatus ?? "-"} |`,
+  );
+}
+
+function formatSummaryTestRows(
+  entries: ReportTestSummary[],
+): string[] {
+  return entries.map(
+    (entry) =>
+      `| ${entry.suite} | ${entry.testName} | ${entry.taskId} | ${entry.filter ?? "-"} | ${entry.status} | ${entry.retryCount} |`,
+  );
+}
+
+function formatReportSection(title: string, rows: string[]): string[] {
+  const lines = [`## ${title}`, ""];
+  if (rows.length === 0) {
+    lines.push("_None_", "");
+    return lines;
+  }
+  lines.push(...rows, "");
+  return lines;
+}
+
+export function formatReportSummary(
+  summary: NormalizedReportSummary,
+  format: "json" | "markdown",
+): string {
+  if (format === "json") {
+    return JSON.stringify(summary, null, 2);
+  }
+
+  const fileRows = summary.files.map(
+    (file) =>
+      `| ${file.suite} | ${file.totals.total} | ${file.totals.passed} | ${file.totals.failed} | ${file.totals.flaky} | ${file.totals.skipped} | ${file.totals.retries} |`,
+  );
+
+  return [
+    "# Test Report Summary",
+    "",
+    `- Adapter: ${summary.adapter}`,
+    ...formatTotals(summary.totals),
+    "",
+    "## Files",
+    "",
+    "| suite | total | passed | failed | flaky | skipped | retries |",
+    "| --- | --- | --- | --- | --- | --- | --- |",
+    ...fileRows,
+    "",
+    ...formatReportSection(
+      "Unstable Tests",
+      summary.unstable.length > 0
+        ? [
+            "| suite | testName | taskId | filter | status | retries |",
+            "| --- | --- | --- | --- | --- | --- |",
+            ...formatSummaryTestRows(summary.unstable),
+          ]
+        : [],
+    ),
+  ].join("\n");
+}
+
+export function formatReportDiff(
+  diff: ReportDiff,
+  format: "json" | "markdown",
+): string {
+  if (format === "json") {
+    return JSON.stringify(diff, null, 2);
+  }
+
+  return [
+    "# Test Report Diff",
+    "",
+    `- Base adapter: ${diff.baseAdapter}`,
+    `- Head adapter: ${diff.headAdapter}`,
+    `- New failures: ${diff.summary.newFailureCount}`,
+    `- New flaky: ${diff.summary.newFlakyCount}`,
+    `- Resolved failures: ${diff.summary.resolvedFailureCount}`,
+    `- Resolved flaky: ${diff.summary.resolvedFlakyCount}`,
+    `- Persistent flaky: ${diff.summary.persistentFlakyCount}`,
+    "",
+    ...formatReportSection(
+      "New Failures",
+      diff.regressions.newFailures.length > 0
+        ? [
+            "| suite | testName | taskId | filter | baseStatus | headStatus |",
+            "| --- | --- | --- | --- | --- | --- |",
+            ...formatTestRows(diff.regressions.newFailures),
+          ]
+        : [],
+    ),
+    ...formatReportSection(
+      "New Flaky",
+      diff.regressions.newFlaky.length > 0
+        ? [
+            "| suite | testName | taskId | filter | baseStatus | headStatus |",
+            "| --- | --- | --- | --- | --- | --- |",
+            ...formatTestRows(diff.regressions.newFlaky),
+          ]
+        : [],
+    ),
+    ...formatReportSection(
+      "Resolved Failures",
+      diff.improvements.resolvedFailures.length > 0
+        ? [
+            "| suite | testName | taskId | filter | baseStatus | headStatus |",
+            "| --- | --- | --- | --- | --- | --- |",
+            ...formatTestRows(diff.improvements.resolvedFailures),
+          ]
+        : [],
+    ),
+    ...formatReportSection(
+      "Resolved Flaky",
+      diff.improvements.resolvedFlaky.length > 0
+        ? [
+            "| suite | testName | taskId | filter | baseStatus | headStatus |",
+            "| --- | --- | --- | --- | --- | --- |",
+            ...formatTestRows(diff.improvements.resolvedFlaky),
+          ]
+        : [],
+    ),
+    ...formatReportSection(
+      "Persistent Flaky",
+      diff.persistent.persistentFlaky.length > 0
+        ? [
+            "| suite | testName | taskId | filter | baseStatus | headStatus |",
+            "| --- | --- | --- | --- | --- | --- |",
+            ...formatTestRows(diff.persistent.persistentFlaky),
+          ]
+        : [],
+    ),
+  ].join("\n");
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { Command } from "commander";
 import { Octokit } from "@octokit/rest";
@@ -34,6 +35,13 @@ import {
   loadTaskDefinitionsForCheck,
   runConfigCheck,
 } from "./commands/check.js";
+import {
+  formatReportDiff,
+  formatReportSummary,
+  parseReportSummary,
+  runReportDiff,
+  runReportSummarize,
+} from "./commands/report.js";
 import { DuckDBStore } from "./storage/duckdb.js";
 import { createRunner } from "./runners/index.js";
 import { resolveTestIdentity } from "./identity.js";
@@ -479,6 +487,75 @@ program
     );
     process.exit(report.errors.length > 0 ? 1 : 0);
   });
+
+// --- report ---
+const reportCommand = program
+  .command("report")
+  .description("Summarize and diff normalized test reports");
+
+reportCommand
+  .command("summarize")
+  .description("Summarize a raw adapter report")
+  .requiredOption("--adapter <type>", "Adapter type (playwright, junit)")
+  .requiredOption("--input <file>", "Raw adapter report file")
+  .option("--json", "Output JSON report")
+  .option("--markdown", "Output Markdown report")
+  .action(
+    (opts: {
+      adapter: string;
+      input: string;
+      json?: boolean;
+      markdown?: boolean;
+    }) => {
+      if (opts.json && opts.markdown) {
+        console.error("Error: choose either --json or --markdown");
+        process.exit(1);
+      }
+
+      const summary = runReportSummarize({
+        adapter: opts.adapter,
+        input: readFileSync(resolve(opts.input), "utf-8"),
+      });
+      console.log(
+        formatReportSummary(summary, opts.json ? "json" : "markdown"),
+      );
+    },
+  );
+
+reportCommand
+  .command("diff")
+  .description("Diff two normalized summaries or raw adapter reports")
+  .requiredOption("--base <file>", "Base summary or raw report file")
+  .requiredOption("--head <file>", "Head summary or raw report file")
+  .option("--adapter <type>", "Adapter type when diffing raw reports")
+  .option("--json", "Output JSON report")
+  .option("--markdown", "Output Markdown report")
+  .action(
+    (opts: {
+      base: string;
+      head: string;
+      adapter?: string;
+      json?: boolean;
+      markdown?: boolean;
+    }) => {
+      if (opts.json && opts.markdown) {
+        console.error("Error: choose either --json or --markdown");
+        process.exit(1);
+      }
+
+      const baseInput = readFileSync(resolve(opts.base), "utf-8");
+      const headInput = readFileSync(resolve(opts.head), "utf-8");
+      const base = opts.adapter
+        ? runReportSummarize({ adapter: opts.adapter, input: baseInput })
+        : parseReportSummary(baseInput);
+      const head = opts.adapter
+        ? runReportSummarize({ adapter: opts.adapter, input: headInput })
+        : parseReportSummary(headInput);
+      const diff = runReportDiff({ base, head });
+
+      console.log(formatReportDiff(diff, opts.json ? "json" : "markdown"));
+    },
+  );
 
 // --- query ---
 program

--- a/tests/commands/report.test.ts
+++ b/tests/commands/report.test.ts
@@ -1,0 +1,231 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveTestIdentity } from "../../src/cli/identity.js";
+import {
+  formatReportDiff,
+  formatReportSummary,
+  runReportDiff,
+  runReportSummarize,
+  summarizeResults,
+} from "../../src/cli/commands/report.js";
+
+const playwrightFixture = readFileSync(
+  join(import.meta.dirname, "../fixtures/playwright-report.json"),
+  "utf-8",
+);
+
+const junitFixture = readFileSync(
+  join(import.meta.dirname, "../fixtures/junit-report.xml"),
+  "utf-8",
+);
+
+describe("report summarize", () => {
+  it("normalizes playwright report into totals, file summaries, and unstable tests", () => {
+    const summary = runReportSummarize({
+      adapter: "playwright",
+      input: playwrightFixture,
+    });
+
+    expect(summary.totals).toMatchObject({
+      total: 4,
+      passed: 1,
+      failed: 1,
+      flaky: 1,
+      skipped: 1,
+      retries: 1,
+      durationMs: 4700,
+    });
+    expect(summary.files).toEqual([
+      expect.objectContaining({
+        suite: "tests/login.spec.ts",
+        totals: expect.objectContaining({
+          total: 4,
+          failed: 1,
+          flaky: 1,
+        }),
+      }),
+    ]);
+    expect(summary.unstable.map((entry) => entry.testName)).toEqual([
+      "should redirect after login",
+      "should show error on invalid credentials",
+    ]);
+
+    const json = formatReportSummary(summary, "json");
+    const markdown = formatReportSummary(summary, "markdown");
+
+    expect(JSON.parse(json)).toMatchObject({
+      adapter: "playwright",
+      totals: { total: 4, flaky: 1, failed: 1 },
+    });
+    expect(markdown).toContain("# Test Report Summary");
+    expect(markdown).toContain("tests/login.spec.ts");
+    expect(markdown).toContain("should redirect after login");
+  });
+
+  it("normalizes junit report into the same summary shape", () => {
+    const summary = runReportSummarize({
+      adapter: "junit",
+      input: junitFixture,
+    });
+
+    expect(summary.totals).toMatchObject({
+      total: 5,
+      passed: 3,
+      failed: 1,
+      flaky: 0,
+      skipped: 1,
+      retries: 0,
+      durationMs: 5200,
+    });
+    expect(summary.files).toEqual([
+      expect.objectContaining({
+        suite: "tests/home.spec.ts",
+        totals: expect.objectContaining({ total: 1, passed: 1 }),
+      }),
+      expect.objectContaining({
+        suite: "tests/login.spec.ts",
+        totals: expect.objectContaining({ total: 4, failed: 1, skipped: 1 }),
+      }),
+    ]);
+    expect(summary.unstable).toEqual([
+      expect.objectContaining({
+        suite: "tests/login.spec.ts",
+        testName: "should redirect after login",
+        status: "failed",
+      }),
+    ]);
+  });
+});
+
+describe("report diff", () => {
+  it("classifies regressions, improvements, and persistent flaky tests", () => {
+    const base = summarizeResults(
+      [
+        resolveTestIdentity({
+          suite: "tests/app.spec.ts",
+          testName: "stable",
+          status: "passed",
+          durationMs: 10,
+          retryCount: 0,
+        }),
+        resolveTestIdentity({
+          suite: "tests/app.spec.ts",
+          testName: "old failure",
+          status: "failed",
+          durationMs: 10,
+          retryCount: 0,
+        }),
+        resolveTestIdentity({
+          suite: "tests/app.spec.ts",
+          testName: "old flaky",
+          status: "flaky",
+          durationMs: 10,
+          retryCount: 1,
+        }),
+        resolveTestIdentity({
+          suite: "tests/app.spec.ts",
+          testName: "persistent flaky",
+          status: "flaky",
+          durationMs: 10,
+          retryCount: 1,
+        }),
+      ],
+      "playwright",
+    );
+
+    const head = summarizeResults(
+      [
+        resolveTestIdentity({
+          suite: "tests/app.spec.ts",
+          testName: "stable",
+          status: "passed",
+          durationMs: 10,
+          retryCount: 0,
+        }),
+        resolveTestIdentity({
+          suite: "tests/app.spec.ts",
+          testName: "old failure",
+          status: "passed",
+          durationMs: 10,
+          retryCount: 0,
+        }),
+        resolveTestIdentity({
+          suite: "tests/app.spec.ts",
+          testName: "old flaky",
+          status: "passed",
+          durationMs: 10,
+          retryCount: 0,
+        }),
+        resolveTestIdentity({
+          suite: "tests/app.spec.ts",
+          testName: "persistent flaky",
+          status: "flaky",
+          durationMs: 10,
+          retryCount: 1,
+        }),
+        resolveTestIdentity({
+          suite: "tests/app.spec.ts",
+          testName: "new failure",
+          status: "failed",
+          durationMs: 10,
+          retryCount: 0,
+        }),
+        resolveTestIdentity({
+          suite: "tests/app.spec.ts",
+          testName: "new flaky",
+          status: "flaky",
+          durationMs: 10,
+          retryCount: 1,
+        }),
+      ],
+      "playwright",
+    );
+
+    const diff = runReportDiff({ base, head });
+
+    expect(diff.summary).toMatchObject({
+      newFailureCount: 1,
+      newFlakyCount: 1,
+      resolvedFailureCount: 1,
+      resolvedFlakyCount: 1,
+      persistentFlakyCount: 1,
+    });
+    expect(diff.regressions.newFailures[0]).toMatchObject({
+      testName: "new failure",
+      headStatus: "failed",
+    });
+    expect(diff.regressions.newFlaky[0]).toMatchObject({
+      testName: "new flaky",
+      headStatus: "flaky",
+    });
+    expect(diff.improvements.resolvedFailures[0]).toMatchObject({
+      testName: "old failure",
+      baseStatus: "failed",
+      headStatus: "passed",
+    });
+    expect(diff.improvements.resolvedFlaky[0]).toMatchObject({
+      testName: "old flaky",
+      baseStatus: "flaky",
+      headStatus: "passed",
+    });
+    expect(diff.persistent.persistentFlaky[0]).toMatchObject({
+      testName: "persistent flaky",
+      baseStatus: "flaky",
+      headStatus: "flaky",
+    });
+
+    const json = formatReportDiff(diff, "json");
+    const markdown = formatReportDiff(diff, "markdown");
+
+    expect(JSON.parse(json)).toMatchObject({
+      summary: {
+        newFailureCount: 1,
+        persistentFlakyCount: 1,
+      },
+    });
+    expect(markdown).toContain("# Test Report Diff");
+    expect(markdown).toContain("new failure");
+    expect(markdown).toContain("persistent flaky");
+  });
+});


### PR DESCRIPTION
### Motivation

- Add a normalized report layer for single CI runs and base/head comparisons so PR review can focus on what regressed without querying the metrics DB.
- Reuse existing adapter parsing to export summaries and diffs as JSON or Markdown for CI artifacts and step summaries.

### Description

- Added `flaker report summarize` to normalize raw adapter reports from `playwright` and `junit` into totals, file summaries, unstable tests, and full test status inventories.
- Added `flaker report diff` to compare two normalized summaries, or two raw adapter reports via `--adapter`, and classify `new_failure`, `new_flaky`, `resolved_failure`, `resolved_flaky`, and `persistent_flaky`.
- Implemented Markdown and JSON formatting for both summary and diff output so they can be pasted directly into CI step summaries or stored as artifacts.
- Added fixture-based tests covering summary normalization for Playwright/JUnit and diff classification across regressions, improvements, and persistent flaky cases.

### Testing

- `pnpm vitest run`
- `pnpm -s tsc --noEmit`

Closes #6