### PR TITLE
Harden sampling CLI and cold start flow

### DIFF
--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -1,5 +1,6 @@
 import type { MetricStore } from "../storage/types.js";
 import { runSample } from "./sample.js";
+import type { SamplingMode } from "./sampling-options.js";
 import type { QuarantineManifestEntry } from "../quarantine-manifest.js";
 import type { DependencyResolver } from "../resolvers/types.js";
 import {
@@ -15,7 +16,7 @@ export interface RunOpts {
   runner: RunnerAdapter;
   count?: number;
   percentage?: number;
-  mode: "random" | "weighted" | "affected" | "hybrid";
+  mode: SamplingMode;
   seed?: number;
   resolver?: DependencyResolver;
   changedFiles?: string[];

--- a/src/cli/commands/sample.ts
+++ b/src/cli/commands/sample.ts
@@ -2,6 +2,7 @@ import type { MetricStore } from "../storage/types.js";
 import type { TestMeta, MetriciCore } from "../core/loader.js";
 import type { DependencyResolver } from "../resolvers/types.js";
 import type { TestId } from "../runners/types.js";
+import type { SamplingMode } from "./sampling-options.js";
 import { loadCore } from "../core/loader.js";
 import { createStableTestId } from "../identity.js";
 import {
@@ -13,7 +14,7 @@ export interface SampleOpts {
   store: MetricStore;
   count?: number;
   percentage?: number;
-  mode: "random" | "weighted" | "affected" | "hybrid";
+  mode: SamplingMode;
   seed?: number;
   resolver?: DependencyResolver;
   changedFiles?: string[];

--- a/src/cli/commands/sampling-options.ts
+++ b/src/cli/commands/sampling-options.ts
@@ -1,0 +1,47 @@
+export const SAMPLING_MODES = [
+  "random",
+  "weighted",
+  "affected",
+  "hybrid",
+] as const;
+
+export type SamplingMode = (typeof SAMPLING_MODES)[number];
+
+export function parseSamplingMode(raw: string): SamplingMode {
+  if (isSamplingMode(raw)) {
+    return raw;
+  }
+  throw new Error(
+    `Unknown sampling strategy: ${raw}. Expected one of: ${SAMPLING_MODES.join(", ")}`,
+  );
+}
+
+export function parseSampleCount(raw?: string): number | undefined {
+  return parseOptionalInteger(raw, "--count");
+}
+
+export function parseSamplePercentage(raw?: string): number | undefined {
+  if (raw == null) return undefined;
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value < 0 || value > 100) {
+    throw new Error(
+      `Invalid --percentage value: ${raw}. Expected a number between 0 and 100.`,
+    );
+  }
+  return value;
+}
+
+function parseOptionalInteger(raw: string | undefined, flag: string): number | undefined {
+  if (raw == null) return undefined;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(
+      `Invalid ${flag} value: ${raw}. Expected a non-negative integer.`,
+    );
+  }
+  return value;
+}
+
+function isSamplingMode(raw: string): raw is SamplingMode {
+  return SAMPLING_MODES.includes(raw as SamplingMode);
+}

--- a/src/cli/core/loader.ts
+++ b/src/cli/core/loader.ts
@@ -94,6 +94,10 @@ function detectFlaky(input: DetectInput): DetectOutput {
 }
 
 function sampleRandom(meta: TestMeta[], count: number, seed: number): TestMeta[] {
+  const actualCount = clampSampleCount(count, meta.length);
+  if (actualCount === 0) {
+    return [];
+  }
   const arr = [...meta];
   let s = seed >>> 0;
 
@@ -105,15 +109,19 @@ function sampleRandom(meta: TestMeta[], count: number, seed: number): TestMeta[]
     [arr[i], arr[j]] = [arr[j], arr[i]];
   }
 
-  return arr.slice(0, count);
+  return arr.slice(0, actualCount);
 }
 
 function sampleWeighted(meta: TestMeta[], count: number, seed: number): TestMeta[] {
+  const actualCount = clampSampleCount(count, meta.length);
+  if (actualCount === 0) {
+    return [];
+  }
   const remaining = [...meta];
   const result: TestMeta[] = [];
   let s = seed >>> 0;
 
-  const n = Math.min(count, remaining.length);
+  const n = actualCount;
   for (let picked = 0; picked < n; picked++) {
     // Compute weights
     const weights = remaining.map((m) => 1.0 + m.flaky_rate);
@@ -141,6 +149,10 @@ function sampleWeighted(meta: TestMeta[], count: number, seed: number): TestMeta
 }
 
 function sampleHybrid(meta: TestMeta[], affectedSuites: string[], count: number, seed: number): TestMeta[] {
+  const actualCount = clampSampleCount(count, meta.length);
+  if (actualCount === 0) {
+    return [];
+  }
   const affectedSet = new Set(affectedSuites);
   const selected: TestMeta[] = [];
   const used = new Set<number>();
@@ -152,12 +164,19 @@ function sampleHybrid(meta: TestMeta[], affectedSuites: string[], count: number,
   // Priority 3: new
   meta.forEach((m, i) => { if (m.is_new && !used.has(i)) { selected.push(m); used.add(i); } });
   // Priority 4: weighted random for remaining
-  if (selected.length < count) {
+  if (selected.length < actualCount) {
     const remaining = meta.filter((_, i) => !used.has(i));
-    const extra = sampleWeighted(remaining, count - selected.length, seed);
+    const extra = sampleWeighted(remaining, actualCount - selected.length, seed);
     selected.push(...extra);
   }
-  return selected.slice(0, count);
+  return selected.slice(0, actualCount);
+}
+
+function clampSampleCount(count: number, total: number): number {
+  if (!Number.isFinite(count)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(Math.trunc(count), total));
 }
 
 // MoonBit JS backend types

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -12,6 +12,11 @@ import {
 import { runFlaky, formatFlakyTable, runFlakyTrend, formatFlakyTrend, runTrueFlaky, formatTrueFlakyTable } from "./commands/flaky.js";
 import { runSample } from "./commands/sample.js";
 import { runTests } from "./commands/run.js";
+import {
+  parseSampleCount,
+  parseSamplePercentage,
+  parseSamplingMode,
+} from "./commands/sampling-options.js";
 import { ActrunRunner } from "./runners/actrun.js";
 import { runBisect } from "./commands/bisect.js";
 import { runImport } from "./commands/import.js";
@@ -307,14 +312,11 @@ program
 
       try {
         const changedFiles = parseChangedFiles(opts.changed);
-        const mode = opts.strategy as "random" | "weighted" | "affected" | "hybrid";
+        const mode = parseSamplingMode(opts.strategy);
         const manifest = opts.skipQuarantined
           ? loadQuarantineManifestIfExists({ cwd: process.cwd() })
           : null;
-        const listedTests =
-          opts.skipQuarantined && manifest
-            ? await listRunnerTests(process.cwd(), config.runner)
-            : [];
+        const listedTests = await listRunnerTests(process.cwd(), config.runner);
 
         // Create resolver from config for affected/hybrid
         let resolver;
@@ -325,8 +327,8 @@ program
         const sampled = await runSample({
           store,
           mode,
-          count: opts.count ? Number(opts.count) : undefined,
-          percentage: opts.percentage ? Number(opts.percentage) : undefined,
+          count: parseSampleCount(opts.count),
+          percentage: parseSamplePercentage(opts.percentage),
           skipQuarantined: opts.skipQuarantined,
           resolver,
           changedFiles,
@@ -362,7 +364,7 @@ program
 
       try {
         const changedFiles = parseChangedFiles(opts.changed);
-        const mode = opts.strategy as "random" | "weighted" | "affected" | "hybrid";
+        const mode = parseSamplingMode(opts.strategy);
         const manifest = opts.skipQuarantined
           ? loadQuarantineManifestIfExists({ cwd })
           : null;
@@ -428,8 +430,8 @@ program
           store,
           runner: createRunner(config.runner),
           mode,
-          count: opts.count ? Number(opts.count) : undefined,
-          percentage: opts.percentage ? Number(opts.percentage) : undefined,
+          count: parseSampleCount(opts.count),
+          percentage: parseSamplePercentage(opts.percentage),
           resolver,
           changedFiles,
           skipQuarantined: opts.skipQuarantined,

--- a/src/cli/storage/duckdb.ts
+++ b/src/cli/storage/duckdb.ts
@@ -1,3 +1,5 @@
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
 import { SCHEMA_DDL, FLAKY_QUERY } from "./schema.js";
 import { createStableTestId, resolveTestIdentity } from "../identity.js";
 import type {
@@ -28,6 +30,9 @@ export class DuckDBStore implements MetricStore {
       duckdb = await this.loadDuckDBModule();
     } catch (error) {
       throw this.buildDuckDBLoadError(error);
+    }
+    if (this.dbPath !== ":memory:") {
+      mkdirSync(dirname(this.dbPath), { recursive: true });
     }
     this.db = await new Promise<DuckDBDatabase>((resolve, reject) => {
       try {

--- a/src/core/src/main/pkg.generated.mbti
+++ b/src/core/src/main/pkg.generated.mbti
@@ -1,8 +1,12 @@
 // Generated using `moon info`, DON'T EDIT IT
-package "mizchi/metrici_core/src/main"
+package "mizchi/flaker/src/main"
 
 // Values
 pub fn detect_flaky_json(String) -> String
+
+pub fn resolve_affected_json(String, String) -> String
+
+pub fn sample_hybrid_json(String, String, Int, Int) -> String
 
 pub fn sample_random_json(String, Int, Int) -> String
 

--- a/src/core/src/sampler/sampler.mbt
+++ b/src/core/src/sampler/sampler.mbt
@@ -1,4 +1,15 @@
 ///|
+fn clamp_count(count : Int, total : Int) -> Int {
+  if count <= 0 {
+    0
+  } else if count > total {
+    total
+  } else {
+    count
+  }
+}
+
+///|
 fn lcg_next(state : UInt64) -> UInt64 {
   state * 6364136223846793005UL + 1442695040888963407UL
 }
@@ -13,7 +24,10 @@ pub fn sample_random(
   if n == 0 {
     return []
   }
-  let actual_count = if count > n { n } else { count }
+  let actual_count = clamp_count(count, n)
+  if actual_count == 0 {
+    return []
+  }
   // Copy array for Fisher-Yates shuffle
   let arr = Array::makei(n, fn(i) { meta[i] })
   let mut state = seed
@@ -36,7 +50,10 @@ pub fn sample_weighted(
   if n == 0 {
     return []
   }
-  let actual_count = if count > n { n } else { count }
+  let actual_count = clamp_count(count, n)
+  if actual_count == 0 {
+    return []
+  }
   // Build weights
   let weights = Array::makei(n, fn(i) { 1.0 + meta[i].flaky_rate })
   let selected : Array[@types.TestMeta] = []
@@ -88,6 +105,10 @@ pub fn sample_hybrid(
   count~ : Int,
   seed~ : UInt64
 ) -> Array[@types.TestMeta] {
+  let actual_count = clamp_count(count, meta.length())
+  if actual_count == 0 {
+    return []
+  }
   let affected_set : Map[String, Bool] = {}
   for s in affected_suites {
     affected_set.set(s, true)
@@ -121,22 +142,22 @@ pub fn sample_hybrid(
   }
 
   // Priority 4: fill remaining with weighted random
-  if selected.length() < count {
+  if selected.length() < actual_count {
     let remaining : Array[@types.TestMeta] = []
     for i, m in meta {
       if !used.contains(i) {
         remaining.push(m)
       }
     }
-    let needed = count - selected.length()
+    let needed = actual_count - selected.length()
     let extra = sample_weighted(remaining, count=needed, seed~)
     for m in extra {
       selected.push(m)
     }
   }
 
-  if selected.length() > count {
-    Array::makei(count, fn(i) { selected[i] })
+  if selected.length() > actual_count {
+    Array::makei(actual_count, fn(i) { selected[i] })
   } else {
     selected
   }

--- a/tests/commands/sample.test.ts
+++ b/tests/commands/sample.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { DuckDBStore } from "../../src/cli/storage/duckdb.js";
 import type { TestResult, WorkflowRun } from "../../src/cli/storage/types.js";
 import { runSample } from "../../src/cli/commands/sample.js";
+import type { DependencyResolver } from "../../src/cli/resolvers/types.js";
 
 describe("sample command", () => {
   let store: DuckDBStore;
@@ -163,6 +164,96 @@ describe("sample command without history", () => {
           suite: expect.stringMatching(/^third_party\/git\/t\/t\d+/),
           is_new: true,
           total_runs: 0,
+        }),
+      ]),
+    );
+  });
+
+  it("supports affected mode from listedTests on cold start", async () => {
+    const resolver: DependencyResolver = {
+      resolve(changedFiles, allTestFiles) {
+        expect(changedFiles).toEqual(["src/cmd/bit/verify_tag.mbt"]);
+        expect(allTestFiles).toEqual([
+          "third_party/git/t/t7004-tag.sh",
+          "third_party/git/t/t7030-verify-tag.sh",
+          "third_party/git/t/t7031-verify-tag-signed-ssh.sh",
+        ]);
+        return [
+          "third_party/git/t/t7004-tag.sh",
+          "third_party/git/t/t7030-verify-tag.sh",
+        ];
+      },
+    };
+
+    const sampled = await runSample({
+      store,
+      mode: "affected",
+      resolver,
+      changedFiles: ["src/cmd/bit/verify_tag.mbt"],
+      listedTests: [
+        {
+          suite: "third_party/git/t/t7004-tag.sh",
+          testName: "t7004-tag.sh",
+          taskId: "git-compat",
+        },
+        {
+          suite: "third_party/git/t/t7030-verify-tag.sh",
+          testName: "t7030-verify-tag.sh",
+          taskId: "git-compat",
+        },
+        {
+          suite: "third_party/git/t/t7031-verify-tag-signed-ssh.sh",
+          testName: "t7031-verify-tag-signed-ssh.sh",
+          taskId: "git-compat",
+        },
+      ],
+    });
+
+    expect(sampled).toHaveLength(2);
+    expect(sampled.map((entry) => entry.suite)).toEqual([
+      "third_party/git/t/t7004-tag.sh",
+      "third_party/git/t/t7030-verify-tag.sh",
+    ]);
+  });
+
+  it("supports hybrid mode from listedTests on cold start", async () => {
+    const resolver: DependencyResolver = {
+      resolve() {
+        return ["third_party/git/t/t7030-verify-tag.sh"];
+      },
+    };
+
+    const sampled = await runSample({
+      store,
+      mode: "hybrid",
+      count: 2,
+      seed: 7,
+      resolver,
+      changedFiles: ["src/cmd/bit/verify_tag.mbt"],
+      listedTests: [
+        {
+          suite: "third_party/git/t/t7004-tag.sh",
+          testName: "t7004-tag.sh",
+          taskId: "git-compat",
+        },
+        {
+          suite: "third_party/git/t/t7030-verify-tag.sh",
+          testName: "t7030-verify-tag.sh",
+          taskId: "git-compat",
+        },
+        {
+          suite: "third_party/git/t/t7031-verify-tag-signed-ssh.sh",
+          testName: "t7031-verify-tag-signed-ssh.sh",
+          taskId: "git-compat",
+        },
+      ],
+    });
+
+    expect(sampled).toHaveLength(2);
+    expect(sampled).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          suite: "third_party/git/t/t7030-verify-tag.sh",
         }),
       ]),
     );

--- a/tests/commands/sampling-options.test.ts
+++ b/tests/commands/sampling-options.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseSampleCount,
+  parseSamplePercentage,
+  parseSamplingMode,
+} from "../../src/cli/commands/sampling-options.js";
+
+describe("sampling options", () => {
+  it("accepts supported sampling modes", () => {
+    expect(parseSamplingMode("affected")).toBe("affected");
+    expect(parseSamplingMode("hybrid")).toBe("hybrid");
+  });
+
+  it("rejects unknown sampling modes instead of falling back silently", () => {
+    expect(() => parseSamplingMode("strategy=affected")).toThrowError(
+      "Unknown sampling strategy: strategy=affected. Expected one of: random, weighted, affected, hybrid",
+    );
+  });
+
+  it("parses count as a non-negative integer", () => {
+    expect(parseSampleCount("25")).toBe(25);
+    expect(() => parseSampleCount("count=25")).toThrowError(
+      "Invalid --count value: count=25. Expected a non-negative integer.",
+    );
+  });
+
+  it("parses percentage within 0-100", () => {
+    expect(parseSamplePercentage("12.5")).toBe(12.5);
+    expect(() => parseSamplePercentage("150")).toThrowError(
+      "Invalid --percentage value: 150. Expected a number between 0 and 100.",
+    );
+  });
+});

--- a/tests/core/loader.test.ts
+++ b/tests/core/loader.test.ts
@@ -54,6 +54,25 @@ describe("loadCore", () => {
     expect(result2).toEqual(result);
   });
 
+  it("clamps negative sample counts to zero", async () => {
+    const core = await loadCore();
+    const meta: TestMeta[] = Array.from({ length: 3 }, (_, i) => ({
+      suite: "s",
+      test_name: `t${i}`,
+      flaky_rate: 0,
+      total_runs: 1,
+      fail_count: 0,
+      last_run_at: "2026-01-01T00:00:00Z",
+      avg_duration_ms: 100,
+      previously_failed: false,
+      is_new: false,
+    }));
+
+    expect(core.sampleRandom(meta, -1, 42)).toEqual([]);
+    expect(core.sampleWeighted(meta, -1, 42)).toEqual([]);
+    expect(core.sampleHybrid(meta, ["s"], -1, 42)).toEqual([]);
+  });
+
   it("sampleWeighted prefers flaky tests", async () => {
     const core = await loadCore();
     const meta: TestMeta[] = [

--- a/tests/storage/duckdb.test.ts
+++ b/tests/storage/duckdb.test.ts
@@ -1,3 +1,6 @@
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { DuckDBStore } from "../../src/cli/storage/duckdb.js";
 import type {
@@ -314,5 +317,21 @@ describe("DuckDBStore", () => {
     const rows = await store.raw<{ answer: number }>("SELECT 42 AS answer");
     expect(rows).toHaveLength(1);
     expect(rows[0].answer).toBe(42);
+  });
+
+  it("creates parent directories for file-backed database paths", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "flaker-duckdb-"));
+    const dbPath = join(tempDir, "nested", ".flaker", "data.duckdb");
+    const fileStore = new DuckDBStore(dbPath);
+
+    try {
+      await fileStore.initialize();
+      const rows = await fileStore.raw<{ answer: number }>("SELECT 1 AS answer");
+      expect(rows[0].answer).toBe(1);
+      expect(existsSync(join(tempDir, "nested", ".flaker"))).toBe(true);
+    } finally {
+      await fileStore.close();
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- validate sampling strategy/count/percentage inputs so malformed just/task arguments fail fast instead of silently falling back
- fall back to runner-listed tests on cold start and create the storage parent directory automatically
- clamp sample counts in both TS and MoonBit samplers to avoid invalid array length crashes

## Testing
- pnpm vitest run
- pnpm -s tsc --noEmit
- moon build --target js
- moon info src/main --target js
- `FLAKER_CMD='...tsx .../main.ts' just flaker-git-compat-sample affected 25 src/cmd/bit/verify_tag.mbt`
