### PR TITLE
Add shard-aware report aggregation

### DIFF
--- a/src/cli/commands/report.ts
+++ b/src/cli/commands/report.ts
@@ -1,3 +1,5 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
 import type { TestCaseResult } from "../adapters/types.js";
 import { junitAdapter } from "../adapters/junit.js";
 import { playwrightAdapter } from "../adapters/playwright.js";
@@ -39,6 +41,21 @@ export interface NormalizedReportSummary {
   tests: ReportTestSummary[];
 }
 
+export interface ReportSummaryArtifactMetadata {
+  shard: string | null;
+  module: string | null;
+  offset: number | null;
+  limit: number | null;
+  matrix: Record<string, string> | null;
+  variant: Record<string, string> | null;
+  extra: Record<string, string>;
+}
+
+export interface ReportSummaryArtifact {
+  summary: NormalizedReportSummary;
+  metadata: ReportSummaryArtifactMetadata;
+}
+
 export interface ReportDiffEntry {
   testId: string;
   suite: string;
@@ -73,6 +90,29 @@ export interface ReportDiff {
   };
 }
 
+export interface ReportAggregateShardSummary {
+  shardId: string;
+  adapter: string;
+  metadata: ReportSummaryArtifactMetadata;
+  totals: ReportTotals;
+  unstableCount: number;
+}
+
+export interface ReportAggregateUnstableTest extends ReportTestSummary {
+  shards: string[];
+  statuses: Array<"failed" | "flaky">;
+}
+
+export interface ReportAggregate {
+  summary: {
+    shardCount: number;
+    unstableCount: number;
+  };
+  totals: ReportTotals;
+  shards: ReportAggregateShardSummary[];
+  unstable: ReportAggregateUnstableTest[];
+}
+
 function emptyTotals(): ReportTotals {
   return {
     total: 0,
@@ -85,8 +125,49 @@ function emptyTotals(): ReportTotals {
   };
 }
 
+function emptyArtifactMetadata(): ReportSummaryArtifactMetadata {
+  return {
+    shard: null,
+    module: null,
+    offset: null,
+    limit: null,
+    matrix: null,
+    variant: null,
+    extra: {},
+  };
+}
+
 function compareNullable(a: string | null, b: string | null): number {
   return (a ?? "").localeCompare(b ?? "");
+}
+
+function normalizeRecord(
+  input?: Record<string, unknown> | null,
+): Record<string, string> | null {
+  if (!input) return null;
+  const entries = Object.entries(input)
+    .filter(([, value]) => value != null)
+    .map(([key, value]) => [key, String(value)] as const)
+    .sort(([a], [b]) => a.localeCompare(b));
+  if (entries.length === 0) return null;
+  return Object.fromEntries(entries);
+}
+
+function normalizeArtifactMetadata(
+  metadata?: Partial<ReportSummaryArtifactMetadata> | null,
+): ReportSummaryArtifactMetadata {
+  const base = emptyArtifactMetadata();
+  if (!metadata) return base;
+
+  return {
+    shard: metadata.shard ?? null,
+    module: metadata.module ?? null,
+    offset: metadata.offset ?? null,
+    limit: metadata.limit ?? null,
+    matrix: normalizeRecord(metadata.matrix) ?? null,
+    variant: normalizeRecord(metadata.variant) ?? null,
+    extra: normalizeRecord(metadata.extra) ?? {},
+  };
 }
 
 function variantLabel(variant: Record<string, string> | null): string {
@@ -173,6 +254,16 @@ export function summarizeResults(
   };
 }
 
+export function createReportSummaryArtifact(
+  summary: NormalizedReportSummary,
+  metadata?: Partial<ReportSummaryArtifactMetadata> | null,
+): ReportSummaryArtifact {
+  return {
+    summary,
+    metadata: normalizeArtifactMetadata(metadata),
+  };
+}
+
 function parseAdapterReport(
   adapter: string,
   input: string,
@@ -196,6 +287,41 @@ export function runReportSummarize(opts: {
 
 export function parseReportSummary(input: string): NormalizedReportSummary {
   return JSON.parse(input) as NormalizedReportSummary;
+}
+
+export function parseReportSummaryArtifact(input: string): ReportSummaryArtifact {
+  const parsed = JSON.parse(input) as
+    | ReportSummaryArtifact
+    | NormalizedReportSummary;
+
+  if (
+    typeof parsed === "object" &&
+    parsed !== null &&
+    "summary" in parsed &&
+    "metadata" in parsed
+  ) {
+    const artifact = parsed as ReportSummaryArtifact;
+    return createReportSummaryArtifact(artifact.summary, artifact.metadata);
+  }
+
+  return createReportSummaryArtifact(parsed as NormalizedReportSummary);
+}
+
+export function loadReportSummaryArtifactsFromDir(
+  dir: string,
+): ReportSummaryArtifact[] {
+  const files = walkJsonFiles(dir).sort((a, b) => a.localeCompare(b));
+  const artifacts: ReportSummaryArtifact[] = [];
+
+  for (const file of files) {
+    try {
+      artifacts.push(parseReportSummaryArtifact(readFileSync(file, "utf-8")));
+    } catch {
+      // Skip non-summary JSON files.
+    }
+  }
+
+  return artifacts;
 }
 
 function toDiffEntry(
@@ -287,6 +413,72 @@ export function runReportDiff(opts: {
   };
 }
 
+export function runReportAggregate(opts: {
+  summaries: ReportSummaryArtifact[];
+}): ReportAggregate {
+  const totals = emptyTotals();
+  const shards = opts.summaries.map((artifact, index) => {
+    const shardId = artifact.metadata.shard ?? `summary-${index + 1}`;
+    addTotals(totals, artifact.summary.totals);
+    return {
+      shardId,
+      adapter: artifact.summary.adapter,
+      metadata: artifact.metadata,
+      totals: artifact.summary.totals,
+      unstableCount: artifact.summary.unstable.length,
+      summary: artifact.summary,
+    };
+  });
+
+  const unstableIndex = new Map<
+    string,
+    ReportAggregateUnstableTest & {
+      shardSet: Set<string>;
+      statusSet: Set<"failed" | "flaky">;
+    }
+  >();
+
+  for (const shard of shards) {
+    for (const test of shard.summary.unstable) {
+      const status = test.status === "failed" ? "failed" : "flaky";
+      const existing = unstableIndex.get(test.testId);
+      if (existing) {
+        existing.shardSet.add(shard.shardId);
+        existing.statusSet.add(status);
+        continue;
+      }
+
+      unstableIndex.set(test.testId, {
+        ...test,
+        shards: [],
+        statuses: [],
+        shardSet: new Set([shard.shardId]),
+        statusSet: new Set([status]),
+      });
+    }
+  }
+
+  return {
+    summary: {
+      shardCount: shards.length,
+      unstableCount: unstableIndex.size,
+    },
+    totals,
+    shards: shards
+      .map(({ summary: _summary, ...shard }) => shard)
+      .sort((a, b) => a.shardId.localeCompare(b.shardId)),
+    unstable: sortTests(
+      [...unstableIndex.values()].map(
+        ({ shardSet, statusSet, ...entry }) => ({
+          ...entry,
+          shards: [...shardSet].sort(),
+          statuses: [...statusSet].sort(),
+        }),
+      ),
+    ),
+  };
+}
+
 function formatTotals(totals: ReportTotals): string[] {
   return [
     `- Total: ${totals.total}`,
@@ -297,6 +489,16 @@ function formatTotals(totals: ReportTotals): string[] {
     `- Retries: ${totals.retries}`,
     `- DurationMs: ${totals.durationMs}`,
   ];
+}
+
+function addTotals(target: ReportTotals, source: ReportTotals): void {
+  target.total += source.total;
+  target.passed += source.passed;
+  target.failed += source.failed;
+  target.flaky += source.flaky;
+  target.skipped += source.skipped;
+  target.retries += source.retries;
+  target.durationMs += source.durationMs;
 }
 
 function formatTestRows(
@@ -315,6 +517,46 @@ function formatSummaryTestRows(
     (entry) =>
       `| ${entry.suite} | ${entry.testName} | ${entry.taskId} | ${entry.filter ?? "-"} | ${entry.status} | ${entry.retryCount} |`,
   );
+}
+
+function formatAggregateUnstableRows(
+  entries: ReportAggregateUnstableTest[],
+): string[] {
+  return entries.map(
+    (entry) =>
+      `| ${entry.suite} | ${entry.testName} | ${entry.taskId} | ${entry.filter ?? "-"} | ${entry.statuses.join(", ")} | ${entry.shards.join(", ")} |`,
+  );
+}
+
+function formatArtifactMetadataValue(
+  metadata: ReportSummaryArtifactMetadata,
+): string {
+  const parts: string[] = [];
+
+  if (metadata.matrix) {
+    parts.push(
+      `matrix:${Object.entries(metadata.matrix)
+        .map(([key, value]) => `${key}=${value}`)
+        .join(",")}`,
+    );
+  }
+
+  if (metadata.variant) {
+    parts.push(
+      `variant:${Object.entries(metadata.variant)
+        .map(([key, value]) => `${key}=${value}`)
+        .join(",")}`,
+    );
+  }
+
+  const extraEntries = Object.entries(metadata.extra);
+  if (extraEntries.length > 0) {
+    parts.push(
+      `meta:${extraEntries.map(([key, value]) => `${key}=${value}`).join(",")}`,
+    );
+  }
+
+  return parts.join(" / ") || "-";
 }
 
 function formatReportSection(title: string, rows: string[]): string[] {
@@ -435,4 +677,62 @@ export function formatReportDiff(
         : [],
     ),
   ].join("\n");
+}
+
+export function formatReportAggregate(
+  aggregate: ReportAggregate,
+  format: "json" | "markdown",
+): string {
+  if (format === "json") {
+    return JSON.stringify(aggregate, null, 2);
+  }
+
+  const shardRows = aggregate.shards.map(
+    (shard) =>
+      `| ${shard.shardId} | ${shard.adapter} | ${shard.metadata.module ?? "-"} | ${shard.metadata.offset ?? "-"} | ${shard.metadata.limit ?? "-"} | ${formatArtifactMetadataValue(shard.metadata)} | ${shard.totals.total} | ${shard.totals.failed} | ${shard.totals.flaky} | ${shard.unstableCount} |`,
+  );
+
+  return [
+    "# Aggregated Test Report",
+    "",
+    `- Shards: ${aggregate.summary.shardCount}`,
+    `- Unstable tests: ${aggregate.summary.unstableCount}`,
+    ...formatTotals(aggregate.totals),
+    "",
+    "## Shards",
+    "",
+    "| shard | adapter | module | offset | limit | metadata | total | failed | flaky | unstable |",
+    "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+    ...shardRows,
+    "",
+    ...formatReportSection(
+      "Aggregated Unstable Tests",
+      aggregate.unstable.length > 0
+        ? [
+            "| suite | testName | taskId | filter | statuses | shards |",
+            "| --- | --- | --- | --- | --- | --- |",
+            ...formatAggregateUnstableRows(aggregate.unstable),
+          ]
+        : [],
+    ),
+  ].join("\n");
+}
+
+function walkJsonFiles(dir: string): string[] {
+  const results: string[] = [];
+
+  for (const entry of readdirSync(dir)) {
+    const fullPath = join(dir, entry);
+    const stat = statSync(fullPath);
+    if (stat.isDirectory()) {
+      results.push(...walkJsonFiles(fullPath));
+      continue;
+    }
+
+    if (entry.endsWith(".json")) {
+      results.push(fullPath);
+    }
+  }
+
+  return results;
 }

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -36,9 +36,13 @@ import {
   runConfigCheck,
 } from "./commands/check.js";
 import {
+  createReportSummaryArtifact,
+  formatReportAggregate,
   formatReportDiff,
   formatReportSummary,
+  loadReportSummaryArtifactsFromDir,
   parseReportSummary,
+  runReportAggregate,
   runReportDiff,
   runReportSummarize,
 } from "./commands/report.js";
@@ -112,6 +116,23 @@ async function listRunnerTests(
   } catch {
     return [];
   }
+}
+
+function parseKeyValuePairs(input?: string): Record<string, string> | undefined {
+  if (!input) return undefined;
+  const entries = input
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .map((part) => {
+      const separator = part.indexOf("=");
+      if (separator === -1) {
+        throw new Error(`Invalid key=value pair: ${part}`);
+      }
+      return [part.slice(0, separator), part.slice(separator + 1)] as const;
+    });
+  if (entries.length === 0) return undefined;
+  return Object.fromEntries(entries);
 }
 
 program
@@ -498,12 +519,28 @@ reportCommand
   .description("Summarize a raw adapter report")
   .requiredOption("--adapter <type>", "Adapter type (playwright, junit)")
   .requiredOption("--input <file>", "Raw adapter report file")
+  .option("--bundle", "Wrap summary with shard metadata for aggregation")
+  .option("--shard <name>", "Shard name")
+  .option("--module <name>", "Module name")
+  .option("--offset <n>", "Shard offset")
+  .option("--limit <n>", "Shard limit")
+  .option("--matrix <pairs>", "Comma-separated matrix metadata (key=value)")
+  .option("--variant <pairs>", "Comma-separated variant metadata (key=value)")
+  .option("--meta <pairs>", "Comma-separated extra metadata (key=value)")
   .option("--json", "Output JSON report")
   .option("--markdown", "Output Markdown report")
   .action(
     (opts: {
       adapter: string;
       input: string;
+      bundle?: boolean;
+      shard?: string;
+      module?: string;
+      offset?: string;
+      limit?: string;
+      matrix?: string;
+      variant?: string;
+      meta?: string;
       json?: boolean;
       markdown?: boolean;
     }) => {
@@ -511,11 +548,33 @@ reportCommand
         console.error("Error: choose either --json or --markdown");
         process.exit(1);
       }
+      if (opts.bundle && opts.markdown) {
+        console.error("Error: --bundle cannot be combined with --markdown");
+        process.exit(1);
+      }
 
       const summary = runReportSummarize({
         adapter: opts.adapter,
         input: readFileSync(resolve(opts.input), "utf-8"),
       });
+      if (opts.bundle) {
+        console.log(
+          JSON.stringify(
+            createReportSummaryArtifact(summary, {
+              shard: opts.shard,
+              module: opts.module,
+              offset: opts.offset ? Number(opts.offset) : undefined,
+              limit: opts.limit ? Number(opts.limit) : undefined,
+              matrix: parseKeyValuePairs(opts.matrix),
+              variant: parseKeyValuePairs(opts.variant),
+              extra: parseKeyValuePairs(opts.meta),
+            }),
+            null,
+            2,
+          ),
+        );
+        return;
+      }
       console.log(
         formatReportSummary(summary, opts.json ? "json" : "markdown"),
       );
@@ -556,6 +615,25 @@ reportCommand
       console.log(formatReportDiff(diff, opts.json ? "json" : "markdown"));
     },
   );
+
+reportCommand
+  .command("aggregate <dir>")
+  .description("Aggregate shard-aware summary artifacts")
+  .option("--json", "Output JSON report")
+  .option("--markdown", "Output Markdown report")
+  .action((dir: string, opts: { json?: boolean; markdown?: boolean }) => {
+    if (opts.json && opts.markdown) {
+      console.error("Error: choose either --json or --markdown");
+      process.exit(1);
+    }
+
+    const aggregate = runReportAggregate({
+      summaries: loadReportSummaryArtifactsFromDir(resolve(dir)),
+    });
+    console.log(
+      formatReportAggregate(aggregate, opts.json ? "json" : "markdown"),
+    );
+  });
 
 // --- query ---
 program

--- a/tests/commands/report.test.ts
+++ b/tests/commands/report.test.ts
@@ -1,10 +1,15 @@
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { describe, expect, it } from "vitest";
 import { resolveTestIdentity } from "../../src/cli/identity.js";
 import {
+  createReportSummaryArtifact,
+  formatReportAggregate,
   formatReportDiff,
   formatReportSummary,
+  loadReportSummaryArtifactsFromDir,
+  runReportAggregate,
   runReportDiff,
   runReportSummarize,
   summarizeResults,
@@ -227,5 +232,183 @@ describe("report diff", () => {
     expect(markdown).toContain("# Test Report Diff");
     expect(markdown).toContain("new failure");
     expect(markdown).toContain("persistent flaky");
+  });
+});
+
+describe("report aggregate", () => {
+  it("aggregates shard bundles and preserves shard metadata", () => {
+    const shardA = createReportSummaryArtifact(
+      summarizeResults(
+        [
+          resolveTestIdentity({
+            suite: "tests/vrt.spec.ts",
+            testName: "renders header",
+            taskId: "vrt",
+            status: "passed",
+            durationMs: 10,
+            retryCount: 0,
+          }),
+          resolveTestIdentity({
+            suite: "tests/vrt.spec.ts",
+            testName: "renders footer",
+            taskId: "vrt",
+            status: "failed",
+            durationMs: 20,
+            retryCount: 0,
+          }),
+        ],
+        "playwright",
+      ),
+      {
+        shard: "shard-1",
+        module: "vrt",
+        offset: 0,
+        limit: 50,
+        matrix: { os: "ubuntu-latest" },
+        extra: { browser: "chromium" },
+      },
+    );
+    const shardB = createReportSummaryArtifact(
+      summarizeResults(
+        [
+          resolveTestIdentity({
+            suite: "tests/vrt.spec.ts",
+            testName: "renders card",
+            taskId: "vrt",
+            status: "flaky",
+            durationMs: 30,
+            retryCount: 1,
+          }),
+        ],
+        "playwright",
+      ),
+      {
+        shard: "shard-2",
+        module: "vrt",
+        offset: 50,
+        limit: 50,
+        matrix: { os: "ubuntu-latest" },
+      },
+    );
+
+    const aggregate = runReportAggregate({
+      summaries: [shardA, shardB],
+    });
+
+    expect(aggregate.summary).toMatchObject({
+      shardCount: 2,
+      unstableCount: 2,
+    });
+    expect(aggregate.totals).toMatchObject({
+      total: 3,
+      passed: 1,
+      failed: 1,
+      flaky: 1,
+      retries: 1,
+      durationMs: 60,
+    });
+    expect(aggregate.shards).toEqual([
+      expect.objectContaining({
+        shardId: "shard-1",
+        metadata: expect.objectContaining({
+          module: "vrt",
+          offset: 0,
+          limit: 50,
+          matrix: { os: "ubuntu-latest" },
+        }),
+        totals: expect.objectContaining({ total: 2, failed: 1 }),
+      }),
+      expect.objectContaining({
+        shardId: "shard-2",
+        totals: expect.objectContaining({ total: 1, flaky: 1 }),
+      }),
+    ]);
+    expect(aggregate.unstable).toEqual([
+      expect.objectContaining({
+        testName: "renders card",
+        shards: ["shard-2"],
+        statuses: ["flaky"],
+      }),
+      expect.objectContaining({
+        testName: "renders footer",
+        shards: ["shard-1"],
+        statuses: ["failed"],
+      }),
+    ]);
+
+    const json = formatReportAggregate(aggregate, "json");
+    const markdown = formatReportAggregate(aggregate, "markdown");
+
+    expect(JSON.parse(json)).toMatchObject({
+      summary: { shardCount: 2, unstableCount: 2 },
+    });
+    expect(markdown).toContain("# Aggregated Test Report");
+    expect(markdown).toContain("shard-1");
+    expect(markdown).toContain("renders footer");
+    expect(markdown).toContain("matrix:os=ubuntu-latest");
+    expect(markdown).toContain("meta:browser=chromium");
+  });
+
+  it("loads plain summaries and bundle artifacts from a directory", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "report-aggregate-"));
+    try {
+      const plainSummary = summarizeResults(
+        [
+          resolveTestIdentity({
+            suite: "tests/plain.spec.ts",
+            testName: "plain test",
+            status: "passed",
+            durationMs: 5,
+            retryCount: 0,
+          }),
+        ],
+        "junit",
+      );
+      const bundledSummary = createReportSummaryArtifact(
+        summarizeResults(
+          [
+            resolveTestIdentity({
+              suite: "tests/bundled.spec.ts",
+              testName: "bundled test",
+              status: "failed",
+              durationMs: 7,
+              retryCount: 0,
+            }),
+          ],
+          "playwright",
+        ),
+        { shard: "bundle-a", module: "ui" },
+      );
+
+      writeFileSync(
+        join(cwd, "plain-summary.json"),
+        JSON.stringify(plainSummary, null, 2),
+      );
+      writeFileSync(
+        join(cwd, "bundled-summary.json"),
+        JSON.stringify(bundledSummary, null, 2),
+      );
+
+      const loaded = loadReportSummaryArtifactsFromDir(cwd);
+
+      expect(loaded).toHaveLength(2);
+      expect(loaded).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            metadata: expect.objectContaining({ shard: null }),
+            summary: expect.objectContaining({ adapter: "junit" }),
+          }),
+          expect.objectContaining({
+            metadata: expect.objectContaining({
+              shard: "bundle-a",
+              module: "ui",
+            }),
+            summary: expect.objectContaining({ adapter: "playwright" }),
+          }),
+        ]),
+      );
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- add shard-aware report summary artifacts with matrix, variant, and extra metadata
- add `flaker report aggregate <dir>` to merge bundled or plain summaries into a single JSON/Markdown report
- include aggregate tests covering shard totals, unstable test merging, markdown metadata rendering, and directory loading

## Testing
- pnpm vitest run tests/commands/report.test.ts
- pnpm -s tsc --noEmit
- pnpm vitest run

Closes #7