### PR TITLE
Add Playwright report core modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,6 @@ jobs:
         run: >
           pnpm exec vitest run
           tests/adapters/playwright.test.ts
-          tests/reporting/playwright-report-contract.test.ts
-          tests/reporting/playwright-report-summary.test.ts
-          tests/reporting/playwright-report-diff.test.ts
+          tests/reporting/*.test.ts
           tests/commands/collect.test.ts
           tests/storage/duckdb.test.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - main
+      - "codex/**"
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Test
+        run: >
+          pnpm exec vitest run
+          tests/adapters/playwright.test.ts
+          tests/reporting/playwright-report-contract.test.ts
+          tests/reporting/playwright-report-summary.test.ts
+          tests/reporting/playwright-report-diff.test.ts
+          tests/commands/collect.test.ts
+          tests/storage/duckdb.test.ts

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "packageManager": "pnpm@10.27.0",
   "pnpm": {
     "onlyBuiltDependencies": [
-      "duckdb"
+      "duckdb",
+      "esbuild"
     ]
   },
   "dependencies": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,1 +1,5 @@
-onlyBuiltDependencies: duckdb
+strictDepBuilds: true
+
+allowBuilds:
+  duckdb: true
+  esbuild: true

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -28,7 +28,7 @@ const DEFAULT_CONFIG: FlakerConfig = {
   flaky: { window_days: 14, detection_threshold: 0.1 },
 };
 
-function deepMerge<T extends Record<string, unknown>>(
+function deepMerge<T>(
   target: T,
   source: Record<string, unknown>,
 ): T {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -75,7 +75,19 @@ program
           created: `>=${created.toISOString().split("T")[0]}`,
           per_page: 100,
         });
-        return response.data;
+        return {
+          total_count: response.data.total_count,
+          workflow_runs: response.data.workflow_runs.map((run) => ({
+            id: run.id,
+            head_branch: run.head_branch ?? "",
+            head_sha: run.head_sha,
+            event: run.event,
+            conclusion: run.conclusion ?? "unknown",
+            created_at: run.created_at,
+            run_started_at: run.run_started_at ?? run.created_at,
+            updated_at: run.updated_at,
+          })),
+        };
       },
       async listArtifacts(runId: number) {
         const response = await octokit.actions.listWorkflowRunArtifacts({

--- a/src/cli/reporting/flaker-batch-summary-core.ts
+++ b/src/cli/reporting/flaker-batch-summary-core.ts
@@ -1,0 +1,113 @@
+import type { PlaywrightSummary } from "./playwright-report-contract.js";
+import type { FlakerTaskSummaryReport } from "./flaker-task-summary-contract.js";
+
+export interface FlakerBatchTaskSummary {
+  taskId: string;
+  totalTests: number;
+  failed: number;
+  flaky: number;
+  skipped: number;
+  healthScore?: number;
+  newFlaky?: number;
+  urgentFixes?: number;
+  status: "ok" | "failed" | "missing";
+}
+
+export interface FlakerBatchSummary {
+  schemaVersion: 1;
+  generatedAt: string;
+  taskCount: number;
+  failedTasks: number;
+  flakyTasks: number;
+  healthyTasks: number;
+  totalTests: number;
+  tasks: FlakerBatchTaskSummary[];
+}
+
+export interface FlakerBatchSummaryInputs {
+  playwrightSummaries: Map<string, PlaywrightSummary>;
+  flakerSummaries: Map<string, FlakerTaskSummaryReport>;
+}
+
+function escapeCell(value: string): string {
+  return value.replace(/\|/g, "\\|");
+}
+
+export function buildFlakerBatchSummary(
+  inputs: FlakerBatchSummaryInputs,
+): FlakerBatchSummary {
+  const taskIds = [
+    ...new Set([
+      ...inputs.playwrightSummaries.keys(),
+      ...inputs.flakerSummaries.keys(),
+    ]),
+  ].sort();
+
+  const tasks: FlakerBatchTaskSummary[] = taskIds.map((taskId) => {
+    const playwrightSummary = inputs.playwrightSummaries.get(taskId);
+    const flakerSummary = inputs.flakerSummaries.get(taskId);
+
+    if (!playwrightSummary) {
+      return {
+        taskId,
+        totalTests: 0,
+        failed: 0,
+        flaky: 0,
+        skipped: 0,
+        status: "missing",
+      };
+    }
+
+    const failed =
+      playwrightSummary.totals.failed
+      + playwrightSummary.totals.timedout
+      + playwrightSummary.totals.interrupted;
+
+    return {
+      taskId,
+      totalTests: playwrightSummary.totals.total,
+      failed,
+      flaky: playwrightSummary.totals.flaky,
+      skipped: playwrightSummary.totals.skipped,
+      healthScore: flakerSummary?.eval.healthScore,
+      newFlaky: flakerSummary?.eval.resolution.newFlaky,
+      urgentFixes: flakerSummary?.reason.summary.urgentFixes,
+      status: failed > 0 ? "failed" : "ok",
+    };
+  });
+
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    taskCount: tasks.length,
+    failedTasks: tasks.filter((task) => task.status === "failed").length,
+    flakyTasks: tasks.filter((task) => task.flaky > 0).length,
+    healthyTasks: tasks.filter((task) => (task.healthScore ?? 0) >= 80).length,
+    totalTests: tasks.reduce((sum, task) => sum + task.totalTests, 0),
+    tasks,
+  };
+}
+
+export function renderFlakerBatchSummaryMarkdown(
+  summary: FlakerBatchSummary,
+): string {
+  const lines: string[] = [];
+  lines.push("# Flaker Daily Batch Summary");
+  lines.push("");
+  lines.push("| Metric | Value |");
+  lines.push("| --- | --- |");
+  lines.push(`| Tasks | ${summary.taskCount} |`);
+  lines.push(`| Failed tasks | ${summary.failedTasks} |`);
+  lines.push(`| Flaky tasks | ${summary.flakyTasks} |`);
+  lines.push(`| Healthy tasks | ${summary.healthyTasks} |`);
+  lines.push(`| Total tests | ${summary.totalTests} |`);
+  lines.push("");
+  lines.push("| Task | Status | Total | Failed | Flaky | Health | New flaky | Urgent fixes |");
+  lines.push("| --- | --- | --- | --- | --- | --- | --- | --- |");
+  for (const task of summary.tasks) {
+    lines.push(
+      `| ${escapeCell(task.taskId)} | ${task.status} | ${task.totalTests} | ${task.failed} | ${task.flaky} | ${task.healthScore ?? "N/A"} | ${task.newFlaky ?? "N/A"} | ${task.urgentFixes ?? "N/A"} |`,
+    );
+  }
+  return `${lines.join("\n")}\n`;
+}

--- a/src/cli/reporting/flaker-issue-contract.ts
+++ b/src/cli/reporting/flaker-issue-contract.ts
@@ -1,0 +1,7 @@
+export interface FlakerIssue {
+  severity: "error" | "warning";
+  code: string;
+  message: string;
+  taskId?: string;
+  spec?: string;
+}

--- a/src/cli/reporting/flaker-quarantine-contract.ts
+++ b/src/cli/reporting/flaker-quarantine-contract.ts
@@ -1,0 +1,41 @@
+import type { FlakerIssue } from "./flaker-issue-contract.js";
+
+export type FlakerQuarantineMode = "skip" | "allow_flaky" | "allow_failure";
+export type FlakerQuarantineScope = "environment" | "flaky" | "expected_failure";
+export type FlakerQuarantineExpiryStatus = "active" | "expires-soon" | "expired" | "invalid";
+
+export interface FlakerQuarantineEntry {
+  id: string;
+  taskId: string;
+  spec: string;
+  titlePattern: string;
+  mode: FlakerQuarantineMode;
+  scope: FlakerQuarantineScope;
+  owner: string;
+  reason: string;
+  condition: string;
+  introducedAt: string;
+  expiresAt: string;
+  trackingIssue?: string;
+}
+
+export interface FlakerQuarantineConfig {
+  schemaVersion: 1;
+  entries: FlakerQuarantineEntry[];
+}
+
+export interface FlakerResolvedQuarantineEntry extends FlakerQuarantineEntry {
+  expiryStatus: FlakerQuarantineExpiryStatus;
+  daysUntilExpiry: number | null;
+}
+
+export interface FlakerQuarantineSummary {
+  schemaVersion: 1;
+  generatedAt: string;
+  entryCount: number;
+  modeCounts: Record<FlakerQuarantineMode, number>;
+  scopeCounts: Record<FlakerQuarantineScope, number>;
+  entries: FlakerResolvedQuarantineEntry[];
+  errors: FlakerIssue[];
+  warnings: FlakerIssue[];
+}

--- a/src/cli/reporting/flaker-quarantine-expiry.ts
+++ b/src/cli/reporting/flaker-quarantine-expiry.ts
@@ -1,0 +1,48 @@
+import type { FlakerQuarantineExpiryStatus } from "./flaker-quarantine-contract.js";
+
+export interface QuarantineExpiry {
+  status: FlakerQuarantineExpiryStatus;
+  daysUntilExpiry: number | null;
+}
+
+export function parseDateOnly(value: string): Date | null {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return null;
+  }
+  const parsed = new Date(`${value}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+  return parsed.toISOString().slice(0, 10) === value ? parsed : null;
+}
+
+export function normalizeToUtcMidnight(value: Date): Date {
+  return new Date(Date.UTC(value.getUTCFullYear(), value.getUTCMonth(), value.getUTCDate()));
+}
+
+export function diffInDays(start: Date, end: Date): number {
+  return Math.floor((end.getTime() - start.getTime()) / 86_400_000);
+}
+
+export function classifyQuarantineExpiry(
+  now: Date,
+  expiresAt: Date | null,
+  expiresSoonDays: number,
+): QuarantineExpiry {
+  if (!expiresAt) {
+    return {
+      status: "invalid",
+      daysUntilExpiry: null,
+    };
+  }
+
+  const daysUntilExpiry = diffInDays(now, expiresAt);
+  return {
+    status: daysUntilExpiry < 0
+      ? "expired"
+      : daysUntilExpiry <= expiresSoonDays
+      ? "expires-soon"
+      : "active",
+    daysUntilExpiry,
+  };
+}

--- a/src/cli/reporting/flaker-quarantine-match.ts
+++ b/src/cli/reporting/flaker-quarantine-match.ts
@@ -1,0 +1,34 @@
+import type {
+  FlakerQuarantineConfig,
+  FlakerQuarantineEntry,
+  FlakerQuarantineMode,
+} from "./flaker-quarantine-contract.js";
+
+export interface QuarantineLookup {
+  taskId: string;
+  spec: string;
+  title: string;
+  mode?: FlakerQuarantineMode;
+}
+
+export function compileTitlePattern(pattern: string): RegExp | null {
+  try {
+    return new RegExp(pattern);
+  } catch {
+    return null;
+  }
+}
+
+export function findMatchingQuarantine(
+  config: FlakerQuarantineConfig,
+  lookup: QuarantineLookup,
+): FlakerQuarantineEntry | undefined {
+  return config.entries.find((entry) => {
+    if (entry.taskId !== lookup.taskId) return false;
+    if (entry.spec !== lookup.spec) return false;
+    if (lookup.mode && entry.mode !== lookup.mode) return false;
+    const titlePattern = compileTitlePattern(entry.titlePattern);
+    if (!titlePattern) return false;
+    return titlePattern.test(lookup.title);
+  });
+}

--- a/src/cli/reporting/flaker-quarantine-parser.ts
+++ b/src/cli/reporting/flaker-quarantine-parser.ts
@@ -1,0 +1,88 @@
+import path from "node:path";
+import type {
+  FlakerQuarantineConfig,
+  FlakerQuarantineMode,
+  FlakerQuarantineScope,
+} from "./flaker-quarantine-contract.js";
+
+function expectRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function expectString(record: Record<string, unknown>, key: string, label: string): string {
+  const value = record[key];
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${label}.${key} must be a non-empty string`);
+  }
+  return value.trim();
+}
+
+function expectEnum<T extends string>(
+  value: string,
+  allowed: readonly T[],
+  label: string,
+): T {
+  if ((allowed as readonly string[]).includes(value)) {
+    return value as T;
+  }
+  throw new Error(`${label} must be one of: ${allowed.join(", ")}`);
+}
+
+function optionalString(
+  record: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const value = record[key];
+  if (value === undefined || value === null || value === "") {
+    return undefined;
+  }
+  if (typeof value !== "string") {
+    throw new Error(`entry.${key} must be a string when provided`);
+  }
+  return value.trim();
+}
+
+export function parseFlakerQuarantine(source: string): FlakerQuarantineConfig {
+  const raw = JSON.parse(source) as unknown;
+  const record = expectRecord(raw, "quarantine");
+  if (record.schemaVersion !== 1) {
+    throw new Error("quarantine.schemaVersion must be 1");
+  }
+  if (!Array.isArray(record.entries)) {
+    throw new Error("quarantine.entries must be an array");
+  }
+
+  const entries = record.entries.map((entry, index) => {
+    const item = expectRecord(entry, `entry[${index}]`);
+    return {
+      id: expectString(item, "id", "entry"),
+      taskId: expectString(item, "taskId", "entry"),
+      spec: expectString(item, "spec", "entry").split(path.sep).join("/"),
+      titlePattern: expectString(item, "titlePattern", "entry"),
+      mode: expectEnum(
+        expectString(item, "mode", "entry"),
+        ["skip", "allow_flaky", "allow_failure"] as const satisfies readonly FlakerQuarantineMode[],
+        "entry.mode",
+      ),
+      scope: expectEnum(
+        expectString(item, "scope", "entry"),
+        ["environment", "flaky", "expected_failure"] as const satisfies readonly FlakerQuarantineScope[],
+        "entry.scope",
+      ),
+      owner: expectString(item, "owner", "entry"),
+      reason: expectString(item, "reason", "entry"),
+      condition: expectString(item, "condition", "entry"),
+      introducedAt: expectString(item, "introducedAt", "entry"),
+      expiresAt: expectString(item, "expiresAt", "entry"),
+      trackingIssue: optionalString(item, "trackingIssue"),
+    };
+  });
+
+  return {
+    schemaVersion: 1,
+    entries,
+  };
+}

--- a/src/cli/reporting/flaker-quarantine-report.ts
+++ b/src/cli/reporting/flaker-quarantine-report.ts
@@ -1,0 +1,57 @@
+import type { FlakerQuarantineSummary } from "./flaker-quarantine-contract.js";
+
+function escapeMarkdownCell(value: string): string {
+  return value.replace(/\|/g, "\\|");
+}
+
+export function renderQuarantineMarkdown(summary: FlakerQuarantineSummary): string {
+  const lines: string[] = [];
+  lines.push("# Flaker Quarantine Summary");
+  lines.push("");
+  lines.push("| Metric | Value |");
+  lines.push("| --- | --- |");
+  lines.push(`| Entries | ${summary.entryCount} |`);
+  lines.push(`| Errors | ${summary.errors.length} |`);
+  lines.push(`| Warnings | ${summary.warnings.length} |`);
+  lines.push(`| Skip | ${summary.modeCounts.skip} |`);
+  lines.push(`| Allow flaky | ${summary.modeCounts.allow_flaky} |`);
+  lines.push(`| Allow failure | ${summary.modeCounts.allow_failure} |`);
+  lines.push(`| Environment | ${summary.scopeCounts.environment} |`);
+  lines.push(`| Flaky | ${summary.scopeCounts.flaky} |`);
+  lines.push(`| Expected failure | ${summary.scopeCounts.expected_failure} |`);
+
+  lines.push("");
+  lines.push("## Entries");
+  lines.push("");
+  lines.push("| Id | Task | Spec | Pattern | Mode | Scope | Owner | Expires | Status |");
+  lines.push("| --- | --- | --- | --- | --- | --- | --- | --- | --- |");
+  for (const entry of summary.entries) {
+    lines.push(
+      `| ${escapeMarkdownCell(entry.id)} | ${escapeMarkdownCell(entry.taskId)} | ${escapeMarkdownCell(entry.spec)} | ${escapeMarkdownCell(entry.titlePattern)} | ${entry.mode} | ${entry.scope} | ${escapeMarkdownCell(entry.owner)} | ${entry.expiresAt} | ${entry.expiryStatus} |`,
+    );
+  }
+
+  if (summary.errors.length > 0) {
+    lines.push("");
+    lines.push("## Errors");
+    lines.push("");
+    lines.push("| Code | Message |");
+    lines.push("| --- | --- |");
+    for (const issue of summary.errors) {
+      lines.push(`| ${escapeMarkdownCell(issue.code)} | ${escapeMarkdownCell(issue.message)} |`);
+    }
+  }
+
+  if (summary.warnings.length > 0) {
+    lines.push("");
+    lines.push("## Warnings");
+    lines.push("");
+    lines.push("| Code | Message |");
+    lines.push("| --- | --- |");
+    for (const issue of summary.warnings) {
+      lines.push(`| ${escapeMarkdownCell(issue.code)} | ${escapeMarkdownCell(issue.message)} |`);
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+}

--- a/src/cli/reporting/flaker-quarantine-summary-core.ts
+++ b/src/cli/reporting/flaker-quarantine-summary-core.ts
@@ -1,0 +1,191 @@
+import type { FlakerIssue } from "./flaker-issue-contract.js";
+import type {
+  FlakerQuarantineConfig,
+  FlakerQuarantineExpiryStatus,
+  FlakerQuarantineMode,
+  FlakerQuarantineScope,
+  FlakerQuarantineSummary,
+  FlakerResolvedQuarantineEntry,
+} from "./flaker-quarantine-contract.js";
+import {
+  classifyQuarantineExpiry,
+  normalizeToUtcMidnight,
+  parseDateOnly,
+} from "./flaker-quarantine-expiry.js";
+import { compileTitlePattern } from "./flaker-quarantine-match.js";
+
+const DEFAULT_EXPIRES_SOON_DAYS = 7;
+
+export interface FlakerQuarantineTaskOwnership {
+  id: string;
+  specs: string[];
+}
+
+export interface BuildFlakerQuarantineSummaryInputs {
+  quarantine: FlakerQuarantineConfig;
+  tasks: FlakerQuarantineTaskOwnership[];
+  existingSpecs: Set<string>;
+  now?: Date;
+  expiresSoonDays?: number;
+}
+
+function createIssue(issue: FlakerIssue): FlakerIssue {
+  return issue;
+}
+
+function buildModeCounts(): Record<FlakerQuarantineMode, number> {
+  return {
+    skip: 0,
+    allow_flaky: 0,
+    allow_failure: 0,
+  };
+}
+
+function buildScopeCounts(): Record<FlakerQuarantineScope, number> {
+  return {
+    environment: 0,
+    flaky: 0,
+    expected_failure: 0,
+  };
+}
+
+export function buildFlakerQuarantineSummary(
+  inputs: BuildFlakerQuarantineSummaryInputs,
+): FlakerQuarantineSummary {
+  const now = normalizeToUtcMidnight(inputs.now ?? new Date());
+  const expiresSoonDays = inputs.expiresSoonDays ?? DEFAULT_EXPIRES_SOON_DAYS;
+  const taskById = new Map(inputs.tasks.map((task) => [task.id, task]));
+  const errors: FlakerIssue[] = [];
+  const warnings: FlakerIssue[] = [];
+  const seenIds = new Set<string>();
+  const entries: FlakerResolvedQuarantineEntry[] = [];
+  const modeCounts = buildModeCounts();
+  const scopeCounts = buildScopeCounts();
+
+  for (const entry of inputs.quarantine.entries) {
+    modeCounts[entry.mode] += 1;
+    scopeCounts[entry.scope] += 1;
+
+    if (seenIds.has(entry.id)) {
+      errors.push(createIssue({
+        severity: "error",
+        code: "duplicate-quarantine-id",
+        message: `Duplicate quarantine id: ${entry.id}`,
+        taskId: entry.taskId,
+        spec: entry.spec,
+      }));
+    } else {
+      seenIds.add(entry.id);
+    }
+
+    const task = taskById.get(entry.taskId);
+    if (!task) {
+      errors.push(createIssue({
+        severity: "error",
+        code: "unknown-task",
+        message: `Quarantine entry references unknown task: ${entry.taskId}`,
+        taskId: entry.taskId,
+        spec: entry.spec,
+      }));
+    }
+
+    if (!inputs.existingSpecs.has(entry.spec)) {
+      errors.push(createIssue({
+        severity: "error",
+        code: "missing-spec",
+        message: `Quarantine entry references missing spec: ${entry.spec}`,
+        taskId: entry.taskId,
+        spec: entry.spec,
+      }));
+    } else if (task && !task.specs.includes(entry.spec)) {
+      errors.push(createIssue({
+        severity: "error",
+        code: "task-does-not-own-spec",
+        message: `Task ${entry.taskId} does not own spec ${entry.spec}`,
+        taskId: entry.taskId,
+        spec: entry.spec,
+      }));
+    }
+
+    if (!compileTitlePattern(entry.titlePattern)) {
+      errors.push(createIssue({
+        severity: "error",
+        code: "invalid-title-pattern",
+        message: `Invalid title pattern for quarantine ${entry.id}: ${entry.titlePattern}`,
+        taskId: entry.taskId,
+        spec: entry.spec,
+      }));
+    }
+
+    const introducedAt = parseDateOnly(entry.introducedAt);
+    if (!introducedAt) {
+      errors.push(createIssue({
+        severity: "error",
+        code: "invalid-introduced-at",
+        message: `Invalid introducedAt for quarantine ${entry.id}: ${entry.introducedAt}`,
+        taskId: entry.taskId,
+        spec: entry.spec,
+      }));
+    }
+
+    const expiresAt = parseDateOnly(entry.expiresAt);
+    if (!expiresAt) {
+      errors.push(createIssue({
+        severity: "error",
+        code: "invalid-expires-at",
+        message: `Invalid expiresAt for quarantine ${entry.id}: ${entry.expiresAt}`,
+        taskId: entry.taskId,
+        spec: entry.spec,
+      }));
+    }
+
+    if (introducedAt && expiresAt && introducedAt.getTime() > expiresAt.getTime()) {
+      errors.push(createIssue({
+        severity: "error",
+        code: "invalid-expiry-range",
+        message: `introducedAt must be on or before expiresAt for quarantine ${entry.id}`,
+        taskId: entry.taskId,
+        spec: entry.spec,
+      }));
+    }
+
+    const expiry = classifyQuarantineExpiry(now, expiresAt, expiresSoonDays);
+    const expiryStatus: FlakerQuarantineExpiryStatus = expiry.status;
+    const daysUntilExpiry = expiry.daysUntilExpiry;
+
+    if (expiryStatus === "expired") {
+      errors.push(createIssue({
+        severity: "error",
+        code: "expired-quarantine",
+        message: `Quarantine ${entry.id} expired on ${entry.expiresAt}`,
+        taskId: entry.taskId,
+        spec: entry.spec,
+      }));
+    } else if (expiryStatus === "expires-soon") {
+      warnings.push(createIssue({
+        severity: "warning",
+        code: "expires-soon",
+        message: `Quarantine ${entry.id} expires on ${entry.expiresAt}`,
+        taskId: entry.taskId,
+        spec: entry.spec,
+      }));
+    }
+
+    entries.push({
+      ...entry,
+      expiryStatus,
+      daysUntilExpiry,
+    });
+  }
+
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    entryCount: inputs.quarantine.entries.length,
+    modeCounts,
+    scopeCounts,
+    entries: entries.sort((a, b) => a.id.localeCompare(b.id)),
+    errors,
+    warnings,
+  };
+}

--- a/src/cli/reporting/flaker-task-summary-contract.ts
+++ b/src/cli/reporting/flaker-task-summary-contract.ts
@@ -1,0 +1,63 @@
+export interface FlakerEvalReport {
+  dataSufficiency: {
+    totalRuns: number;
+    totalResults: number;
+    uniqueTests: number;
+    firstDate: string | null;
+    lastDate: string | null;
+    avgRunsPerTest: number;
+  };
+  detection: {
+    flakyTests: number;
+    trueFlakyTests: number;
+    quarantinedTests: number;
+    distribution: Array<{ range: string; count: number }>;
+  };
+  resolution: {
+    resolvedFlaky: number;
+    newFlaky: number;
+    mttdDays: number | null;
+    mttrDays: number | null;
+  };
+  healthScore: number;
+}
+
+export interface FlakerReasonReport {
+  classifications: Array<{
+    suite: string;
+    testName: string;
+    classification: string;
+    confidence: number;
+    recommendation: string;
+    priority: string;
+    evidence: string[];
+  }>;
+  patterns: Array<{
+    type: string;
+    description: string;
+    severity: string;
+    affectedTests: string[];
+  }>;
+  riskPredictions: Array<{
+    suite: string;
+    testName: string;
+    riskScore: number;
+    reason: string;
+  }>;
+  summary: {
+    totalAnalyzed: number;
+    trueFlakyCount: number;
+    regressionCount: number;
+    quarantineRecommended: number;
+    urgentFixes: number;
+  };
+}
+
+export interface FlakerTaskSummaryReport {
+  schemaVersion: 1;
+  generatedAt: string;
+  taskId: string;
+  workspaceDir: string;
+  eval: FlakerEvalReport;
+  reason: FlakerReasonReport;
+}

--- a/src/cli/reporting/flaker-task-summary-core.ts
+++ b/src/cli/reporting/flaker-task-summary-core.ts
@@ -1,0 +1,100 @@
+import type {
+  FlakerEvalReport,
+  FlakerReasonReport,
+  FlakerTaskSummaryReport,
+} from "./flaker-task-summary-contract.js";
+
+export interface BuildFlakerTaskSummaryInput {
+  taskId: string;
+  workspaceDir: string;
+  eval: FlakerEvalReport;
+  reason: FlakerReasonReport;
+}
+
+function escapeCell(value: string): string {
+  return value.replace(/\|/g, "\\|");
+}
+
+function formatNumber(value: number | null): string {
+  if (value == null) {
+    return "N/A";
+  }
+  return `${value}`;
+}
+
+export function buildFlakerTaskSummaryReport(
+  input: BuildFlakerTaskSummaryInput,
+): FlakerTaskSummaryReport {
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    taskId: input.taskId,
+    workspaceDir: input.workspaceDir,
+    eval: input.eval,
+    reason: input.reason,
+  };
+}
+
+export function renderFlakerTaskSummaryMarkdown(summary: FlakerTaskSummaryReport): string {
+  const lines: string[] = [];
+  lines.push("# Flaker Task Summary");
+  lines.push("");
+  lines.push("| Metric | Value |");
+  lines.push("| --- | --- |");
+  lines.push(`| Task | ${escapeCell(summary.taskId)} |`);
+  lines.push(`| Health score | ${summary.eval.healthScore} |`);
+  lines.push(`| Workflow runs | ${summary.eval.dataSufficiency.totalRuns} |`);
+  lines.push(`| Test results | ${summary.eval.dataSufficiency.totalResults} |`);
+  lines.push(`| Unique tests | ${summary.eval.dataSufficiency.uniqueTests} |`);
+  lines.push(`| Avg runs/test | ${summary.eval.dataSufficiency.avgRunsPerTest} |`);
+  lines.push(`| Flaky tests | ${summary.eval.detection.flakyTests} |`);
+  lines.push(`| True flaky | ${summary.eval.detection.trueFlakyTests} |`);
+  lines.push(`| Quarantined | ${summary.eval.detection.quarantinedTests} |`);
+  lines.push(`| New flaky | ${summary.eval.resolution.newFlaky} |`);
+  lines.push(`| Resolved flaky | ${summary.eval.resolution.resolvedFlaky} |`);
+  lines.push(`| Quarantine recommended | ${summary.reason.summary.quarantineRecommended} |`);
+  lines.push(`| Urgent fixes | ${summary.reason.summary.urgentFixes} |`);
+
+  if (summary.reason.classifications.length > 0) {
+    lines.push("");
+    lines.push("## Priority Tests");
+    lines.push("");
+    lines.push("| Test | Classification | Recommendation | Priority | Confidence |");
+    lines.push("| --- | --- | --- | --- | --- |");
+    for (const classification of summary.reason.classifications.slice(0, 5)) {
+      lines.push(
+        `| ${escapeCell(`${classification.suite} > ${classification.testName}`)} | ${escapeCell(classification.classification)} | ${escapeCell(classification.recommendation)} | ${escapeCell(classification.priority)} | ${classification.confidence.toFixed(2)} |`,
+      );
+    }
+  }
+
+  if (summary.reason.patterns.length > 0) {
+    lines.push("");
+    lines.push("## Patterns");
+    lines.push("");
+    for (const pattern of summary.reason.patterns.slice(0, 5)) {
+      lines.push(`- ${pattern.severity.toUpperCase()}: ${pattern.description}`);
+    }
+  }
+
+  if (summary.reason.riskPredictions.length > 0) {
+    lines.push("");
+    lines.push("## Risk Predictions");
+    lines.push("");
+    lines.push("| Test | Risk score | Reason |");
+    lines.push("| --- | --- | --- |");
+    for (const risk of summary.reason.riskPredictions.slice(0, 5)) {
+      lines.push(
+        `| ${escapeCell(`${risk.suite} > ${risk.testName}`)} | ${risk.riskScore} | ${escapeCell(risk.reason)} |`,
+      );
+    }
+  }
+
+  lines.push("");
+  lines.push("## Windows");
+  lines.push("");
+  lines.push(`- Date range: ${summary.eval.dataSufficiency.firstDate ?? "N/A"} -> ${summary.eval.dataSufficiency.lastDate ?? "N/A"}`);
+  lines.push(`- Avg MTTD: ${formatNumber(summary.eval.resolution.mttdDays)}`);
+  lines.push(`- Avg MTTR: ${formatNumber(summary.eval.resolution.mttrDays)}`);
+  return `${lines.join("\n")}\n`;
+}

--- a/src/cli/reporting/playwright-report-contract.ts
+++ b/src/cli/reporting/playwright-report-contract.ts
@@ -1,0 +1,198 @@
+export type PlaywrightOutcome =
+  | "passed"
+  | "failed"
+  | "flaky"
+  | "skipped"
+  | "timedout"
+  | "interrupted"
+  | "unknown";
+
+export interface PlaywrightStableIdentity {
+  key: string;
+  suite: string;
+  testName: string;
+  spec: string;
+  titlePath: string[];
+  variant: Record<string, string>;
+}
+
+export interface PlaywrightTestRow {
+  id: string;
+  file: string;
+  title: string;
+  titlePath: string[];
+  identityKey: string;
+  identity?: PlaywrightStableIdentity;
+  projectName: string;
+  expectedStatus: string;
+  rawStatus: string;
+  outcome: PlaywrightOutcome;
+  attempts: string[];
+  retryCount: number;
+  durationMs: number;
+  errorMessages: string[];
+}
+
+export interface PlaywrightFileSummary {
+  file: string;
+  total: number;
+  passed: number;
+  failed: number;
+  flaky: number;
+  skipped: number;
+  retries: number;
+  durationMs: number;
+}
+
+export interface PlaywrightSummaryTotals {
+  total: number;
+  passed: number;
+  failed: number;
+  flaky: number;
+  skipped: number;
+  timedout: number;
+  interrupted: number;
+  unknown: number;
+  retries: number;
+  durationMs: number;
+}
+
+export interface PlaywrightSummary {
+  schemaVersion: 1;
+  generatedAt: string;
+  label: string;
+  sourceFile?: string;
+  totals: PlaywrightSummaryTotals;
+  files: PlaywrightFileSummary[];
+  tests: PlaywrightTestRow[];
+}
+
+export function normalizePlaywrightVariant(
+  variant: Record<string, string> | null | undefined,
+): Record<string, string> {
+  if (!variant) {
+    return {};
+  }
+  return Object.fromEntries(
+    Object.entries(variant)
+      .filter((entry) => entry[1].length > 0)
+      .sort((a, b) => a[0].localeCompare(b[0])),
+  );
+}
+
+export function buildStablePlaywrightIdentity(input: {
+  suite: string;
+  testName: string;
+  spec: string;
+  titlePath: string[];
+  variant?: Record<string, string> | null;
+}): PlaywrightStableIdentity {
+  const variant = normalizePlaywrightVariant(input.variant);
+  const keyPayload: Record<string, unknown> = {
+    spec: input.spec,
+    suite: input.suite,
+    testName: input.testName,
+    titlePath: [...input.titlePath],
+  };
+  if (Object.keys(variant).length > 0) {
+    keyPayload.variant = variant;
+  }
+  return {
+    key: JSON.stringify(keyPayload),
+    suite: input.suite,
+    testName: input.testName,
+    spec: input.spec,
+    titlePath: [...input.titlePath],
+    variant,
+  };
+}
+
+export function resolvePlaywrightTestIdentityKey(
+  row: Pick<PlaywrightTestRow, "id" | "identityKey" | "identity">,
+): string {
+  return row.identityKey || row.identity?.key || row.id;
+}
+
+export function createEmptyPlaywrightSummaryTotals(): PlaywrightSummaryTotals {
+  return {
+    total: 0,
+    passed: 0,
+    failed: 0,
+    flaky: 0,
+    skipped: 0,
+    timedout: 0,
+    interrupted: 0,
+    unknown: 0,
+    retries: 0,
+    durationMs: 0,
+  };
+}
+
+export function createEmptyPlaywrightFileSummary(
+  file: string,
+): PlaywrightFileSummary {
+  return {
+    file,
+    total: 0,
+    passed: 0,
+    failed: 0,
+    flaky: 0,
+    skipped: 0,
+    retries: 0,
+    durationMs: 0,
+  };
+}
+
+function pushCount(
+  totals: PlaywrightSummaryTotals,
+  outcome: PlaywrightOutcome,
+): void {
+  totals.total += 1;
+  if (outcome === "passed") totals.passed += 1;
+  else if (outcome === "failed") totals.failed += 1;
+  else if (outcome === "flaky") totals.flaky += 1;
+  else if (outcome === "skipped") totals.skipped += 1;
+  else if (outcome === "timedout") totals.timedout += 1;
+  else if (outcome === "interrupted") totals.interrupted += 1;
+  else totals.unknown += 1;
+}
+
+export function accumulatePlaywrightSummaryTotals(
+  totals: PlaywrightSummaryTotals,
+  row: Pick<PlaywrightTestRow, "outcome" | "retryCount" | "durationMs">,
+): void {
+  pushCount(totals, row.outcome);
+  totals.retries += row.retryCount;
+  totals.durationMs += row.durationMs;
+}
+
+export function accumulatePlaywrightFileSummary(
+  summary: PlaywrightFileSummary,
+  row: Pick<PlaywrightTestRow, "outcome" | "retryCount" | "durationMs">,
+): void {
+  summary.total += 1;
+  if (row.outcome === "passed") summary.passed += 1;
+  else if (row.outcome === "failed") summary.failed += 1;
+  else if (row.outcome === "flaky") summary.flaky += 1;
+  else if (row.outcome === "skipped") summary.skipped += 1;
+  summary.retries += row.retryCount;
+  summary.durationMs += row.durationMs;
+}
+
+export function playwrightOutcomeSeverity(
+  outcome: PlaywrightOutcome | undefined,
+): number {
+  if (!outcome || outcome === "passed" || outcome === "skipped") {
+    return 0;
+  }
+  if (outcome === "flaky") {
+    return 1;
+  }
+  return 2;
+}
+
+export function isPlaywrightOutcomeUnstable(
+  outcome: PlaywrightOutcome | undefined,
+): boolean {
+  return playwrightOutcomeSeverity(outcome) > 0;
+}

--- a/src/cli/reporting/playwright-report-diff-core.ts
+++ b/src/cli/reporting/playwright-report-diff-core.ts
@@ -1,0 +1,309 @@
+import {
+  isPlaywrightOutcomeUnstable,
+  playwrightOutcomeSeverity,
+  resolvePlaywrightTestIdentityKey,
+  type PlaywrightOutcome,
+  type PlaywrightSummary,
+  type PlaywrightTestRow,
+} from "./playwright-report-contract.js";
+
+export type PlaywrightDiffKind =
+  | "new_failure"
+  | "worsened_failure"
+  | "new_flaky"
+  | "resolved"
+  | "improved"
+  | "removed_unstable"
+  | "persistent_failure"
+  | "persistent_flaky";
+
+export interface PlaywrightDiffRow {
+  id: string;
+  identityKey: string;
+  file: string;
+  title: string;
+  projectName: string;
+  kind: PlaywrightDiffKind;
+  baseOutcome?: PlaywrightOutcome;
+  headOutcome?: PlaywrightOutcome;
+  baseAttempts: string[];
+  headAttempts: string[];
+}
+
+export interface PlaywrightDiffTotals {
+  baseTotal: number;
+  headTotal: number;
+  addedTests: number;
+  removedTests: number;
+  regressions: number;
+  newFailures: number;
+  worsenedFailures: number;
+  newFlaky: number;
+  improvements: number;
+  resolved: number;
+  improved: number;
+  removedUnstable: number;
+  persistentUnstable: number;
+  persistentFailures: number;
+  persistentFlaky: number;
+}
+
+export interface PlaywrightDiff {
+  schemaVersion: 1;
+  generatedAt: string;
+  label: string;
+  baseLabel: string;
+  headLabel: string;
+  baseSourceFile?: string;
+  headSourceFile?: string;
+  totals: PlaywrightDiffTotals;
+  regressions: PlaywrightDiffRow[];
+  improvements: PlaywrightDiffRow[];
+  persistentUnstable: PlaywrightDiffRow[];
+}
+
+function createTotals(
+  base: PlaywrightSummary,
+  head: PlaywrightSummary,
+): PlaywrightDiffTotals {
+  return {
+    baseTotal: base.tests.length,
+    headTotal: head.tests.length,
+    addedTests: 0,
+    removedTests: 0,
+    regressions: 0,
+    newFailures: 0,
+    worsenedFailures: 0,
+    newFlaky: 0,
+    improvements: 0,
+    resolved: 0,
+    improved: 0,
+    removedUnstable: 0,
+    persistentUnstable: 0,
+    persistentFailures: 0,
+    persistentFlaky: 0,
+  };
+}
+
+function createRow(
+  kind: PlaywrightDiffKind,
+  baseRow: PlaywrightTestRow | undefined,
+  headRow: PlaywrightTestRow | undefined,
+): PlaywrightDiffRow {
+  const row = headRow ?? baseRow;
+  if (!row) {
+    throw new Error("Diff row requires a base or head test row");
+  }
+  return {
+    id: row.id,
+    identityKey: resolvePlaywrightTestIdentityKey(row),
+    file: row.file,
+    title: row.title,
+    projectName: row.projectName,
+    kind,
+    baseOutcome: baseRow?.outcome,
+    headOutcome: headRow?.outcome,
+    baseAttempts: [...(baseRow?.attempts ?? [])],
+    headAttempts: [...(headRow?.attempts ?? [])],
+  };
+}
+
+function compareRows(
+  baseRow: PlaywrightTestRow | undefined,
+  headRow: PlaywrightTestRow | undefined,
+  totals: PlaywrightDiffTotals,
+  regressions: PlaywrightDiffRow[],
+  improvements: PlaywrightDiffRow[],
+  persistentUnstable: PlaywrightDiffRow[],
+): void {
+  if (!baseRow && headRow) {
+    totals.addedTests += 1;
+    const headSeverity = playwrightOutcomeSeverity(headRow.outcome);
+    if (headSeverity === 2) {
+      totals.regressions += 1;
+      totals.newFailures += 1;
+      regressions.push(createRow("new_failure", undefined, headRow));
+    } else if (headSeverity === 1) {
+      totals.regressions += 1;
+      totals.newFlaky += 1;
+      regressions.push(createRow("new_flaky", undefined, headRow));
+    }
+    return;
+  }
+
+  if (baseRow && !headRow) {
+    totals.removedTests += 1;
+    if (isPlaywrightOutcomeUnstable(baseRow.outcome)) {
+      totals.improvements += 1;
+      totals.removedUnstable += 1;
+      improvements.push(createRow("removed_unstable", baseRow, undefined));
+    }
+    return;
+  }
+
+  if (!baseRow || !headRow) {
+    return;
+  }
+
+  const baseSeverity = playwrightOutcomeSeverity(baseRow.outcome);
+  const headSeverity = playwrightOutcomeSeverity(headRow.outcome);
+
+  if (headSeverity > baseSeverity) {
+    totals.regressions += 1;
+    if (headSeverity === 2 && baseSeverity === 1) {
+      totals.worsenedFailures += 1;
+      regressions.push(createRow("worsened_failure", baseRow, headRow));
+    } else if (headSeverity === 2) {
+      totals.newFailures += 1;
+      regressions.push(createRow("new_failure", baseRow, headRow));
+    } else {
+      totals.newFlaky += 1;
+      regressions.push(createRow("new_flaky", baseRow, headRow));
+    }
+    return;
+  }
+
+  if (headSeverity < baseSeverity) {
+    totals.improvements += 1;
+    if (headSeverity === 0) {
+      totals.resolved += 1;
+      improvements.push(createRow("resolved", baseRow, headRow));
+    } else {
+      totals.improved += 1;
+      improvements.push(createRow("improved", baseRow, headRow));
+    }
+    return;
+  }
+
+  if (headSeverity === 0) {
+    return;
+  }
+
+  totals.persistentUnstable += 1;
+  if (headSeverity === 2) {
+    totals.persistentFailures += 1;
+    persistentUnstable.push(createRow("persistent_failure", baseRow, headRow));
+  } else {
+    totals.persistentFlaky += 1;
+    persistentUnstable.push(createRow("persistent_flaky", baseRow, headRow));
+  }
+}
+
+function compareId(a: { id: string }, b: { id: string }): number {
+  return a.id.localeCompare(b.id);
+}
+
+export function buildPlaywrightDiff(
+  base: PlaywrightSummary,
+  head: PlaywrightSummary,
+  label = head.label,
+): PlaywrightDiff {
+  const baseById = new Map(base.tests.map((row) => [resolvePlaywrightTestIdentityKey(row), row]));
+  const headById = new Map(head.tests.map((row) => [resolvePlaywrightTestIdentityKey(row), row]));
+  const ids = new Set([...baseById.keys(), ...headById.keys()]);
+
+  const totals = createTotals(base, head);
+  const regressions: PlaywrightDiffRow[] = [];
+  const improvements: PlaywrightDiffRow[] = [];
+  const persistentUnstable: PlaywrightDiffRow[] = [];
+
+  for (const id of [...ids].sort()) {
+    compareRows(
+      baseById.get(id),
+      headById.get(id),
+      totals,
+      regressions,
+      improvements,
+      persistentUnstable,
+    );
+  }
+
+  regressions.sort(compareId);
+  improvements.sort(compareId);
+  persistentUnstable.sort(compareId);
+
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    label,
+    baseLabel: base.label,
+    headLabel: head.label,
+    baseSourceFile: base.sourceFile,
+    headSourceFile: head.sourceFile,
+    totals,
+    regressions,
+    improvements,
+    persistentUnstable,
+  };
+}
+
+function escapeCell(value: string): string {
+  return value.replace(/\|/g, "\\|");
+}
+
+function outcomeLabel(outcome: PlaywrightOutcome | undefined): string {
+  return outcome ?? "-";
+}
+
+function attemptsLabel(attempts: string[]): string {
+  return attempts.length > 0 ? attempts.join(" -> ") : "-";
+}
+
+function renderRows(rows: PlaywrightDiffRow[]): string[] {
+  const lines: string[] = [];
+  lines.push("| Kind | Test | Base | Head | Base Attempts | Head Attempts |");
+  lines.push("| --- | --- | --- | --- | --- | --- |");
+  for (const row of rows) {
+    lines.push(
+      `| ${row.kind} | ${escapeCell(row.id)} | ${outcomeLabel(row.baseOutcome)} | ${outcomeLabel(row.headOutcome)} | ${escapeCell(attemptsLabel(row.baseAttempts))} | ${escapeCell(attemptsLabel(row.headAttempts))} |`,
+    );
+  }
+  return lines;
+}
+
+export function renderPlaywrightDiffMarkdown(diff: PlaywrightDiff): string {
+  const lines: string[] = [];
+  lines.push("# Playwright Baseline Diff");
+  lines.push("");
+  lines.push("| Metric | Value |");
+  lines.push("| --- | --- |");
+  lines.push(`| Label | ${escapeCell(diff.label)} |`);
+  lines.push(`| Base | ${escapeCell(diff.baseLabel)} |`);
+  lines.push(`| Head | ${escapeCell(diff.headLabel)} |`);
+  if (diff.baseSourceFile) {
+    lines.push(`| Base Source | ${escapeCell(diff.baseSourceFile)} |`);
+  }
+  if (diff.headSourceFile) {
+    lines.push(`| Head Source | ${escapeCell(diff.headSourceFile)} |`);
+  }
+  lines.push(`| Base Total | ${diff.totals.baseTotal} |`);
+  lines.push(`| Head Total | ${diff.totals.headTotal} |`);
+  lines.push(`| Regressions | ${diff.totals.regressions} |`);
+  lines.push(`| Improvements | ${diff.totals.improvements} |`);
+  lines.push(`| Persistent Unstable | ${diff.totals.persistentUnstable} |`);
+  lines.push(`| Added Tests | ${diff.totals.addedTests} |`);
+  lines.push(`| Removed Tests | ${diff.totals.removedTests} |`);
+
+  if (diff.regressions.length > 0) {
+    lines.push("");
+    lines.push("## Regressions");
+    lines.push("");
+    lines.push(...renderRows(diff.regressions));
+  }
+
+  if (diff.improvements.length > 0) {
+    lines.push("");
+    lines.push("## Improvements");
+    lines.push("");
+    lines.push(...renderRows(diff.improvements));
+  }
+
+  if (diff.persistentUnstable.length > 0) {
+    lines.push("");
+    lines.push("## Persistent Unstable");
+    lines.push("");
+    lines.push(...renderRows(diff.persistentUnstable));
+  }
+
+  return `${lines.join("\n")}\n`;
+}

--- a/src/cli/reporting/playwright-report-summary-core.ts
+++ b/src/cli/reporting/playwright-report-summary-core.ts
@@ -1,0 +1,300 @@
+import {
+  accumulatePlaywrightFileSummary,
+  accumulatePlaywrightSummaryTotals,
+  buildStablePlaywrightIdentity,
+  createEmptyPlaywrightFileSummary,
+  createEmptyPlaywrightSummaryTotals,
+  type PlaywrightFileSummary,
+  type PlaywrightOutcome,
+  type PlaywrightSummary,
+  type PlaywrightTestRow,
+} from "./playwright-report-contract.js";
+
+export interface PlaywrightJsonResultError {
+  message?: string;
+  value?: string;
+}
+
+export interface PlaywrightJsonResult {
+  retry?: number;
+  workerIndex?: number;
+  status?: string;
+  duration?: number;
+  startTime?: string;
+  errors?: PlaywrightJsonResultError[];
+}
+
+export interface PlaywrightJsonTest {
+  projectName?: string;
+  projectId?: string;
+  expectedStatus?: string;
+  status?: string;
+  annotations?: Array<{ type?: string; description?: string }>;
+  results?: PlaywrightJsonResult[];
+}
+
+export interface PlaywrightJsonSpec {
+  title?: string;
+  ok?: boolean;
+  file?: string;
+  line?: number;
+  column?: number;
+  tags?: string[];
+  tests?: PlaywrightJsonTest[];
+}
+
+export interface PlaywrightJsonSuite {
+  title?: string;
+  file?: string;
+  line?: number;
+  column?: number;
+  specs?: PlaywrightJsonSpec[];
+  suites?: PlaywrightJsonSuite[];
+}
+
+export interface PlaywrightJsonReport {
+  config?: unknown;
+  suites?: PlaywrightJsonSuite[];
+  errors?: PlaywrightJsonResultError[];
+  stats?: {
+    startTime?: string;
+    duration?: number;
+    expected?: number;
+    skipped?: number;
+    unexpected?: number;
+    flaky?: number;
+  };
+}
+
+function asArray<T>(value: T[] | undefined | null): T[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function pickFile(
+  candidates: Array<string | undefined>,
+  fallback: string,
+): string {
+  for (const candidate of candidates) {
+    if (candidate && candidate.trim().length > 0) {
+      return candidate;
+    }
+  }
+  return fallback;
+}
+
+function normalizeAttemptStatus(status: string | undefined): string {
+  const normalized = (status ?? "").trim().toLowerCase();
+  if (!normalized) return "unknown";
+  return normalized;
+}
+
+function normalizeOutcome(
+  rawStatus: string,
+  attemptStatuses: string[],
+): PlaywrightOutcome {
+  if (rawStatus === "skipped") return "skipped";
+  if (rawStatus === "flaky") return "flaky";
+
+  if (attemptStatuses.includes("timedout")) return "timedout";
+  if (attemptStatuses.includes("interrupted")) return "interrupted";
+
+  const finalAttempt = attemptStatuses.at(-1) ?? "unknown";
+  if (finalAttempt === "skipped") return "skipped";
+  if (finalAttempt === "passed") {
+    const unique = new Set(attemptStatuses);
+    return unique.size > 1 ? "flaky" : "passed";
+  }
+  if (finalAttempt === "failed") return "failed";
+  if (finalAttempt === "timedout") return "timedout";
+  if (finalAttempt === "interrupted") return "interrupted";
+  return "unknown";
+}
+
+function rowId(file: string, titlePath: string[], projectName: string): string {
+  const base = `${file}::${titlePath.join(" > ")}`;
+  return projectName ? `${base} [${projectName}]` : base;
+}
+
+function isFileContainerSuite(suite: PlaywrightJsonSuite): boolean {
+  return typeof suite.file === "string"
+    || /\.(spec|test)\.[cm]?[jt]sx?$/.test(suite.title ?? "");
+}
+
+function collectRowsFromSuite(
+  suite: PlaywrightJsonSuite,
+  parentTitles: string[],
+  inheritedFile: string | undefined,
+  rows: PlaywrightTestRow[],
+): void {
+  const suiteTitle = suite.title?.trim() ?? "";
+  const fileContainer = isFileContainerSuite(suite);
+  const nextTitles = fileContainer
+    ? [...parentTitles]
+    : suiteTitle
+    ? [...parentTitles, suiteTitle]
+    : [...parentTitles];
+  const suiteFile = suite.file ?? inheritedFile ?? (fileContainer ? suiteTitle : undefined);
+  const currentTitle = nextTitles[nextTitles.length - 1] ?? suiteTitle ?? suiteFile ?? "unknown";
+
+  for (const spec of asArray(suite.specs)) {
+    const specTitle = spec.title?.trim() ?? "unnamed";
+    const specFile = pickFile(
+      [spec.file, suiteFile, inheritedFile],
+      "unknown",
+    );
+    const specTitlePath = [...nextTitles, specTitle];
+
+    for (const test of asArray(spec.tests)) {
+      const attemptStatuses = asArray(test.results).map((result) =>
+        normalizeAttemptStatus(result.status),
+      );
+      const rawStatus = normalizeAttemptStatus(test.status);
+      const outcome = normalizeOutcome(rawStatus, attemptStatuses);
+      const retryCount = Math.max(
+        0,
+        ...asArray(test.results).map((result) =>
+          typeof result.retry === "number" ? result.retry : 0,
+        ),
+      );
+      const durationMs = asArray(test.results).reduce(
+        (sum, result) => sum + (typeof result.duration === "number" ? result.duration : 0),
+        0,
+      );
+      const errorMessages = asArray(test.results).flatMap((result) =>
+        asArray(result.errors)
+          .map((error) => error.message ?? error.value ?? "")
+          .filter((message) => message.length > 0),
+      );
+      const projectName = test.projectName ?? test.projectId ?? "";
+      const identity = buildStablePlaywrightIdentity({
+        suite: currentTitle,
+        testName: specTitle,
+        spec: specFile,
+        titlePath: specTitlePath,
+        variant: projectName ? { project: projectName } : {},
+      });
+
+      rows.push({
+        id: rowId(specFile, specTitlePath, projectName),
+        file: specFile,
+        title: specTitle,
+        titlePath: specTitlePath,
+        identityKey: identity.key,
+        identity,
+        projectName,
+        expectedStatus: test.expectedStatus ?? "passed",
+        rawStatus,
+        outcome,
+        attempts: attemptStatuses,
+        retryCount,
+        durationMs,
+        errorMessages,
+      });
+    }
+  }
+
+  for (const childSuite of asArray(suite.suites)) {
+    collectRowsFromSuite(childSuite, nextTitles, suiteFile, rows);
+  }
+}
+
+export function buildPlaywrightSummary(
+  report: PlaywrightJsonReport,
+  label: string,
+  sourceFile?: string,
+): PlaywrightSummary {
+  const rows: PlaywrightTestRow[] = [];
+  for (const suite of asArray(report.suites)) {
+    collectRowsFromSuite(suite, [], suite.file, rows);
+  }
+
+  rows.sort((a, b) => {
+    if (b.durationMs !== a.durationMs) return b.durationMs - a.durationMs;
+    return a.id.localeCompare(b.id);
+  });
+
+  const totals = createEmptyPlaywrightSummaryTotals();
+  const byFile = new Map<string, PlaywrightFileSummary>();
+
+  for (const row of rows) {
+    accumulatePlaywrightSummaryTotals(totals, row);
+    const fileSummary = byFile.get(row.file) ?? createEmptyPlaywrightFileSummary(row.file);
+    accumulatePlaywrightFileSummary(fileSummary, row);
+    byFile.set(row.file, fileSummary);
+  }
+
+  const files = [...byFile.values()].sort((a, b) => {
+    if (b.failed !== a.failed) return b.failed - a.failed;
+    if (b.flaky !== a.flaky) return b.flaky - a.flaky;
+    if (b.durationMs !== a.durationMs) return b.durationMs - a.durationMs;
+    return a.file.localeCompare(b.file);
+  });
+
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    label,
+    sourceFile,
+    totals,
+    files,
+    tests: rows,
+  };
+}
+
+function escapeCell(value: string): string {
+  return value.replace(/\|/g, "\\|");
+}
+
+function fmtMs(value: number): string {
+  return `${value}`;
+}
+
+export function renderPlaywrightMarkdown(summary: PlaywrightSummary): string {
+  const lines: string[] = [];
+  lines.push("# Playwright Report Summary");
+  lines.push("");
+  lines.push("| Metric | Value |");
+  lines.push("| --- | --- |");
+  lines.push(`| Label | ${escapeCell(summary.label)} |`);
+  if (summary.sourceFile) {
+    lines.push(`| Source | ${escapeCell(summary.sourceFile)} |`);
+  }
+  lines.push(`| Total | ${summary.totals.total} |`);
+  lines.push(`| Passed | ${summary.totals.passed} |`);
+  lines.push(`| Failed | ${summary.totals.failed} |`);
+  lines.push(`| Flaky | ${summary.totals.flaky} |`);
+  lines.push(`| Skipped | ${summary.totals.skipped} |`);
+  lines.push(`| Timed out | ${summary.totals.timedout} |`);
+  lines.push(`| Interrupted | ${summary.totals.interrupted} |`);
+  lines.push(`| Retries | ${summary.totals.retries} |`);
+  lines.push(`| Duration (ms) | ${summary.totals.durationMs} |`);
+
+  lines.push("");
+  lines.push("## Files");
+  lines.push("");
+  lines.push("| File | Total | Passed | Failed | Flaky | Skipped | Retries | Duration (ms) |");
+  lines.push("| --- | --- | --- | --- | --- | --- | --- | --- |");
+  for (const file of summary.files) {
+    lines.push(
+      `| ${escapeCell(file.file)} | ${file.total} | ${file.passed} | ${file.failed} | ${file.flaky} | ${file.skipped} | ${file.retries} | ${fmtMs(file.durationMs)} |`,
+    );
+  }
+
+  const unstableTests = summary.tests.filter((row) =>
+    row.outcome === "failed" || row.outcome === "flaky" || row.retryCount > 0,
+  );
+  if (unstableTests.length > 0) {
+    lines.push("");
+    lines.push("## Flaky / Retried Tests");
+    lines.push("");
+    lines.push("| Test | Outcome | Attempts | Retries | Duration (ms) |");
+    lines.push("| --- | --- | --- | --- | --- |");
+    for (const row of unstableTests) {
+      lines.push(
+        `| ${escapeCell(row.id)} | ${row.outcome} | ${escapeCell(row.attempts.join(" -> "))} | ${row.retryCount} | ${fmtMs(row.durationMs)} |`,
+      );
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+}

--- a/tests/reporting/flaker-batch-summary-core.test.ts
+++ b/tests/reporting/flaker-batch-summary-core.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+import type { PlaywrightSummary } from "../../src/cli/reporting/playwright-report-contract.js";
+import type { FlakerTaskSummaryReport } from "../../src/cli/reporting/flaker-task-summary-contract.js";
+import {
+  buildFlakerBatchSummary,
+  renderFlakerBatchSummaryMarkdown,
+} from "../../src/cli/reporting/flaker-batch-summary-core.js";
+
+describe("buildFlakerBatchSummary", () => {
+  it("aggregates task summaries from loaded reports", () => {
+    const summary = buildFlakerBatchSummary({
+      playwrightSummaries: new Map([
+        ["paint-vrt", {
+          totals: {
+            total: 10,
+            passed: 9,
+            failed: 1,
+            flaky: 0,
+            skipped: 0,
+            timedout: 0,
+            interrupted: 0,
+            unknown: 0,
+            retries: 1,
+            durationMs: 100,
+          },
+        } as PlaywrightSummary],
+        ["wpt-vrt", {
+          totals: {
+            total: 20,
+            passed: 20,
+            failed: 0,
+            flaky: 2,
+            skipped: 0,
+            timedout: 0,
+            interrupted: 0,
+            unknown: 0,
+            retries: 2,
+            durationMs: 200,
+          },
+        } as PlaywrightSummary],
+      ]),
+      flakerSummaries: new Map([
+        ["paint-vrt", {
+          eval: {
+            healthScore: 72,
+            resolution: { newFlaky: 1 },
+          },
+          reason: {
+            summary: { urgentFixes: 1 },
+          },
+        } as FlakerTaskSummaryReport],
+      ]),
+    });
+
+    expect(summary.taskCount).toBe(2);
+    expect(summary.failedTasks).toBe(1);
+    expect(summary.flakyTasks).toBe(1);
+    expect(summary.totalTests).toBe(30);
+    expect(summary.tasks).toEqual([
+      {
+        taskId: "paint-vrt",
+        totalTests: 10,
+        failed: 1,
+        flaky: 0,
+        skipped: 0,
+        healthScore: 72,
+        newFlaky: 1,
+        urgentFixes: 1,
+        status: "failed",
+      },
+      {
+        taskId: "wpt-vrt",
+        totalTests: 20,
+        failed: 0,
+        flaky: 2,
+        skipped: 0,
+        healthScore: undefined,
+        newFlaky: undefined,
+        urgentFixes: undefined,
+        status: "ok",
+      },
+    ]);
+  });
+
+  it("marks tasks without playwright summary as missing", () => {
+    const summary = buildFlakerBatchSummary({
+      playwrightSummaries: new Map(),
+      flakerSummaries: new Map([
+        ["paint-vrt", {
+          schemaVersion: 1,
+          generatedAt: "2026-04-02T00:00:00.000Z",
+          taskId: "paint-vrt",
+          workspaceDir: "/tmp/paint-vrt",
+          eval: {
+            dataSufficiency: {
+              totalRuns: 1,
+              totalResults: 1,
+              uniqueTests: 1,
+              firstDate: null,
+              lastDate: null,
+              avgRunsPerTest: 1,
+            },
+            detection: {
+              flakyTests: 0,
+              trueFlakyTests: 0,
+              quarantinedTests: 0,
+              distribution: [],
+            },
+            resolution: {
+              resolvedFlaky: 0,
+              newFlaky: 0,
+              mttdDays: null,
+              mttrDays: null,
+            },
+            healthScore: 100,
+          },
+          reason: {
+            classifications: [],
+            patterns: [],
+            riskPredictions: [],
+            summary: {
+              totalAnalyzed: 0,
+              trueFlakyCount: 0,
+              regressionCount: 0,
+              quarantineRecommended: 0,
+              urgentFixes: 0,
+            },
+          },
+        }],
+      ]),
+    });
+
+    expect(summary.tasks).toEqual([
+      {
+        taskId: "paint-vrt",
+        totalTests: 0,
+        failed: 0,
+        flaky: 0,
+        skipped: 0,
+        status: "missing",
+      },
+    ]);
+  });
+});
+
+describe("renderFlakerBatchSummaryMarkdown", () => {
+  it("renders aggregate overview", () => {
+    const markdown = renderFlakerBatchSummaryMarkdown({
+      schemaVersion: 1,
+      generatedAt: "2026-04-02T00:00:00.000Z",
+      taskCount: 2,
+      failedTasks: 1,
+      flakyTasks: 1,
+      healthyTasks: 0,
+      totalTests: 30,
+      tasks: [
+        {
+          taskId: "paint-vrt",
+          totalTests: 10,
+          failed: 1,
+          flaky: 0,
+          skipped: 0,
+          healthScore: 72,
+          newFlaky: 1,
+          urgentFixes: 1,
+          status: "failed",
+        },
+      ],
+    });
+
+    expect(markdown).toContain("# Flaker Daily Batch Summary");
+    expect(markdown).toContain("| Failed tasks | 1 |");
+    expect(markdown).toContain("| paint-vrt | failed | 10 | 1 | 0 | 72 | 1 | 1 |");
+  });
+});

--- a/tests/reporting/flaker-quarantine-expiry.test.ts
+++ b/tests/reporting/flaker-quarantine-expiry.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyQuarantineExpiry,
+  normalizeToUtcMidnight,
+  parseDateOnly,
+} from "../../src/cli/reporting/flaker-quarantine-expiry.js";
+
+describe("flaker-quarantine-expiry", () => {
+  it("parses YYYY-MM-DD dates only", () => {
+    expect(parseDateOnly("2026-04-02")?.toISOString()).toBe("2026-04-02T00:00:00.000Z");
+    expect(parseDateOnly("2026-04-31")).toBeNull();
+    expect(parseDateOnly("2026/04/02")).toBeNull();
+  });
+
+  it("normalizes dates to UTC midnight", () => {
+    expect(normalizeToUtcMidnight(new Date("2026-04-02T12:34:56Z")).toISOString()).toBe(
+      "2026-04-02T00:00:00.000Z",
+    );
+  });
+
+  it("classifies active, expires-soon, expired, and invalid expiry states", () => {
+    const now = new Date("2026-04-02T00:00:00.000Z");
+
+    expect(
+      classifyQuarantineExpiry(now, parseDateOnly("2026-04-10"), 7),
+    ).toEqual({
+      status: "active",
+      daysUntilExpiry: 8,
+    });
+    expect(
+      classifyQuarantineExpiry(now, parseDateOnly("2026-04-09"), 7),
+    ).toEqual({
+      status: "expires-soon",
+      daysUntilExpiry: 7,
+    });
+    expect(
+      classifyQuarantineExpiry(now, parseDateOnly("2026-04-01"), 7),
+    ).toEqual({
+      status: "expired",
+      daysUntilExpiry: -1,
+    });
+    expect(classifyQuarantineExpiry(now, null, 7)).toEqual({
+      status: "invalid",
+      daysUntilExpiry: null,
+    });
+  });
+});

--- a/tests/reporting/flaker-quarantine-match.test.ts
+++ b/tests/reporting/flaker-quarantine-match.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { parseFlakerQuarantine } from "../../src/cli/reporting/flaker-quarantine-parser.js";
+import {
+  compileTitlePattern,
+  findMatchingQuarantine,
+} from "../../src/cli/reporting/flaker-quarantine-match.js";
+
+describe("flaker-quarantine-match", () => {
+  it("compiles valid patterns and rejects invalid regex source", () => {
+    expect(compileTitlePattern("^real-world snapshot:")?.test("real-world snapshot: a")).toBe(
+      true,
+    );
+    expect(compileTitlePattern("(")).toBeNull();
+  });
+
+  it("matches entries by task, spec, mode, and title", () => {
+    const quarantine = parseFlakerQuarantine(`
+{
+  "schemaVersion": 1,
+  "entries": [
+    {
+      "id": "paint-vrt-real-world-local-assets",
+      "taskId": "paint-vrt",
+      "spec": "tests/paint-vrt.test.ts",
+      "titlePattern": "^real-world snapshot:",
+      "mode": "skip",
+      "scope": "environment",
+      "owner": "mizchi",
+      "reason": "Optional real-world fixtures are not always present locally.",
+      "condition": "Skip only when the named real-world snapshot is missing from disk.",
+      "introducedAt": "2026-04-01",
+      "expiresAt": "2026-06-30"
+    }
+  ]
+}
+`);
+
+    expect(findMatchingQuarantine(quarantine, {
+      taskId: "paint-vrt",
+      spec: "tests/paint-vrt.test.ts",
+      title: "real-world snapshot: playwright-intro stays within loose visual diff budget",
+      mode: "skip",
+    })?.id).toBe("paint-vrt-real-world-local-assets");
+    expect(findMatchingQuarantine(quarantine, {
+      taskId: "paint-vrt",
+      spec: "tests/paint-vrt.test.ts",
+      title: "other",
+    })).toBeUndefined();
+  });
+});

--- a/tests/reporting/flaker-quarantine-parser.test.ts
+++ b/tests/reporting/flaker-quarantine-parser.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { parseFlakerQuarantine } from "../../src/cli/reporting/flaker-quarantine-parser.js";
+
+describe("flaker-quarantine-parser", () => {
+  it("parses tracked quarantine entries directly", () => {
+    const config = parseFlakerQuarantine(`
+{
+  "schemaVersion": 1,
+  "entries": [
+    {
+      "id": "paint-vrt-real-world-local-assets",
+      "taskId": "paint-vrt",
+      "spec": "tests/paint-vrt.test.ts",
+      "titlePattern": "^real-world snapshot:",
+      "mode": "skip",
+      "scope": "environment",
+      "owner": "mizchi",
+      "reason": "Optional real-world fixtures are not always present locally.",
+      "condition": "Skip only when the named real-world snapshot is missing from disk.",
+      "introducedAt": "2026-04-01",
+      "expiresAt": "2026-06-30"
+    }
+  ]
+}
+`);
+
+    expect(config).toEqual({
+      schemaVersion: 1,
+      entries: [
+        {
+          id: "paint-vrt-real-world-local-assets",
+          taskId: "paint-vrt",
+          spec: "tests/paint-vrt.test.ts",
+          titlePattern: "^real-world snapshot:",
+          mode: "skip",
+          scope: "environment",
+          owner: "mizchi",
+          reason: "Optional real-world fixtures are not always present locally.",
+          condition: "Skip only when the named real-world snapshot is missing from disk.",
+          introducedAt: "2026-04-01",
+          expiresAt: "2026-06-30",
+          trackingIssue: undefined,
+        },
+      ],
+    });
+  });
+});

--- a/tests/reporting/flaker-quarantine-report.test.ts
+++ b/tests/reporting/flaker-quarantine-report.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { renderQuarantineMarkdown } from "../../src/cli/reporting/flaker-quarantine-report.js";
+import type { FlakerQuarantineSummary } from "../../src/cli/reporting/flaker-quarantine-contract.js";
+
+const SUMMARY: FlakerQuarantineSummary = {
+  schemaVersion: 1,
+  generatedAt: "2026-04-02T00:00:00.000Z",
+  entryCount: 1,
+  modeCounts: {
+    skip: 1,
+    allow_flaky: 0,
+    allow_failure: 0,
+  },
+  scopeCounts: {
+    environment: 1,
+    flaky: 0,
+    expected_failure: 0,
+  },
+  entries: [
+    {
+      id: "paint-vrt-real-world-local-assets",
+      taskId: "paint-vrt",
+      spec: "tests/paint-vrt.test.ts",
+      titlePattern: "^real-world snapshot:",
+      mode: "skip",
+      scope: "environment",
+      owner: "mizchi",
+      reason: "Optional real-world fixtures are not always present locally.",
+      condition: "Skip only when the named real-world snapshot is missing from disk.",
+      introducedAt: "2026-04-01",
+      expiresAt: "2026-06-30",
+      expiryStatus: "active",
+      daysUntilExpiry: 89,
+    },
+  ],
+  errors: [
+    {
+      severity: "error",
+      code: "expired-quarantine",
+      message: "Quarantine entry expired",
+    },
+  ],
+  warnings: [
+    {
+      severity: "warning",
+      code: "expires-soon",
+      message: "Quarantine entry expires soon",
+    },
+  ],
+};
+
+describe("flaker-quarantine-report", () => {
+  it("renders markdown summary directly", () => {
+    const markdown = renderQuarantineMarkdown(SUMMARY);
+
+    expect(markdown).toContain("# Flaker Quarantine Summary");
+    expect(markdown).toContain("| Entries | 1 |");
+    expect(markdown).toContain("paint-vrt-real-world-local-assets");
+    expect(markdown).toContain("## Errors");
+    expect(markdown).toContain("## Warnings");
+  });
+});

--- a/tests/reporting/flaker-quarantine-summary-core.test.ts
+++ b/tests/reporting/flaker-quarantine-summary-core.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { parseFlakerQuarantine } from "../../src/cli/reporting/flaker-quarantine-parser.js";
+import { buildFlakerQuarantineSummary } from "../../src/cli/reporting/flaker-quarantine-summary-core.js";
+
+describe("buildFlakerQuarantineSummary", () => {
+  it("validates ownership, expiry, and missing specs from prepared inputs", () => {
+    const quarantine = parseFlakerQuarantine(`
+{
+  "schemaVersion": 1,
+  "entries": [
+    {
+      "id": "paint-vrt-real-world-local-assets",
+      "taskId": "paint-vrt",
+      "spec": "tests/paint-vrt.test.ts",
+      "titlePattern": "^real-world snapshot:",
+      "mode": "skip",
+      "scope": "environment",
+      "owner": "mizchi",
+      "reason": "Optional real-world fixtures are not always present locally.",
+      "condition": "Skip only when the named real-world snapshot is missing from disk.",
+      "introducedAt": "2026-04-01",
+      "expiresAt": "2026-04-04"
+    },
+    {
+      "id": "missing-spec",
+      "taskId": "paint-vrt",
+      "spec": "tests/missing.test.ts",
+      "titlePattern": "^fixture:",
+      "mode": "skip",
+      "scope": "environment",
+      "owner": "mizchi",
+      "reason": "Broken config fixture",
+      "condition": "Never",
+      "introducedAt": "2026-04-01",
+      "expiresAt": "2026-05-01"
+    },
+    {
+      "id": "missing-task",
+      "taskId": "does-not-exist",
+      "spec": "tests/paint-vrt.test.ts",
+      "titlePattern": "[",
+      "mode": "skip",
+      "scope": "environment",
+      "owner": "mizchi",
+      "reason": "Broken config fixture",
+      "condition": "Never",
+      "introducedAt": "2026-04-01",
+      "expiresAt": "2026-03-31"
+    }
+  ]
+}
+`);
+
+    const summary = buildFlakerQuarantineSummary({
+      quarantine,
+      tasks: [
+        {
+          id: "paint-vrt",
+          specs: ["tests/paint-vrt.test.ts"],
+        },
+      ],
+      existingSpecs: new Set(["tests/paint-vrt.test.ts"]),
+      now: new Date("2026-04-01T00:00:00Z"),
+    });
+
+    expect(summary.entryCount).toBe(3);
+    expect(summary.modeCounts.skip).toBe(3);
+    expect(summary.scopeCounts.environment).toBe(3);
+    expect(summary.errors.map((issue) => issue.code)).toEqual([
+      "missing-spec",
+      "unknown-task",
+      "invalid-title-pattern",
+      "invalid-expiry-range",
+      "expired-quarantine",
+    ]);
+    expect(summary.warnings.map((issue) => issue.code)).toEqual(["expires-soon"]);
+    expect(summary.entries.find((entry) => entry.id === "paint-vrt-real-world-local-assets")?.expiryStatus)
+      .toBe("expires-soon");
+    expect(summary.entries.find((entry) => entry.id === "missing-task")?.expiryStatus)
+      .toBe("expired");
+  });
+});

--- a/tests/reporting/flaker-task-summary-core.test.ts
+++ b/tests/reporting/flaker-task-summary-core.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildFlakerTaskSummaryReport,
+  renderFlakerTaskSummaryMarkdown,
+} from "../../src/cli/reporting/flaker-task-summary-core.js";
+
+describe("buildFlakerTaskSummaryReport", () => {
+  it("builds a report from eval and reason outputs", () => {
+    const summary = buildFlakerTaskSummaryReport({
+      taskId: "paint-vrt",
+      workspaceDir: "/tmp/.flaker/tasks/paint-vrt",
+      eval: {
+        dataSufficiency: {
+          totalRuns: 4,
+          totalResults: 28,
+          uniqueTests: 7,
+          firstDate: "2026-04-01T00:00:00.000Z",
+          lastDate: "2026-04-02T00:00:00.000Z",
+          avgRunsPerTest: 4,
+        },
+        detection: {
+          flakyTests: 2,
+          trueFlakyTests: 1,
+          quarantinedTests: 0,
+          distribution: [],
+        },
+        resolution: {
+          resolvedFlaky: 1,
+          newFlaky: 1,
+          mttdDays: 0.5,
+          mttrDays: 1.5,
+        },
+        healthScore: 72,
+      },
+      reason: {
+        classifications: [],
+        patterns: [],
+        riskPredictions: [],
+        summary: {
+          totalAnalyzed: 1,
+          trueFlakyCount: 0,
+          regressionCount: 0,
+          quarantineRecommended: 0,
+          urgentFixes: 0,
+        },
+      },
+    });
+
+    expect(summary).toMatchObject({
+      schemaVersion: 1,
+      taskId: "paint-vrt",
+      workspaceDir: "/tmp/.flaker/tasks/paint-vrt",
+    });
+    expect(summary.generatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+});
+
+describe("renderFlakerTaskSummaryMarkdown", () => {
+  it("renders key eval and reason sections", () => {
+    const markdown = renderFlakerTaskSummaryMarkdown({
+      schemaVersion: 1,
+      generatedAt: "2026-04-02T00:00:00.000Z",
+      taskId: "paint-vrt",
+      workspaceDir: "/tmp/.flaker/tasks/paint-vrt",
+      eval: {
+        dataSufficiency: {
+          totalRuns: 4,
+          totalResults: 28,
+          uniqueTests: 7,
+          firstDate: "2026-04-01T00:00:00.000Z",
+          lastDate: "2026-04-02T00:00:00.000Z",
+          avgRunsPerTest: 4,
+        },
+        detection: {
+          flakyTests: 2,
+          trueFlakyTests: 1,
+          quarantinedTests: 0,
+          distribution: [],
+        },
+        resolution: {
+          resolvedFlaky: 1,
+          newFlaky: 1,
+          mttdDays: 0.5,
+          mttrDays: 1.5,
+        },
+        healthScore: 72,
+      },
+      reason: {
+        classifications: [
+          {
+            suite: "tests/paint-vrt.test.ts",
+            testName: "fixture: cards",
+            classification: "intermittent",
+            confidence: 0.7,
+            recommendation: "monitor",
+            priority: "medium",
+            evidence: ["passes on retry"],
+          },
+        ],
+        patterns: [
+          {
+            type: "suite-instability",
+            description: "Suite has multiple flaky tests",
+            severity: "medium",
+            affectedTests: ["fixture: cards"],
+          },
+        ],
+        riskPredictions: [
+          {
+            suite: "tests/paint-vrt.test.ts",
+            testName: "fixture: cards",
+            riskScore: 55,
+            reason: "recent failure",
+          },
+        ],
+        summary: {
+          totalAnalyzed: 1,
+          trueFlakyCount: 0,
+          regressionCount: 0,
+          quarantineRecommended: 0,
+          urgentFixes: 0,
+        },
+      },
+    });
+
+    expect(markdown).toContain("# Flaker Task Summary");
+    expect(markdown).toContain("| Health score | 72 |");
+    expect(markdown).toContain("## Priority Tests");
+    expect(markdown).toContain("## Patterns");
+    expect(markdown).toContain("## Risk Predictions");
+  });
+});

--- a/tests/reporting/playwright-report-contract.test.ts
+++ b/tests/reporting/playwright-report-contract.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import {
+  accumulatePlaywrightFileSummary,
+  accumulatePlaywrightSummaryTotals,
+  buildStablePlaywrightIdentity,
+  createEmptyPlaywrightFileSummary,
+  createEmptyPlaywrightSummaryTotals,
+  isPlaywrightOutcomeUnstable,
+  playwrightOutcomeSeverity,
+  resolvePlaywrightTestIdentityKey,
+  type PlaywrightTestRow,
+} from "../../src/cli/reporting/playwright-report-contract.js";
+
+function makeRow(
+  outcome: PlaywrightTestRow["outcome"],
+  overrides?: Partial<PlaywrightTestRow>,
+): PlaywrightTestRow {
+  return {
+    id: "tests/example.test.ts::works [chromium]",
+    file: "tests/example.test.ts",
+    title: "works",
+    titlePath: ["Example Suite", "works"],
+    identityKey: "{\"spec\":\"tests/example.test.ts\",\"suite\":\"Example Suite\",\"testName\":\"works\",\"titlePath\":[\"works\"],\"variant\":{\"project\":\"chromium\"}}",
+    identity: {
+      key: "{\"spec\":\"tests/example.test.ts\",\"suite\":\"Example Suite\",\"testName\":\"works\",\"titlePath\":[\"works\"],\"variant\":{\"project\":\"chromium\"}}",
+      suite: "Example Suite",
+      testName: "works",
+      spec: "tests/example.test.ts",
+      titlePath: ["works"],
+      variant: { project: "chromium" },
+    },
+    projectName: "chromium",
+    expectedStatus: "passed",
+    rawStatus: outcome,
+    outcome,
+    attempts: [outcome],
+    retryCount: 0,
+    durationMs: 10,
+    errorMessages: [],
+    ...overrides,
+  };
+}
+
+describe("buildStablePlaywrightIdentity", () => {
+  it("drops empty variant values and sorts keys before building the key", () => {
+    const identity = buildStablePlaywrightIdentity({
+      suite: "Example Suite",
+      testName: "works",
+      spec: "tests/example.test.ts",
+      titlePath: ["works"],
+      variant: {
+        browser: "chromium",
+        empty: "",
+        shard: "2/4",
+      },
+    });
+
+    expect(identity.variant).toEqual({
+      browser: "chromium",
+      shard: "2/4",
+    });
+    expect(identity.key).toBe(
+      "{\"spec\":\"tests/example.test.ts\",\"suite\":\"Example Suite\",\"testName\":\"works\",\"titlePath\":[\"works\"],\"variant\":{\"browser\":\"chromium\",\"shard\":\"2/4\"}}",
+    );
+  });
+});
+
+describe("resolvePlaywrightTestIdentityKey", () => {
+  it("prefers identityKey, then stable identity key, then row id", () => {
+    expect(resolvePlaywrightTestIdentityKey(makeRow("passed"))).toBe(
+      "{\"spec\":\"tests/example.test.ts\",\"suite\":\"Example Suite\",\"testName\":\"works\",\"titlePath\":[\"works\"],\"variant\":{\"project\":\"chromium\"}}",
+    );
+    expect(
+      resolvePlaywrightTestIdentityKey(
+        makeRow("passed", {
+          identityKey: "",
+        }),
+      ),
+    ).toBe(
+      "{\"spec\":\"tests/example.test.ts\",\"suite\":\"Example Suite\",\"testName\":\"works\",\"titlePath\":[\"works\"],\"variant\":{\"project\":\"chromium\"}}",
+    );
+    expect(
+      resolvePlaywrightTestIdentityKey(
+        makeRow("passed", {
+          identityKey: "",
+          identity: undefined,
+        }),
+      ),
+    ).toBe("tests/example.test.ts::works [chromium]");
+  });
+});
+
+describe("playwright report accumulators", () => {
+  it("updates totals, file summary, and unstable severity consistently", () => {
+    const flakyRow = makeRow("flaky", {
+      attempts: ["failed", "passed"],
+      retryCount: 1,
+      durationMs: 42,
+    });
+    const totals = createEmptyPlaywrightSummaryTotals();
+    const fileSummary = createEmptyPlaywrightFileSummary(flakyRow.file);
+
+    accumulatePlaywrightSummaryTotals(totals, flakyRow);
+    accumulatePlaywrightFileSummary(fileSummary, flakyRow);
+
+    expect(totals).toMatchObject({
+      total: 1,
+      flaky: 1,
+      retries: 1,
+      durationMs: 42,
+    });
+    expect(fileSummary).toMatchObject({
+      file: "tests/example.test.ts",
+      total: 1,
+      flaky: 1,
+      retries: 1,
+      durationMs: 42,
+    });
+    expect(playwrightOutcomeSeverity("passed")).toBe(0);
+    expect(playwrightOutcomeSeverity("flaky")).toBe(1);
+    expect(playwrightOutcomeSeverity("failed")).toBe(2);
+    expect(isPlaywrightOutcomeUnstable("passed")).toBe(false);
+    expect(isPlaywrightOutcomeUnstable("flaky")).toBe(true);
+  });
+});

--- a/tests/reporting/playwright-report-diff.test.ts
+++ b/tests/reporting/playwright-report-diff.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPlaywrightDiff,
+  renderPlaywrightDiffMarkdown,
+} from "../../src/cli/reporting/playwright-report-diff-core.js";
+import type {
+  PlaywrightFileSummary,
+  PlaywrightStableIdentity,
+  PlaywrightOutcome,
+  PlaywrightSummary,
+  PlaywrightSummaryTotals,
+  PlaywrightTestRow,
+} from "../../src/cli/reporting/playwright-report-contract.js";
+
+function makeIdentity(
+  file: string,
+  title: string,
+  projectName: string,
+): PlaywrightStableIdentity {
+  const variant = projectName ? { project: projectName } : {};
+  const keyPayload: Record<string, unknown> = {
+    spec: file,
+    suite: file,
+    testName: title,
+    titlePath: [title],
+  };
+  if (projectName) {
+    keyPayload.variant = variant;
+  }
+  return {
+    key: JSON.stringify(keyPayload),
+    suite: file,
+    testName: title,
+    spec: file,
+    titlePath: [title],
+    variant,
+  };
+}
+
+function makeRow(
+  id: string,
+  file: string,
+  title: string,
+  outcome: PlaywrightOutcome,
+  attempts: string[],
+): PlaywrightTestRow {
+  const identity = makeIdentity(file, title, "chromium");
+  return {
+    id,
+    file,
+    title,
+    titlePath: [file, title],
+    identityKey: identity.key,
+    identity,
+    projectName: "chromium",
+    expectedStatus: "passed",
+    rawStatus: outcome,
+    outcome,
+    attempts,
+    retryCount: Math.max(0, attempts.length - 1),
+    durationMs: attempts.length * 10,
+    errorMessages: [],
+  };
+}
+
+function makeSummary(label: string, tests: PlaywrightTestRow[]): PlaywrightSummary {
+  const totals: PlaywrightSummaryTotals = {
+    total: 0,
+    passed: 0,
+    failed: 0,
+    flaky: 0,
+    skipped: 0,
+    timedout: 0,
+    interrupted: 0,
+    unknown: 0,
+    retries: 0,
+    durationMs: 0,
+  };
+  const byFile = new Map<string, PlaywrightFileSummary>();
+
+  for (const row of tests) {
+    totals.total += 1;
+    totals.durationMs += row.durationMs;
+    totals.retries += row.retryCount;
+    if (row.outcome === "passed") totals.passed += 1;
+    else if (row.outcome === "failed") totals.failed += 1;
+    else if (row.outcome === "flaky") totals.flaky += 1;
+    else if (row.outcome === "skipped") totals.skipped += 1;
+    else if (row.outcome === "timedout") totals.timedout += 1;
+    else if (row.outcome === "interrupted") totals.interrupted += 1;
+    else totals.unknown += 1;
+
+    const fileSummary = byFile.get(row.file) ?? {
+      file: row.file,
+      total: 0,
+      passed: 0,
+      failed: 0,
+      flaky: 0,
+      skipped: 0,
+      retries: 0,
+      durationMs: 0,
+    };
+    fileSummary.total += 1;
+    if (row.outcome === "passed") fileSummary.passed += 1;
+    else if (row.outcome === "failed") fileSummary.failed += 1;
+    else if (row.outcome === "flaky") fileSummary.flaky += 1;
+    else if (row.outcome === "skipped") fileSummary.skipped += 1;
+    fileSummary.retries += row.retryCount;
+    fileSummary.durationMs += row.durationMs;
+    byFile.set(row.file, fileSummary);
+  }
+
+  return {
+    schemaVersion: 1,
+    generatedAt: "2026-04-01T00:00:00.000Z",
+    label,
+    totals,
+    files: [...byFile.values()].sort((a, b) => a.file.localeCompare(b.file)),
+    tests: [...tests].sort((a, b) => a.id.localeCompare(b.id)),
+  };
+}
+
+function makeBaseSummary(): PlaywrightSummary {
+  return makeSummary("base", [
+    makeRow("tests/a.test.ts::smoke [chromium]", "tests/a.test.ts", "smoke", "passed", ["passed"]),
+    makeRow("tests/a.test.ts::retry [chromium]", "tests/a.test.ts", "retry", "flaky", ["failed", "passed"]),
+    makeRow("tests/b.test.ts::render [chromium]", "tests/b.test.ts", "render", "failed", ["failed"]),
+    makeRow("tests/c.test.ts::legacy [chromium]", "tests/c.test.ts", "legacy", "flaky", ["failed", "passed"]),
+    makeRow("tests/d.test.ts::removed [chromium]", "tests/d.test.ts", "removed", "failed", ["failed"]),
+  ]);
+}
+
+function makeHeadSummary(): PlaywrightSummary {
+  return makeSummary("head", [
+    makeRow("HEAD::tests/a.test.ts::smoke [chromium]", "tests/a.test.ts", "smoke", "failed", ["failed"]),
+    makeRow("HEAD::tests/a.test.ts::retry [chromium]", "tests/a.test.ts", "retry", "passed", ["passed"]),
+    makeRow("HEAD::tests/b.test.ts::render [chromium]", "tests/b.test.ts", "render", "flaky", ["failed", "passed"]),
+    makeRow("HEAD::tests/c.test.ts::legacy [chromium]", "tests/c.test.ts", "legacy", "flaky", ["failed", "passed"]),
+    makeRow("HEAD::tests/e.test.ts::new flaky [chromium]", "tests/e.test.ts", "new flaky", "flaky", ["failed", "passed"]),
+  ]);
+}
+
+describe("buildPlaywrightDiff", () => {
+  it("detects regressions, improvements, and persistent unstable tests", () => {
+    const diff = buildPlaywrightDiff(makeBaseSummary(), makeHeadSummary(), "paint-vrt");
+
+    expect(diff.totals.baseTotal).toBe(5);
+    expect(diff.totals.headTotal).toBe(5);
+    expect(diff.totals.addedTests).toBe(1);
+    expect(diff.totals.removedTests).toBe(1);
+    expect(diff.totals.regressions).toBe(2);
+    expect(diff.totals.newFailures).toBe(1);
+    expect(diff.totals.newFlaky).toBe(1);
+    expect(diff.totals.improvements).toBe(3);
+    expect(diff.totals.resolved).toBe(1);
+    expect(diff.totals.improved).toBe(1);
+    expect(diff.totals.removedUnstable).toBe(1);
+    expect(diff.totals.persistentUnstable).toBe(1);
+    expect(diff.regressions.map((row) => row.kind)).toEqual(["new_failure", "new_flaky"]);
+    expect(diff.improvements.map((row) => row.kind)).toEqual([
+      "resolved",
+      "improved",
+      "removed_unstable",
+    ]);
+    expect(diff.persistentUnstable.map((row) => row.kind)).toEqual(["persistent_flaky"]);
+  });
+});
+
+describe("renderPlaywrightDiffMarkdown", () => {
+  it("renders regression and improvement sections", () => {
+    const markdown = renderPlaywrightDiffMarkdown(
+      buildPlaywrightDiff(makeBaseSummary(), makeHeadSummary(), "paint-vrt"),
+    );
+
+    expect(markdown).toContain("# Playwright Baseline Diff");
+    expect(markdown).toContain("| Label | paint-vrt |");
+    expect(markdown).toContain("| Base | base |");
+    expect(markdown).toContain("| Head | head |");
+    expect(markdown).toContain("## Regressions");
+    expect(markdown).toContain("new_failure");
+    expect(markdown).toContain("## Improvements");
+    expect(markdown).toContain("removed_unstable");
+    expect(markdown).toContain("## Persistent Unstable");
+    expect(markdown).toContain("persistent_flaky");
+  });
+});

--- a/tests/reporting/playwright-report-summary.test.ts
+++ b/tests/reporting/playwright-report-summary.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPlaywrightSummary,
+  renderPlaywrightMarkdown,
+  type PlaywrightJsonReport,
+} from "../../src/cli/reporting/playwright-report-summary-core.js";
+
+function makeReport(): PlaywrightJsonReport {
+  return {
+    config: {},
+    suites: [
+      {
+        title: "tests/playwright-adapter.test.ts",
+        file: "tests/playwright-adapter.test.ts",
+        suites: [
+          {
+            title: "Playwright Adapter Tests",
+            file: "tests/playwright-adapter.test.ts",
+            specs: [
+              {
+                title: "goto and evaluate work together",
+                ok: true,
+                tags: [],
+                tests: [
+                  {
+                    projectName: "chromium",
+                    expectedStatus: "passed",
+                    status: "expected",
+                    results: [
+                      {
+                        retry: 0,
+                        workerIndex: 0,
+                        status: "passed",
+                        duration: 18,
+                        errors: [],
+                        startTime: "2026-04-01T00:00:00.000Z",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                title: "locator count",
+                ok: true,
+                tags: [],
+                tests: [
+                  {
+                    projectName: "chromium",
+                    expectedStatus: "passed",
+                    status: "flaky",
+                    results: [
+                      {
+                        retry: 0,
+                        workerIndex: 0,
+                        status: "failed",
+                        duration: 120,
+                        errors: [{ message: "first failure" }],
+                        startTime: "2026-04-01T00:00:01.000Z",
+                      },
+                      {
+                        retry: 1,
+                        workerIndex: 1,
+                        status: "passed",
+                        duration: 33,
+                        errors: [],
+                        startTime: "2026-04-01T00:00:02.000Z",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        title: "tests/paint-vrt.test.ts",
+        file: "tests/paint-vrt.test.ts",
+        specs: [
+          {
+            title: "fixture: cards and controls stay within relaxed visual diff budget",
+            ok: false,
+            tags: [],
+            tests: [
+              {
+                projectName: "chromium",
+                expectedStatus: "passed",
+                status: "unexpected",
+                results: [
+                  {
+                    retry: 0,
+                    workerIndex: 0,
+                    status: "failed",
+                    duration: 210,
+                    errors: [{ message: "visual diff exceeded" }],
+                    startTime: "2026-04-01T00:00:05.000Z",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            title: "fixture: footer with multi-column links",
+            ok: true,
+            tags: [],
+            tests: [
+              {
+                projectName: "chromium",
+                expectedStatus: "skipped",
+                status: "skipped",
+                annotations: [{ type: "skip", description: "temporarily disabled" }],
+                results: [
+                  {
+                    retry: 0,
+                    workerIndex: 0,
+                    status: "skipped",
+                    duration: 0,
+                    errors: [],
+                    startTime: "2026-04-01T00:00:06.000Z",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    errors: [],
+    stats: {
+      startTime: "2026-04-01T00:00:00.000Z",
+      duration: 381,
+      expected: 2,
+      skipped: 1,
+      unexpected: 1,
+      flaky: 1,
+    },
+  };
+}
+
+describe("buildPlaywrightSummary", () => {
+  it("normalizes rows, emits stable identities, and groups by file", () => {
+    const summary = buildPlaywrightSummary(makeReport(), "playwright-bidi");
+
+    expect(summary.totals.total).toBe(4);
+    expect(summary.totals.passed).toBe(1);
+    expect(summary.totals.failed).toBe(1);
+    expect(summary.totals.flaky).toBe(1);
+    expect(summary.totals.skipped).toBe(1);
+    expect(summary.totals.retries).toBe(1);
+    expect(summary.files).toHaveLength(2);
+    expect(summary.files[0]?.file).toBe("tests/paint-vrt.test.ts");
+    expect(summary.files[0]?.failed).toBe(1);
+
+    const flakyRow = summary.tests.find((row) => row.title === "locator count");
+    expect(flakyRow?.outcome).toBe("flaky");
+    expect(flakyRow?.attempts).toEqual(["failed", "passed"]);
+    expect(flakyRow?.retryCount).toBe(1);
+    expect(flakyRow?.identityKey).toBe(flakyRow?.identity?.key);
+    expect(flakyRow?.identity).toMatchObject({
+      suite: "Playwright Adapter Tests",
+      testName: "locator count",
+      spec: "tests/playwright-adapter.test.ts",
+      titlePath: ["locator count"],
+      variant: { project: "chromium" },
+    });
+  });
+});
+
+describe("renderPlaywrightMarkdown", () => {
+  it("renders totals, file table, and flaky section", () => {
+    const markdown = renderPlaywrightMarkdown(
+      buildPlaywrightSummary(makeReport(), "paint-vrt"),
+    );
+
+    expect(markdown).toContain("# Playwright Report Summary");
+    expect(markdown).toContain("| Label | paint-vrt |");
+    expect(markdown).toContain("| tests/paint-vrt.test.ts | 2 | 0 | 1 | 0 | 1 |");
+    expect(markdown).toContain("## Flaky / Retried Tests");
+    expect(markdown).toContain("locator count");
+    expect(markdown).toContain("failed -> passed");
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable Playwright normalized report contract, summary core, and baseline diff core under `src/cli/reporting`
- port the crater-side tests for report contract/summary/diff into `tests/reporting`
- fix existing `tsc` type errors in `src/cli/config.ts` and `src/cli/main.ts` so the branch builds cleanly

## Verification
- `pnpm run build`
- `pnpm exec vitest run tests/adapters/playwright.test.ts tests/reporting/playwright-report-contract.test.ts tests/reporting/playwright-report-summary.test.ts tests/reporting/playwright-report-diff.test.ts`

## Notes
- `tests/commands/collect.test.ts` still could not run locally in this worktree because the local `duckdb` native binding was not materialized by pnpm build approval in this environment.