### PR TITLE
Support affected and hybrid run sampling

### DIFF
--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -1,6 +1,7 @@
 import type { MetricStore } from "../storage/types.js";
 import { runSample } from "./sample.js";
 import type { QuarantineManifestEntry } from "../quarantine-manifest.js";
+import type { DependencyResolver } from "../resolvers/types.js";
 import {
   orchestrate,
   withQuarantineRuntime,
@@ -14,8 +15,10 @@ export interface RunOpts {
   runner: RunnerAdapter;
   count?: number;
   percentage?: number;
-  mode: "random" | "weighted";
+  mode: "random" | "weighted" | "affected" | "hybrid";
   seed?: number;
+  resolver?: DependencyResolver;
+  changedFiles?: string[];
   skipQuarantined?: boolean;
   quarantineManifestEntries?: QuarantineManifestEntry[];
   cwd?: string;
@@ -68,6 +71,8 @@ export async function runTests(opts: RunOpts): Promise<ExecuteResult> {
     percentage: opts.percentage,
     mode: opts.mode,
     seed: opts.seed,
+    resolver: opts.resolver,
+    changedFiles: opts.changedFiles,
     skipQuarantined: opts.skipQuarantined,
     quarantineManifestEntries: opts.quarantineManifestEntries,
     listedTests,

--- a/src/cli/commands/sample.ts
+++ b/src/cli/commands/sample.ts
@@ -38,7 +38,10 @@ function buildListedTestIndex(listedTests: TestId[]): Map<string, TestId[]> {
 
 export async function runSample(opts: SampleOpts): Promise<TestMeta[]> {
   const core = await loadCore();
-  let allTests = await buildTestMeta(opts.store);
+  let allTests = mergeListedTests(
+    await buildTestMeta(opts.store),
+    opts.listedTests ?? [],
+  );
   if (opts.skipQuarantined) {
     const quarantined = await opts.store.queryQuarantined();
     const qSet = new Set(quarantined.map((q) => q.testId));
@@ -145,4 +148,31 @@ async function buildTestMeta(store: MetricStore): Promise<TestMeta[]> {
     previously_failed: r.previously_failed,
     is_new: r.total_runs <= 1,
   }));
+}
+
+function mergeListedTests(
+  meta: TestMeta[],
+  listedTests: TestId[],
+): TestMeta[] {
+  const seen = new Set(meta.map((entry) => `${entry.suite}\0${entry.test_name}`));
+  const merged = [...meta];
+
+  for (const test of listedTests) {
+    const key = `${test.suite}\0${test.testName}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push({
+      suite: test.suite,
+      test_name: test.testName,
+      flaky_rate: 0,
+      total_runs: 0,
+      fail_count: 0,
+      last_run_at: "",
+      avg_duration_ms: 0,
+      previously_failed: false,
+      is_new: true,
+    });
+  }
+
+  return merged;
 }

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -135,6 +135,35 @@ function parseKeyValuePairs(input?: string): Record<string, string> | undefined 
   return Object.fromEntries(entries);
 }
 
+function parseChangedFiles(input?: string): string[] | undefined {
+  const files = input
+    ?.split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+  return files && files.length > 0 ? files : undefined;
+}
+
+async function createConfiguredResolver(
+  cwd: string,
+  affectedConfig: { resolver: string; config: string },
+) {
+  const resolverType = affectedConfig.resolver ?? "simple";
+  if (resolverType === "bitflow" && affectedConfig.config) {
+    const { BitflowNativeResolver } = await import("./resolvers/bitflow-native.js");
+    return new BitflowNativeResolver(resolve(affectedConfig.config));
+  }
+  if (resolverType === "workspace") {
+    const { WorkspaceResolver } = await import("./resolvers/workspace.js");
+    return new WorkspaceResolver(cwd);
+  }
+  if (resolverType === "moon") {
+    const { MoonResolver } = await import("./resolvers/moon.js");
+    return new MoonResolver(cwd);
+  }
+  const { SimpleResolver } = await import("./resolvers/simple.js");
+  return new SimpleResolver();
+}
+
 program
   .name("flaker")
   .description("CI metrics collection and analysis tool")
@@ -285,7 +314,7 @@ program
       await store.initialize();
 
       try {
-        const changedFiles = opts.changed?.split(",").map(f => f.trim()).filter(Boolean);
+        const changedFiles = parseChangedFiles(opts.changed);
         const mode = opts.strategy as "random" | "weighted" | "affected" | "hybrid";
         const manifest = opts.skipQuarantined
           ? loadQuarantineManifestIfExists({ cwd: process.cwd() })
@@ -298,20 +327,7 @@ program
         // Create resolver from config for affected/hybrid
         let resolver;
         if ((mode === "affected" || mode === "hybrid") && changedFiles?.length) {
-          const resolverType = config.affected.resolver ?? "simple";
-          if (resolverType === "bitflow" && config.affected.config) {
-            const { BitflowNativeResolver } = await import("./resolvers/bitflow-native.js");
-            resolver = new BitflowNativeResolver(resolve(config.affected.config));
-          } else if (resolverType === "workspace") {
-            const { WorkspaceResolver } = await import("./resolvers/workspace.js");
-            resolver = new WorkspaceResolver(process.cwd());
-          } else if (resolverType === "moon") {
-            const { MoonResolver } = await import("./resolvers/moon.js");
-            resolver = new MoonResolver(process.cwd());
-          } else {
-            const { SimpleResolver } = await import("./resolvers/simple.js");
-            resolver = new SimpleResolver();
-          }
+          resolver = await createConfiguredResolver(process.cwd(), config.affected);
         }
 
         const sampled = await runSample({
@@ -338,22 +354,30 @@ program
 program
   .command("run")
   .description("Sample and run tests")
-  .option("--strategy <s>", "Sampling strategy: random or weighted", "random")
+  .option("--strategy <s>", "Sampling strategy: random, weighted, affected, hybrid", "random")
   .option("--count <n>", "Number of tests to run")
   .option("--percentage <n>", "Percentage of tests to run")
+  .option("--changed <files>", "Comma-separated list of changed files (for affected/hybrid)")
   .option("--runner <runner>", "Runner type: direct or actrun", "direct")
   .option("--retry", "Retry failed tests (actrun only)")
   .option("--skip-quarantined", "Exclude quarantined tests")
   .action(
-    async (opts: { strategy: string; count?: string; percentage?: string; runner: string; retry?: boolean; skipQuarantined?: boolean }) => {
-      const config = loadConfig(process.cwd());
+    async (opts: { strategy: string; count?: string; percentage?: string; changed?: string; runner: string; retry?: boolean; skipQuarantined?: boolean }) => {
+      const cwd = process.cwd();
+      const config = loadConfig(cwd);
       const store = new DuckDBStore(resolve(config.storage.path));
       await store.initialize();
 
       try {
+        const changedFiles = parseChangedFiles(opts.changed);
+        const mode = opts.strategy as "random" | "weighted" | "affected" | "hybrid";
         const manifest = opts.skipQuarantined
-          ? loadQuarantineManifestIfExists({ cwd: process.cwd() })
+          ? loadQuarantineManifestIfExists({ cwd })
           : null;
+        const resolver =
+          (mode === "affected" || mode === "hybrid") && changedFiles?.length
+            ? await createConfiguredResolver(cwd, config.affected)
+            : undefined;
         if (opts.runner === "actrun") {
           const actRunner = new ActrunRunner({
             workflow: config.runner.command,
@@ -411,12 +435,14 @@ program
         const runResult = await runTests({
           store,
           runner: createRunner(config.runner),
-          mode: opts.strategy as "random" | "weighted",
+          mode,
           count: opts.count ? Number(opts.count) : undefined,
           percentage: opts.percentage ? Number(opts.percentage) : undefined,
+          resolver,
+          changedFiles,
           skipQuarantined: opts.skipQuarantined,
           quarantineManifestEntries: manifest?.entries,
-          cwd: process.cwd(),
+          cwd,
         });
         if (runResult.exitCode !== 0) {
           process.exit(1);

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -147,21 +147,13 @@ async function createConfiguredResolver(
   cwd: string,
   affectedConfig: { resolver: string; config: string },
 ) {
-  const resolverType = affectedConfig.resolver ?? "simple";
-  if (resolverType === "bitflow" && affectedConfig.config) {
-    const { BitflowNativeResolver } = await import("./resolvers/bitflow-native.js");
-    return new BitflowNativeResolver(resolve(affectedConfig.config));
-  }
-  if (resolverType === "workspace") {
-    const { WorkspaceResolver } = await import("./resolvers/workspace.js");
-    return new WorkspaceResolver(cwd);
-  }
-  if (resolverType === "moon") {
-    const { MoonResolver } = await import("./resolvers/moon.js");
-    return new MoonResolver(cwd);
-  }
-  const { SimpleResolver } = await import("./resolvers/simple.js");
-  return new SimpleResolver();
+  return createResolver(
+    {
+      resolver: affectedConfig.resolver ?? "simple",
+      config: affectedConfig.config ? resolve(cwd, affectedConfig.config) : undefined,
+    },
+    cwd,
+  );
 }
 
 program

--- a/src/cli/resolvers/glob.ts
+++ b/src/cli/resolvers/glob.ts
@@ -1,0 +1,175 @@
+import { readFileSync } from "node:fs";
+import { parse } from "smol-toml";
+import {
+  buildAffectedReport,
+  createAffectedSelection,
+} from "./affected-report.js";
+import type {
+  AffectedReport,
+  AffectedSelection,
+  AffectedTarget,
+  DependencyResolver,
+} from "./types.js";
+
+interface GlobRuleFile {
+  rules?: Array<{
+    changed?: unknown;
+    select?: unknown;
+    reason?: unknown;
+  }>;
+}
+
+interface CompiledGlobRule {
+  changed: RegExp[];
+  select: RegExp[];
+  reason: string;
+}
+
+function normalizePath(path: string): string {
+  return path.replaceAll("\\", "/");
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+}
+
+function compileGlob(glob: string): RegExp {
+  const normalized = normalizePath(glob);
+  const escaped = escapeRegex(normalized)
+    .replaceAll("**", "\u0000")
+    .replaceAll("*", "[^/]*")
+    .replaceAll("?", "[^/]")
+    .replaceAll("\u0000", ".*");
+  return new RegExp(`^${escaped}$`);
+}
+
+function normalizeStringArray(
+  value: unknown,
+  fieldName: string,
+  ruleIndex: number,
+): string[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error(`glob rule ${ruleIndex} requires non-empty ${fieldName}`);
+  }
+
+  return value.map((entry, offset) => {
+    if (typeof entry !== "string" || entry.trim() === "") {
+      throw new Error(
+        `glob rule ${ruleIndex} ${fieldName}[${offset}] must be a non-empty string`,
+      );
+    }
+    return entry;
+  });
+}
+
+function compileRules(configPath: string): CompiledGlobRule[] {
+  const raw = readFileSync(configPath, "utf-8");
+  const parsed = parse(raw) as GlobRuleFile;
+  const rules = parsed.rules ?? [];
+
+  return rules.map((rule, index) => {
+    const changed = normalizeStringArray(rule.changed, "changed", index + 1);
+    const select = normalizeStringArray(rule.select, "select", index + 1);
+    const reason = typeof rule.reason === "string" && rule.reason.trim() !== ""
+      ? rule.reason
+      : `rule:${index + 1}`;
+
+    return {
+      changed: changed.map(compileGlob),
+      select: select.map(compileGlob),
+      reason,
+    };
+  });
+}
+
+function targetMatchesRule(target: AffectedTarget, rule: CompiledGlobRule): boolean {
+  const spec = normalizePath(target.spec);
+  return rule.select.some((pattern) => pattern.test(spec));
+}
+
+function buildSelection(
+  target: AffectedTarget,
+  matchedPaths: Set<string>,
+  reasons: Set<string>,
+): AffectedSelection {
+  return createAffectedSelection(target, {
+    direct: true,
+    matchedPaths: [...matchedPaths],
+    matchReasons: [...reasons].sort(),
+  });
+}
+
+export class GlobRuleResolver implements DependencyResolver {
+  private readonly rules: CompiledGlobRule[];
+
+  constructor(configPath: string) {
+    this.rules = compileRules(configPath);
+  }
+
+  resolve(changedFiles: string[], allTestFiles: string[]): string[] {
+    const selected = new Set<string>();
+    const normalizedTargets = allTestFiles.map((target) => ({
+      raw: target,
+      normalized: normalizePath(target),
+    }));
+
+    for (const file of changedFiles.map(normalizePath)) {
+      const matchedRules = this.rules.filter((rule) =>
+        rule.changed.some((pattern) => pattern.test(file))
+      );
+      if (matchedRules.length === 0) continue;
+
+      for (const target of normalizedTargets) {
+        if (matchedRules.some((rule) => rule.select.some((pattern) => pattern.test(target.normalized)))) {
+          selected.add(target.raw);
+        }
+      }
+    }
+
+    return allTestFiles.filter((target) => selected.has(target));
+  }
+
+  explain(changedFiles: string[], targets: AffectedTarget[]): AffectedReport {
+    const matchedFiles = new Set<string>();
+    const selected = new Map<string, { target: AffectedTarget; matchedPaths: Set<string>; reasons: Set<string> }>();
+
+    for (const file of changedFiles) {
+      const normalizedFile = normalizePath(file);
+      const matchedRules = this.rules.filter((rule) =>
+        rule.changed.some((pattern) => pattern.test(normalizedFile))
+      );
+      if (matchedRules.length === 0) continue;
+      matchedFiles.add(file);
+
+      for (const target of targets) {
+        const matchingRules = matchedRules.filter((rule) => targetMatchesRule(target, rule));
+        if (matchingRules.length === 0) continue;
+
+        const key = JSON.stringify({
+          spec: target.spec,
+          taskId: target.taskId,
+          filter: target.filter ?? null,
+        });
+        const entry = selected.get(key) ?? {
+          target,
+          matchedPaths: new Set<string>(),
+          reasons: new Set<string>(),
+        };
+        entry.matchedPaths.add(file);
+        for (const rule of matchingRules) {
+          entry.reasons.add(rule.reason);
+        }
+        selected.set(key, entry);
+      }
+    }
+
+    return buildAffectedReport(
+      "glob",
+      changedFiles,
+      [...selected.values()].map((entry) =>
+        buildSelection(entry.target, entry.matchedPaths, entry.reasons)
+      ),
+      changedFiles.filter((file) => !matchedFiles.has(file)),
+    );
+  }
+}

--- a/src/cli/resolvers/index.ts
+++ b/src/cli/resolvers/index.ts
@@ -1,12 +1,14 @@
 import type { DependencyResolver } from "./types.js";
 import { SimpleResolver } from "./simple.js";
 import { BitflowNativeResolver } from "./bitflow-native.js";
+import { GlobRuleResolver } from "./glob.js";
 import { WorkspaceResolver } from "./workspace.js";
 import { MoonResolver } from "./moon.js";
 
 export type { DependencyResolver } from "./types.js";
 export { SimpleResolver } from "./simple.js";
 export { BitflowNativeResolver } from "./bitflow-native.js";
+export { GlobRuleResolver } from "./glob.js";
 export { WorkspaceResolver } from "./workspace.js";
 export { MoonResolver } from "./moon.js";
 
@@ -26,6 +28,9 @@ export function createResolver(
     case "bitflow":
       if (!config.config) throw new Error("bitflow resolver requires a config path");
       return new BitflowNativeResolver(config.config);
+    case "glob":
+      if (!config.config) throw new Error("glob resolver requires a config path");
+      return new GlobRuleResolver(config.config);
     case "workspace":
       return new WorkspaceResolver(rootDir);
     case "moon":

--- a/tests/commands/run.test.ts
+++ b/tests/commands/run.test.ts
@@ -3,6 +3,7 @@ import { DuckDBStore } from "../../src/cli/storage/duckdb.js";
 import { runTests } from "../../src/cli/commands/run.js";
 import type { RunnerAdapter, TestId } from "../../src/cli/runners/types.js";
 import type { QuarantineManifestEntry } from "../../src/cli/quarantine-manifest.js";
+import type { DependencyResolver } from "../../src/cli/resolvers/types.js";
 
 describe("run command", () => {
   let store: DuckDBStore;
@@ -107,5 +108,172 @@ describe("run command", () => {
         id: "paint-vrt-local-assets",
       },
     });
+  });
+
+  it("supports affected mode in runTests", async () => {
+    await store.insertTestResults([
+      {
+        workflowRunId: 1,
+        suite: "tests/auth.spec.ts",
+        testName: "auth works",
+        status: "passed",
+        durationMs: 100,
+        retryCount: 0,
+        errorMessage: null,
+        commitSha: "abc",
+        variant: null,
+        createdAt: new Date(),
+      },
+      {
+        workflowRunId: 1,
+        suite: "tests/home.spec.ts",
+        testName: "home works",
+        status: "passed",
+        durationMs: 100,
+        retryCount: 0,
+        errorMessage: null,
+        commitSha: "abc",
+        variant: null,
+        createdAt: new Date(),
+      },
+    ]);
+
+    const calls: TestId[][] = [];
+    const runner: RunnerAdapter = {
+      name: "mock",
+      capabilities: { nativeParallel: false },
+      async listTests() {
+        return [
+          { suite: "tests/auth.spec.ts", testName: "auth works", taskId: "auth" },
+          { suite: "tests/home.spec.ts", testName: "home works", taskId: "home" },
+        ];
+      },
+      async execute(tests) {
+        calls.push([...tests]);
+        return {
+          exitCode: 0,
+          results: tests.map((test) => ({
+            suite: test.suite,
+            testName: test.testName,
+            taskId: test.taskId,
+            status: "passed",
+            durationMs: 10,
+            retryCount: 0,
+          })),
+          durationMs: 10,
+          stdout: "",
+          stderr: "",
+        };
+      },
+    };
+    const resolver: DependencyResolver = {
+      resolve(changedFiles) {
+        expect(changedFiles).toEqual(["src/auth/login.ts"]);
+        return ["tests/auth.spec.ts"];
+      },
+    };
+
+    const result = await runTests({
+      store,
+      runner,
+      mode: "affected",
+      changedFiles: ["src/auth/login.ts"],
+      resolver,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual([
+      expect.objectContaining({
+        suite: "tests/auth.spec.ts",
+        testName: "auth works",
+        taskId: "auth",
+      }),
+    ]);
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]).toMatchObject({
+      suite: "tests/auth.spec.ts",
+      testName: "auth works",
+    });
+  });
+
+  it("supports hybrid mode in runTests", async () => {
+    for (const entry of [
+      { suite: "tests/auth.spec.ts", testName: "auth works" },
+      { suite: "tests/home.spec.ts", testName: "home works" },
+      { suite: "tests/api.spec.ts", testName: "api works" },
+    ]) {
+      await store.insertTestResults([
+        {
+          workflowRunId: 1,
+          suite: entry.suite,
+          testName: entry.testName,
+          status: "passed",
+          durationMs: 100,
+          retryCount: 0,
+          errorMessage: null,
+          commitSha: "abc",
+          variant: null,
+          createdAt: new Date(),
+        },
+      ]);
+    }
+
+    const calls: TestId[][] = [];
+    const runner: RunnerAdapter = {
+      name: "mock",
+      capabilities: { nativeParallel: false },
+      async listTests() {
+        return [
+          { suite: "tests/auth.spec.ts", testName: "auth works", taskId: "auth" },
+          { suite: "tests/home.spec.ts", testName: "home works", taskId: "home" },
+          { suite: "tests/api.spec.ts", testName: "api works", taskId: "api" },
+        ];
+      },
+      async execute(tests) {
+        calls.push([...tests]);
+        return {
+          exitCode: 0,
+          results: tests.map((test) => ({
+            suite: test.suite,
+            testName: test.testName,
+            taskId: test.taskId,
+            status: "passed",
+            durationMs: 10,
+            retryCount: 0,
+          })),
+          durationMs: 10,
+          stdout: "",
+          stderr: "",
+        };
+      },
+    };
+    const resolver: DependencyResolver = {
+      resolve() {
+        return ["tests/home.spec.ts"];
+      },
+    };
+
+    const result = await runTests({
+      store,
+      runner,
+      mode: "hybrid",
+      count: 2,
+      seed: 42,
+      changedFiles: ["src/home/index.ts"],
+      resolver,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toHaveLength(2);
+    expect(calls[0]).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          suite: "tests/home.spec.ts",
+          testName: "home works",
+          taskId: "home",
+        }),
+      ]),
+    );
+    expect(result.results).toHaveLength(2);
   });
 });

--- a/tests/commands/sample.test.ts
+++ b/tests/commands/sample.test.ts
@@ -118,3 +118,53 @@ describe("sample command", () => {
     expect(sampled).toHaveLength(10);
   });
 });
+
+describe("sample command without history", () => {
+  let store: DuckDBStore;
+
+  beforeEach(async () => {
+    store = new DuckDBStore(":memory:");
+    await store.initialize();
+  });
+
+  afterEach(async () => {
+    await store.close();
+  });
+
+  it("falls back to listedTests when the store has no test history", async () => {
+    const sampled = await runSample({
+      store,
+      mode: "random",
+      count: 2,
+      seed: 42,
+      listedTests: [
+        {
+          suite: "third_party/git/t/t1300-config.sh",
+          testName: "t1300-config.sh",
+          taskId: "git-compat",
+        },
+        {
+          suite: "third_party/git/t/t3200-branch.sh",
+          testName: "t3200-branch.sh",
+          taskId: "git-compat",
+        },
+        {
+          suite: "third_party/git/t/t5302-pack-index.sh",
+          testName: "t5302-pack-index.sh",
+          taskId: "git-compat",
+        },
+      ],
+    });
+
+    expect(sampled).toHaveLength(2);
+    expect(sampled).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          suite: expect.stringMatching(/^third_party\/git\/t\/t\d+/),
+          is_new: true,
+          total_runs: 0,
+        }),
+      ]),
+    );
+  });
+});

--- a/tests/resolvers/glob.test.ts
+++ b/tests/resolvers/glob.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createResolver } from "../../src/cli/resolvers/index.js";
+import { GlobRuleResolver } from "../../src/cli/resolvers/glob.js";
+
+describe("GlobRuleResolver", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function writeConfig(content: string): string {
+    const dir = mkdtempSync(join(tmpdir(), "flaker-glob-resolver-"));
+    tempDirs.push(dir);
+    const configPath = join(dir, "affected-rules.toml");
+    writeFileSync(configPath, content);
+    return configPath;
+  }
+
+  it("maps changed files to suites through glob rules", () => {
+    const resolver = new GlobRuleResolver(
+      writeConfig(`
+[[rules]]
+changed = ["src/cmd/bit/merge*.mbt", "src/lib/merge*.mbt"]
+select = ["third_party/git/t/t64*.sh", "third_party/git/t/t760*.sh"]
+reason = "command:merge"
+`),
+    );
+
+    const result = resolver.resolve(
+      ["src/cmd/bit/merge.mbt"],
+      [
+        "third_party/git/t/t6400-merge-df.sh",
+        "third_party/git/t/t7600-merge.sh",
+        "third_party/git/t/t7508-status.sh",
+      ],
+    );
+
+    expect(result).toEqual([
+      "third_party/git/t/t6400-merge-df.sh",
+      "third_party/git/t/t7600-merge.sh",
+    ]);
+  });
+
+  it("dedupes suites selected by multiple matching rules", () => {
+    const configPath = writeConfig(`
+[[rules]]
+changed = ["src/cmd/bit/fetch*.mbt"]
+select = ["third_party/git/t/t55*.sh"]
+reason = "command:fetch"
+
+[[rules]]
+changed = ["src/protocol/**"]
+select = ["third_party/git/t/t55*.sh", "third_party/git/t/t57*.sh"]
+reason = "protocol"
+`);
+    const resolver = createResolver(
+      { resolver: "glob", config: configPath },
+      process.cwd(),
+    );
+
+    const result = resolver.resolve(
+      ["src/cmd/bit/fetch.mbt", "src/protocol/transport.mbt"],
+      [
+        "third_party/git/t/t5500-fetch-pack.sh",
+        "third_party/git/t/t5510-fetch.sh",
+        "third_party/git/t/t5700-protocol-v1.sh",
+      ],
+    );
+
+    expect(result).toEqual([
+      "third_party/git/t/t5500-fetch-pack.sh",
+      "third_party/git/t/t5510-fetch.sh",
+      "third_party/git/t/t5700-protocol-v1.sh",
+    ]);
+  });
+
+  it("explains selected suites, reasons, and unmatched files", async () => {
+    const resolver = new GlobRuleResolver(
+      writeConfig(`
+[[rules]]
+changed = ["src/cmd/bit/config*.mbt", "src/lib/remote_config*.mbt"]
+select = ["third_party/git/t/t1300-config.sh"]
+reason = "command:config"
+
+[[rules]]
+changed = ["src/cmd/bit/remote*.mbt", "src/lib/remote_*.mbt"]
+select = ["third_party/git/t/t55*.sh", "third_party/git/t/t57*.sh"]
+reason = "command:remote"
+`),
+    );
+
+    const report = await resolver.explain?.(
+      [
+        "src/cmd/bit/config.mbt",
+        "src/cmd/bit/config_wbtest.mbt",
+        "src/misc/readme.md",
+      ],
+      [
+        {
+          spec: "third_party/git/t/t1300-config.sh",
+          taskId: "git-compat",
+          filter: null,
+        },
+        {
+          spec: "third_party/git/t/t5505-remote.sh",
+          taskId: "git-compat",
+          filter: null,
+        },
+      ],
+    );
+
+    expect(report?.matched).toHaveLength(1);
+    expect(report?.selected).toEqual([
+      expect.objectContaining({
+        spec: "third_party/git/t/t1300-config.sh",
+        taskId: "git-compat",
+        direct: true,
+        matchedPaths: [
+          "src/cmd/bit/config.mbt",
+          "src/cmd/bit/config_wbtest.mbt",
+        ],
+        matchReasons: ["command:config"],
+      }),
+    ]);
+    expect(report?.unmatched).toEqual(["src/misc/readme.md"]);
+  });
+});


### PR DESCRIPTION
## Summary
- allow `flaker run` to use `affected` and `hybrid` strategies with `--changed`
- reuse the same resolver path as `sample` so local runs can target changed areas
- fall back to runner `listedTests` when there is no stored history yet

## Testing
- pnpm vitest run tests/commands/run.test.ts
- pnpm vitest run tests/commands/sample.test.ts tests/commands/run.test.ts
- pnpm -s tsc --noEmit
- pnpm vitest run