### PR TITLE
Add VRT adapters and collected artifact tracking

### DIFF
--- a/docs/how-to-use.ja.md
+++ b/docs/how-to-use.ja.md
@@ -42,6 +42,22 @@ flaker import report.json --adapter playwright --commit $(git rev-parse HEAD)
 
 # JUnit XML レポート
 flaker import results.xml --adapter junit --commit $(git rev-parse HEAD)
+
+# vrt-harness migration-report.json 用の built-in adapter
+flaker import ../vrt-harness/test-results/migration/migration-report.json \
+  --adapter vrt-migration \
+  --commit $(git rev-parse HEAD)
+
+# vrt-harness bench-report.json 用の built-in adapter
+flaker import ../vrt-harness/test-results/css-bench/dashboard/bench-report.json \
+  --adapter vrt-bench \
+  --commit $(git rev-parse HEAD)
+
+# 任意フォーマット向け custom adapter
+flaker import ../vrt-harness/test-results/migration/migration-report.json \
+  --adapter custom \
+  --custom-command "node --experimental-strip-types ../vrt-harness/src/flaker-vrt-report-adapter.ts --scenario-id migration/tailwind-to-vanilla --backend chromium" \
+  --commit $(git rev-parse HEAD)
 ```
 
 ### 3. 分析する
@@ -84,7 +100,9 @@ path = ".flaker/data.duckdb"
 
 # テスト結果のパース形式
 [adapter]
-type = "playwright"     # "playwright" | "junit" | "custom"
+type = "playwright"     # "playwright" | "junit" | "vrt-migration" | "vrt-bench" | "custom"
+artifact_name = "playwright-report"
+# command = "node ./adapter.js"  # custom のときだけ必要
 
 # テストランナー
 [runner]
@@ -119,17 +137,22 @@ flaker collect --last 90          # 直近 90 日分
 flaker collect --branch main      # main ブランチのみ
 ```
 
-GitHub Actions の artifact から Playwright JSON / JUnit XML を自動抽出します。`GITHUB_TOKEN` 環境変数が必要です。
+GitHub Actions の artifact からテストレポートを自動抽出します。既定の artifact 名は `playwright` が `playwright-report`、`junit` が `junit-report`、`vrt-migration` が `migration-report`、`vrt-bench` が `bench-report` です。workflow 側で別名を使う場合は `[adapter].artifact_name` で上書きします。`GITHUB_TOKEN` 環境変数が必要です。
 
 ### `flaker import` — ローカルレポートの取り込み
 
 ```bash
 flaker import report.json --adapter playwright
 flaker import results.xml --adapter junit
+flaker import migration-report.json --adapter vrt-migration
+flaker import bench-report.json --adapter vrt-bench
+flaker import migration-report.json --adapter custom --custom-command "node ./adapter.js"
 flaker import report.json --commit abc123 --branch feature-x
 ```
 
 CI を使わずローカルで生成したテストレポートを直接 DB に格納します。
+
+`--adapter custom` では、入力ファイルの中身を stdin で受けて `TestCaseResult[]` JSON を stdout に返す任意コマンドを指定できます。Playwright/JUnit 以外の独自レポートを bridge する用途です。
 
 ### `flaker collect-local` — actrun 実行履歴の取り込み
 

--- a/docs/how-to-use.md
+++ b/docs/how-to-use.md
@@ -42,6 +42,22 @@ flaker import report.json --adapter playwright --commit $(git rev-parse HEAD)
 
 # JUnit XML report
 flaker import results.xml --adapter junit --commit $(git rev-parse HEAD)
+
+# Built-in vrt-harness migration-report.json adapter
+flaker import ../vrt-harness/test-results/migration/migration-report.json \
+  --adapter vrt-migration \
+  --commit $(git rev-parse HEAD)
+
+# Built-in vrt-harness bench-report.json adapter
+flaker import ../vrt-harness/test-results/css-bench/dashboard/bench-report.json \
+  --adapter vrt-bench \
+  --commit $(git rev-parse HEAD)
+
+# Custom adapter for arbitrary formats
+flaker import ../vrt-harness/test-results/migration/migration-report.json \
+  --adapter custom \
+  --custom-command "node --experimental-strip-types ../vrt-harness/src/flaker-vrt-report-adapter.ts --scenario-id migration/tailwind-to-vanilla --backend chromium" \
+  --commit $(git rev-parse HEAD)
 ```
 
 ### 3. Analyze
@@ -84,7 +100,9 @@ path = ".flaker/data.duckdb"
 
 # Test result parsing format
 [adapter]
-type = "playwright"     # "playwright" | "junit" | "custom"
+type = "playwright"     # "playwright" | "junit" | "vrt-migration" | "vrt-bench" | "custom"
+artifact_name = "playwright-report"
+# command = "node ./adapter.js"  # required only for custom
 
 # Test runner
 [runner]
@@ -119,17 +137,22 @@ flaker collect --last 90          # Last 90 days
 flaker collect --branch main      # main branch only
 ```
 
-Auto-extracts Playwright JSON / JUnit XML from GitHub Actions artifacts. Requires `GITHUB_TOKEN` environment variable.
+Auto-extracts test reports from GitHub Actions artifacts. The default artifact name is `playwright-report` for `playwright`, `junit-report` for `junit`, `migration-report` for `vrt-migration`, and `bench-report` for `vrt-bench`. Override it with `[adapter].artifact_name` when your workflow uses a different artifact name. Requires `GITHUB_TOKEN` environment variable.
 
 ### `flaker import` — Import Local Reports
 
 ```bash
 flaker import report.json --adapter playwright
 flaker import results.xml --adapter junit
+flaker import migration-report.json --adapter vrt-migration
+flaker import bench-report.json --adapter vrt-bench
+flaker import migration-report.json --adapter custom --custom-command "node ./adapter.js"
 flaker import report.json --commit abc123 --branch feature-x
 ```
 
 Import locally-generated test reports directly into the database.
+
+With `--adapter custom`, you provide an arbitrary command that receives the file contents on stdin and returns `TestCaseResult[]` JSON on stdout. This is the bridge for importing non-Playwright / non-JUnit report formats.
 
 ### `flaker collect-local` — Import actrun History
 

--- a/src/cli/adapters/actrun.ts
+++ b/src/cli/adapters/actrun.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 import type { TestCaseResult, TestResultAdapter } from "./types.js";
 import { resolveTestIdentity } from "../identity.js";
+import { parseVitestJson } from "../runners/vitest.js";
 
 export interface ActrunTask {
   id: string;
@@ -102,7 +103,8 @@ export function extractTestReportsFromArtifacts(
           }
           // Detect Vitest format (has "testResults" key)
           if (parsed.testResults) {
-            // Could add vitest parsing here too
+            results.push(...parseVitestJson(content));
+            continue;
           }
         } catch {
           /* not a valid report, skip */

--- a/src/cli/adapters/index.ts
+++ b/src/cli/adapters/index.ts
@@ -1,0 +1,29 @@
+import type { TestResultAdapter } from "./types.js";
+import { CustomAdapter } from "./custom.js";
+import { junitAdapter } from "./junit.js";
+import { playwrightAdapter } from "./playwright.js";
+import { vrtBenchAdapter } from "./vrt-bench.js";
+import { vrtMigrationAdapter } from "./vrt-migration.js";
+
+export function createTestResultAdapter(
+  type: string,
+  customCommand?: string,
+): TestResultAdapter {
+  switch (type) {
+    case "playwright":
+      return playwrightAdapter;
+    case "junit":
+      return junitAdapter;
+    case "vrt-migration":
+      return vrtMigrationAdapter;
+    case "vrt-bench":
+      return vrtBenchAdapter;
+    case "custom":
+      if (!customCommand) {
+        throw new Error("Custom adapter requires a command (customCommand)");
+      }
+      return new CustomAdapter({ command: customCommand });
+    default:
+      throw new Error(`Unknown adapter type: ${type}`);
+  }
+}

--- a/src/cli/adapters/vrt-bench.ts
+++ b/src/cli/adapters/vrt-bench.ts
@@ -1,0 +1,123 @@
+import { resolveTestIdentity } from "../identity.js";
+import type { TestCaseResult, TestResultAdapter } from "./types.js";
+
+interface BenchViewportResult {
+  width: number;
+  height: number;
+  visualDiffDetected: boolean;
+  visualDiffRatio: number;
+  a11yDiffDetected: boolean;
+  a11yChangeCount: number;
+  computedStyleDiffCount: number;
+  hoverDiffDetected: boolean;
+  paintTreeDiffCount: number;
+}
+
+interface BenchTrial {
+  fixture?: string;
+  backend: string;
+  fallbackUsed?: boolean;
+  backendResolvedBy?: string;
+  selector: string;
+  property: string;
+  value: string;
+  category: string;
+  selectorType: string;
+  isInteractive: boolean;
+  mediaCondition: string | null;
+  viewports?: BenchViewportResult[];
+  detected: boolean;
+  undetectedReason: string | null;
+}
+
+interface BenchReport {
+  meta?: {
+    fixture?: string;
+  };
+  trials: BenchTrial[];
+}
+
+function resolveFixture(report: BenchReport, trial: BenchTrial): string {
+  return trial.fixture ?? report.meta?.fixture ?? "unknown";
+}
+
+function buildSuite(fixture: string): string {
+  return `fixtures/css-challenge/${fixture}.html`;
+}
+
+function buildTaskId(fixture: string): string {
+  return `css-bench/${fixture}`;
+}
+
+function buildTestName(trial: BenchTrial): string {
+  return `${trial.selector} { ${trial.property}: ${trial.value} }`;
+}
+
+function buildVariant(trial: BenchTrial): Record<string, string> {
+  return {
+    backend: trial.backend,
+    category: trial.category,
+    selectorType: trial.selectorType,
+    interactive: String(trial.isInteractive),
+    fallbackUsed: String(Boolean(trial.fallbackUsed)),
+    resolvedBy: trial.backendResolvedBy ?? trial.backend,
+  };
+}
+
+function summarizeSignals(trial: BenchTrial): string | null {
+  if (!trial.viewports || trial.viewports.length === 0) {
+    return null;
+  }
+
+  const signalCount = trial.viewports.reduce(
+    (acc, viewport) => ({
+      visual: acc.visual + (viewport.visualDiffDetected ? 1 : 0),
+      computed: acc.computed + viewport.computedStyleDiffCount,
+      hover: acc.hover + (viewport.hoverDiffDetected ? 1 : 0),
+      paint: acc.paint + viewport.paintTreeDiffCount,
+    }),
+    { visual: 0, computed: 0, hover: 0, paint: 0 },
+  );
+
+  return `signals visual=${signalCount.visual} computed=${signalCount.computed} hover=${signalCount.hover} paint=${signalCount.paint}`;
+}
+
+function buildErrorMessage(trial: BenchTrial): string | undefined {
+  const pieces = [
+    trial.undetectedReason ?? "undetected",
+    `backend=${trial.backend}`,
+    trial.mediaCondition ? `media=${trial.mediaCondition}` : null,
+    summarizeSignals(trial),
+  ].filter((piece): piece is string => Boolean(piece));
+
+  return pieces.length > 0 ? pieces.join(" | ") : undefined;
+}
+
+export const vrtBenchAdapter: TestResultAdapter = {
+  name: "vrt-bench",
+  parse(input: string): TestCaseResult[] {
+    const report = JSON.parse(input) as BenchReport;
+
+    return report.trials.map((trial) => {
+      const fixture = resolveFixture(report, trial);
+      const status: TestCaseResult["status"] = trial.detected
+        ? "passed"
+        : "failed";
+      const result: TestCaseResult = resolveTestIdentity({
+        suite: buildSuite(fixture),
+        testName: buildTestName(trial),
+        taskId: buildTaskId(fixture),
+        filter: trial.mediaCondition ?? undefined,
+        status,
+        durationMs: 0,
+        retryCount: 0,
+        variant: buildVariant(trial),
+      });
+
+      if (status === "failed") {
+        result.errorMessage = buildErrorMessage(trial);
+      }
+      return result;
+    });
+  },
+};

--- a/src/cli/adapters/vrt-migration.ts
+++ b/src/cli/adapters/vrt-migration.ts
@@ -1,0 +1,143 @@
+import { resolveTestIdentity } from "../identity.js";
+import type { TestCaseResult, TestResultAdapter } from "./types.js";
+
+interface MigrationViewport {
+  width: number;
+  height: number;
+  label: string;
+}
+
+interface MigrationResult {
+  variant?: string;
+  variantFile?: string;
+  viewport: string;
+  diffPixels: number;
+  approved?: boolean;
+  approvalReasons?: string[];
+  dominantCategory?: string;
+  categorySummary?: string;
+  paintTreeSummary?: string;
+}
+
+interface MigrationReport {
+  dir?: string;
+  variants: string[];
+  viewports: MigrationViewport[];
+  results: MigrationResult[];
+}
+
+function normalizePath(value: string): string {
+  return value.replaceAll("\\", "/");
+}
+
+function basenameWithoutHtml(value: string): string {
+  const normalized = normalizePath(value).split("/").at(-1) ?? value;
+  return normalized.endsWith(".html")
+    ? normalized.slice(0, -".html".length)
+    : normalized;
+}
+
+function inferTaskId(reportDir?: string): string {
+  if (!reportDir) {
+    return "migration/unknown";
+  }
+
+  const segments = normalizePath(reportDir).split("/").filter(Boolean);
+  const migrationIndex = segments.lastIndexOf("migration");
+  if (migrationIndex >= 0 && segments[migrationIndex + 1]) {
+    return `migration/${segments[migrationIndex + 1]}`;
+  }
+
+  return `migration/${segments.at(-1) ?? "unknown"}`;
+}
+
+function resolveVariantFile(
+  report: MigrationReport,
+  result: MigrationResult,
+): string {
+  if (result.variantFile) {
+    return normalizePath(result.variantFile);
+  }
+
+  const exactMatch = report.variants.find((variantFile) =>
+    variantFile === result.variant || basenameWithoutHtml(variantFile) === result.variant,
+  );
+
+  if (exactMatch) {
+    return normalizePath(exactMatch);
+  }
+
+  return normalizePath(result.variant ? `${result.variant}.html` : "unknown.html");
+}
+
+function resolveSuite(reportDir: string | undefined, variantFile: string): string {
+  const normalizedVariant = normalizePath(variantFile);
+  if (!reportDir) {
+    return normalizedVariant;
+  }
+  if (normalizedVariant.includes("/")) {
+    return normalizedVariant;
+  }
+  return normalizePath(`${normalizePath(reportDir)}/${normalizedVariant}`);
+}
+
+function buildVariant(viewport: MigrationViewport): Record<string, string> {
+  return {
+    backend: "chromium",
+    viewport: viewport.label,
+    width: String(viewport.width),
+    height: String(viewport.height),
+  };
+}
+
+function buildErrorMessage(result: MigrationResult): string | undefined {
+  const pieces = [
+    `${result.diffPixels}px diff`,
+    result.dominantCategory && result.dominantCategory !== "none"
+      ? result.dominantCategory
+      : null,
+    result.categorySummary ?? null,
+    result.paintTreeSummary ?? null,
+  ].filter((entry): entry is string => Boolean(entry));
+
+  return pieces.length > 0 ? pieces.join(" | ") : undefined;
+}
+
+export const vrtMigrationAdapter: TestResultAdapter = {
+  name: "vrt-migration",
+  parse(input: string): TestCaseResult[] {
+    const report = JSON.parse(input) as MigrationReport;
+    const taskId = inferTaskId(report.dir);
+
+    return report.results.map((result) => {
+      const viewport = report.viewports.find((entry) => entry.label === result.viewport);
+      if (!viewport) {
+        throw new Error(`Unknown viewport in migration report: ${result.viewport}`);
+      }
+
+      const suite = resolveSuite(report.dir, resolveVariantFile(report, result));
+      const status: TestCaseResult["status"] =
+        result.approved || result.diffPixels === 0 ? "passed" : "failed";
+      const errorMessage = status === "failed"
+        ? buildErrorMessage(result)
+        : result.approved
+          ? (result.approvalReasons ?? []).join("; ") || "approved"
+          : undefined;
+
+      const testCaseResult: TestCaseResult = resolveTestIdentity({
+        suite,
+        testName: `viewport:${result.viewport}`,
+        taskId,
+        status,
+        durationMs: 0,
+        retryCount: 0,
+        variant: buildVariant(viewport),
+      });
+
+      if (errorMessage) {
+        testCaseResult.errorMessage = errorMessage;
+      }
+      return testCaseResult;
+    });
+  },
+};

--- a/src/cli/commands/collect-local.ts
+++ b/src/cli/commands/collect-local.ts
@@ -25,6 +25,13 @@ interface ActrunRunListEntry {
   status: string;
 }
 
+function actrunArtifactDirs(workspace: string, runId: string): string[] {
+  return [
+    join(workspace, ".actrun", "runs", runId, "artifacts"),
+    join(workspace, "_build", "actrun", "runs", runId, "artifacts"),
+  ];
+}
+
 export async function runCollectLocal(opts: CollectLocalOpts): Promise<CollectLocalResult> {
   const { store } = opts;
   const execFn = opts.exec ?? ((cmd: string) => execSync(cmd, { encoding: "utf-8" }));
@@ -58,9 +65,9 @@ export async function runCollectLocal(opts: CollectLocalOpts): Promise<CollectLo
 
     // Try to extract richer test reports from actrun artifacts
     const workspace = opts.workspace ?? process.cwd();
-    const artifactsDir = join(workspace, ".actrun", "runs", entry.run_id, "artifacts");
-    let testCases = existsSync(artifactsDir)
-      ? extractTestReportsFromArtifacts([artifactsDir], {
+    const artifactDirs = actrunArtifactDirs(workspace, entry.run_id).filter(existsSync);
+    let testCases = artifactDirs.length > 0
+      ? extractTestReportsFromArtifacts(artifactDirs, {
           playwright: playwrightAdapter,
           junit: junitAdapter,
         })

--- a/src/cli/commands/collect.ts
+++ b/src/cli/commands/collect.ts
@@ -1,7 +1,5 @@
 import AdmZip from "adm-zip";
-import { CustomAdapter } from "../adapters/custom.js";
-import { junitAdapter } from "../adapters/junit.js";
-import { playwrightAdapter } from "../adapters/playwright.js";
+import { createTestResultAdapter } from "../adapters/index.js";
 import type { TestResultAdapter } from "../adapters/types.js";
 import type { MetricStore, WorkflowRun, TestResult } from "../storage/types.js";
 import { toStoredTestResult } from "../storage/test-result-mapper.js";
@@ -41,20 +39,24 @@ export interface CollectResult {
   testsCollected: number;
 }
 
-function getAdapter(adapterType: string, customCommand?: string): TestResultAdapter {
+export function defaultArtifactNameForAdapter(adapterType: string): string {
   switch (adapterType) {
-    case "playwright":
-      return playwrightAdapter;
     case "junit":
-      return junitAdapter;
+      return "junit-report";
+    case "vrt-migration":
+      return "migration-report";
+    case "vrt-bench":
+      return "bench-report";
     case "custom":
-      if (!customCommand) {
-        throw new Error("Custom adapter requires a command (customCommand)");
-      }
-      return new CustomAdapter({ command: customCommand });
+      return "custom-report";
+    case "playwright":
     default:
-      throw new Error(`Unknown adapter type: ${adapterType}`);
+      return "playwright-report";
   }
+}
+
+function getAdapter(adapterType: string, customCommand?: string): TestResultAdapter {
+  return createTestResultAdapter(adapterType, customCommand);
 }
 
 export async function collectWorkflowRuns(
@@ -65,9 +67,10 @@ export async function collectWorkflowRuns(
     github,
     repo,
     adapterType,
-    artifactName = "playwright-report",
     customCommand,
   } = opts;
+  const artifactName = opts.artifactName ?? defaultArtifactNameForAdapter(adapterType);
+  const adapterConfig = customCommand ?? "";
 
   const adapter = getAdapter(adapterType, customCommand);
   const { workflow_runs } = await github.listWorkflowRuns();
@@ -76,16 +79,16 @@ export async function collectWorkflowRuns(
   let testsCollected = 0;
 
   for (const run of workflow_runs) {
-    // Check if already in DB
-    const existing = await store.raw<{ id: number }>(
-      "SELECT id FROM workflow_runs WHERE id = ?",
-      [run.id],
-    );
-    if (existing.length > 0) {
+    const existing = await store.hasCollectedArtifact({
+      workflowRunId: run.id,
+      adapterType,
+      artifactName,
+      adapterConfig,
+    });
+    if (existing) {
       continue;
     }
 
-    // Compute duration
     const startedAt = new Date(run.run_started_at);
     const updatedAt = new Date(run.updated_at);
     const durationMs = updatedAt.getTime() - startedAt.getTime();
@@ -103,7 +106,14 @@ export async function collectWorkflowRuns(
 
     await store.insertWorkflowRun(workflowRun);
 
-    // Find artifact
+    const collectedRecord = {
+      workflowRunId: run.id,
+      adapterType,
+      artifactName,
+      adapterConfig,
+      collectedAt: new Date(run.created_at),
+    };
+
     const { artifacts } = await github.listArtifacts(run.id);
     const artifact = artifacts.find(
       (a) => a.name === artifactName && !a.expired,
@@ -113,16 +123,17 @@ export async function collectWorkflowRuns(
       continue;
     }
 
-    // Download and extract zip
     const zipBuffer = await github.downloadArtifact(artifact.id);
     const zip = new AdmZip(zipBuffer);
     const entries = zip.getEntries();
 
-    // Find the report file in the zip
     let reportContent: string | null = null;
     for (const entry of entries) {
       const name = entry.entryName.toLowerCase();
-      if (adapterType === "playwright" && (name.endsWith(".json") || name.includes("report"))) {
+      if (
+        (adapterType === "playwright" || adapterType === "vrt-migration" || adapterType === "vrt-bench")
+        && name.endsWith(".json")
+      ) {
         reportContent = entry.getData().toString("utf-8");
         break;
       }
@@ -130,7 +141,6 @@ export async function collectWorkflowRuns(
         reportContent = entry.getData().toString("utf-8");
         break;
       }
-      // For custom or unknown, take the first file
       if (!reportContent) {
         reportContent = entry.getData().toString("utf-8");
       }
@@ -153,6 +163,7 @@ export async function collectWorkflowRuns(
     if (testResults.length > 0) {
       await store.insertTestResults(testResults);
     }
+    await store.recordCollectedArtifact(collectedRecord);
 
     runsCollected++;
     testsCollected += testResults.length;

--- a/src/cli/commands/import.ts
+++ b/src/cli/commands/import.ts
@@ -1,7 +1,5 @@
 import { readFileSync } from "node:fs";
-import { playwrightAdapter } from "../adapters/playwright.js";
-import { junitAdapter } from "../adapters/junit.js";
-import type { TestResultAdapter } from "../adapters/types.js";
+import { createTestResultAdapter } from "../adapters/index.js";
 import type { MetricStore, WorkflowRun, TestResult } from "../storage/types.js";
 import { toStoredTestResult } from "../storage/test-result-mapper.js";
 
@@ -9,6 +7,7 @@ interface ImportOpts {
   store: MetricStore;
   filePath: string;
   adapterType: string;
+  customCommand?: string;
   commitSha?: string;
   branch?: string;
   repo?: string;
@@ -18,15 +17,9 @@ interface ImportResult {
   testsImported: number;
 }
 
-function getAdapter(type: string): TestResultAdapter {
-  if (type === "playwright") return playwrightAdapter;
-  if (type === "junit") return junitAdapter;
-  throw new Error(`Unknown adapter type: ${type}`);
-}
-
 export async function runImport(opts: ImportOpts): Promise<ImportResult> {
-  const { store, filePath, adapterType } = opts;
-  const adapter = getAdapter(adapterType);
+  const { store, filePath, adapterType, customCommand } = opts;
+  const adapter = createTestResultAdapter(adapterType, customCommand);
 
   const content = readFileSync(filePath, "utf-8");
   const testCases = adapter.parse(content);
@@ -35,13 +28,11 @@ export async function runImport(opts: ImportOpts): Promise<ImportResult> {
     return { testsImported: 0 };
   }
 
-  // Get commit info from options or use defaults
   const commitSha = opts.commitSha ?? "local-" + Date.now();
   const branch = opts.branch ?? "local";
   const repo = opts.repo ?? "local/local";
   const now = new Date();
 
-  // Create a synthetic workflow run
   const runId = Date.now();
   const workflowRun: WorkflowRun = {
     id: runId,

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -10,7 +10,9 @@ name = "${name}"
 path = ".flaker/data"
 
 [adapter]
-type = "command"
+type = "playwright"
+artifact_name = "playwright-report"
+# command = "node ./adapter.js"
 
 [runner]
 type = "vitest"

--- a/src/cli/commands/report.ts
+++ b/src/cli/commands/report.ts
@@ -1,8 +1,7 @@
 import { readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 import type { TestCaseResult } from "../adapters/types.js";
-import { junitAdapter } from "../adapters/junit.js";
-import { playwrightAdapter } from "../adapters/playwright.js";
+import { createTestResultAdapter } from "../adapters/index.js";
 import { normalizeVariant, resolveTestIdentity } from "../identity.js";
 
 export interface ReportTotals {
@@ -268,14 +267,7 @@ function parseAdapterReport(
   adapter: string,
   input: string,
 ): TestCaseResult[] {
-  switch (adapter) {
-    case "playwright":
-      return playwrightAdapter.parse(input);
-    case "junit":
-      return junitAdapter.parse(input);
-    default:
-      throw new Error(`Unsupported adapter: ${adapter}`);
-  }
+  return createTestResultAdapter(adapter).parse(input);
 }
 
 export function runReportSummarize(opts: {

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -5,7 +5,7 @@ import { parse } from "smol-toml";
 export interface FlakerConfig {
   repo: { owner: string; name: string };
   storage: { path: string };
-  adapter: { type: string; command?: string };
+  adapter: { type: string; command?: string; artifact_name?: string };
   runner: {
     type: string;
     command: string;
@@ -21,7 +21,7 @@ export interface FlakerConfig {
 const DEFAULT_CONFIG: FlakerConfig = {
   repo: { owner: "", name: "" },
   storage: { path: ".flaker/data" },
-  adapter: { type: "command" },
+  adapter: { type: "playwright" },
   runner: { type: "vitest", command: "pnpm test" },
   affected: { resolver: "git", config: "" },
   quarantine: { auto: true, flaky_rate_threshold: 0.3, min_runs: 5 },

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -248,6 +248,8 @@ program
         github,
         repo: `${owner}/${repo}`,
         adapterType: config.adapter.type,
+        artifactName: config.adapter.artifact_name,
+        customCommand: config.adapter.command,
       });
       console.log(
         `Collected ${result.runsCollected} runs, ${result.testsCollected} test results`,
@@ -537,7 +539,7 @@ const reportCommand = program
 reportCommand
   .command("summarize")
   .description("Summarize a raw adapter report")
-  .requiredOption("--adapter <type>", "Adapter type (playwright, junit)")
+  .requiredOption("--adapter <type>", "Adapter type (playwright, junit, vrt-migration, vrt-bench)")
   .requiredOption("--input <file>", "Raw adapter report file")
   .option("--bundle", "Wrap summary with shard metadata for aggregation")
   .option("--shard <name>", "Shard name")
@@ -885,10 +887,11 @@ program
 program
   .command("import <file>")
   .description("Import a local test report file")
-  .option("--adapter <type>", "Adapter type (playwright, junit)", "playwright")
+  .option("--adapter <type>", "Adapter type (playwright, junit, vrt-migration, vrt-bench, custom)", "playwright")
+  .option("--custom-command <cmd>", "Custom adapter command (required with --adapter custom)")
   .option("--commit <sha>", "Commit SHA")
   .option("--branch <branch>", "Branch name")
-  .action(async (file: string, opts: { adapter: string; commit?: string; branch?: string }) => {
+  .action(async (file: string, opts: { adapter: string; customCommand?: string; commit?: string; branch?: string }) => {
     const config = loadConfig(process.cwd());
     const store = new DuckDBStore(resolve(config.storage.path));
     await store.initialize();
@@ -897,6 +900,7 @@ program
         store,
         filePath: resolve(file),
         adapterType: opts.adapter,
+        customCommand: opts.customCommand,
         commitSha: opts.commit,
         branch: opts.branch,
         repo: `${config.repo.owner}/${config.repo.name}`,

--- a/src/cli/storage/duckdb.ts
+++ b/src/cli/storage/duckdb.ts
@@ -13,6 +13,7 @@ import type {
   TrueFlakyScore,
   VariantFlakyScore,
   TestSelector,
+  CollectedArtifactRecord,
 } from "./types.js";
 
 export class DuckDBStore implements MetricStore {
@@ -81,7 +82,8 @@ export class DuckDBStore implements MetricStore {
   async insertWorkflowRun(run: WorkflowRun): Promise<void> {
     await this.run(
       `INSERT INTO workflow_runs (id, repo, branch, commit_sha, event, status, created_at, duration_ms)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT (id) DO NOTHING`,
       [
         run.id,
         run.repo,
@@ -92,6 +94,36 @@ export class DuckDBStore implements MetricStore {
         run.createdAt,
         run.durationMs,
       ]
+    );
+  }
+
+  async hasCollectedArtifact(record: CollectedArtifactRecord): Promise<boolean> {
+    const rows = await this.all(
+      `SELECT 1
+       FROM collected_artifacts
+       WHERE workflow_run_id = ? AND adapter_type = ? AND artifact_name = ? AND adapter_config = ?`,
+      [
+        record.workflowRunId,
+        record.adapterType,
+        record.artifactName,
+        record.adapterConfig ?? "",
+      ],
+    );
+    return rows.length > 0;
+  }
+
+  async recordCollectedArtifact(record: CollectedArtifactRecord): Promise<void> {
+    await this.run(
+      `INSERT INTO collected_artifacts (workflow_run_id, adapter_type, artifact_name, adapter_config, collected_at)
+       VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT (workflow_run_id, adapter_type, artifact_name, adapter_config) DO NOTHING`,
+      [
+        record.workflowRunId,
+        record.adapterType,
+        record.artifactName,
+        record.adapterConfig ?? "",
+        record.collectedAt ?? new Date(),
+      ],
     );
   }
 

--- a/src/cli/storage/schema.ts
+++ b/src/cli/storage/schema.ts
@@ -28,6 +28,15 @@ CREATE TABLE IF NOT EXISTS test_results (
   created_at      TIMESTAMP
 );
 
+CREATE TABLE IF NOT EXISTS collected_artifacts (
+  workflow_run_id BIGINT REFERENCES workflow_runs(id),
+  adapter_type    VARCHAR NOT NULL,
+  artifact_name   VARCHAR NOT NULL,
+  adapter_config  VARCHAR NOT NULL DEFAULT '',
+  collected_at    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (workflow_run_id, adapter_type, artifact_name, adapter_config)
+);
+
 CREATE SEQUENCE IF NOT EXISTS test_results_id_seq START 1;
 
 CREATE TABLE IF NOT EXISTS quarantined_tests (

--- a/src/cli/storage/types.ts
+++ b/src/cli/storage/types.ts
@@ -97,10 +97,20 @@ export interface TestSelector extends TestIdentityFields {
   testName: string;
 }
 
+export interface CollectedArtifactRecord {
+  workflowRunId: number;
+  adapterType: string;
+  artifactName: string;
+  adapterConfig?: string | null;
+  collectedAt?: Date;
+}
+
 export interface MetricStore {
   initialize(): Promise<void>;
   close(): Promise<void>;
   insertWorkflowRun(run: WorkflowRun): Promise<void>;
+  hasCollectedArtifact(record: CollectedArtifactRecord): Promise<boolean>;
+  recordCollectedArtifact(record: CollectedArtifactRecord): Promise<void>;
   insertTestResults(results: TestResult[]): Promise<void>;
   queryFlakyTests(opts: FlakyQueryOpts): Promise<FlakyScore[]>;
   queryTestHistory(suite: string, testName: string): Promise<TestResult[]>;

--- a/tests/adapters/vrt-bench.test.ts
+++ b/tests/adapters/vrt-bench.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { vrtBenchAdapter } from "../../src/cli/adapters/vrt-bench.js";
+
+const fixtureJson = readFileSync(
+  join(import.meta.dirname, "../fixtures/vrt-bench-report.json"),
+  "utf-8",
+);
+
+describe("vrtBenchAdapter", () => {
+  it('has name "vrt-bench"', () => {
+    expect(vrtBenchAdapter.name).toBe("vrt-bench");
+  });
+
+  it("converts bench report JSON into stable test case results", () => {
+    const results = vrtBenchAdapter.parse(fixtureJson);
+
+    expect(results).toHaveLength(3);
+    expect(results[0]).toMatchObject({
+      suite: "fixtures/css-challenge/dashboard.html",
+      testName: ".hero-card { border-radius: 12px }",
+      taskId: "css-bench/dashboard",
+      status: "passed",
+      durationMs: 0,
+      retryCount: 0,
+      variant: {
+        backend: "chromium",
+        category: "visual",
+        selectorType: "class",
+        interactive: "false",
+        fallbackUsed: "false",
+        resolvedBy: "chromium",
+      },
+    });
+    expect(results[0].testId).toBeTruthy();
+
+    expect(results[1]).toMatchObject({
+      testName: ".search-box input:focus { border-color: rgb(59, 130, 246) }",
+      status: "failed",
+      filter: "(max-width: 768px)",
+    });
+    expect(results[1].errorMessage).toContain("hover-only");
+
+    expect(results[2]).toMatchObject({
+      testName: ".toolbar { padding-top: 24px }",
+      status: "passed",
+      variant: {
+        backend: "prescanner",
+        category: "layout",
+        selectorType: "class",
+        interactive: "false",
+        fallbackUsed: "true",
+        resolvedBy: "chromium",
+      },
+    });
+  });
+});

--- a/tests/adapters/vrt-migration.test.ts
+++ b/tests/adapters/vrt-migration.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { vrtMigrationAdapter } from "../../src/cli/adapters/vrt-migration.js";
+
+const fixtureJson = readFileSync(
+  join(import.meta.dirname, "../fixtures/vrt-migration-report.json"),
+  "utf-8",
+);
+
+describe("vrtMigrationAdapter", () => {
+  it('has name "vrt-migration"', () => {
+    expect(vrtMigrationAdapter.name).toBe("vrt-migration");
+  });
+
+  it("converts migration report JSON into stable test case results", () => {
+    const results = vrtMigrationAdapter.parse(fixtureJson);
+
+    expect(results).toHaveLength(3);
+    expect(results[0]).toMatchObject({
+      suite: "fixtures/migration/reset-css/after.html",
+      testName: "viewport:mobile",
+      taskId: "migration/reset-css",
+      status: "passed",
+      durationMs: 0,
+      retryCount: 0,
+      variant: {
+        backend: "chromium",
+        viewport: "mobile",
+        width: "375",
+        height: "900",
+      },
+    });
+    expect(results[0].testId).toBeTruthy();
+
+    expect(results[1]).toMatchObject({
+      testName: "viewport:tablet",
+      status: "passed",
+      errorMessage: "known spacing diff",
+    });
+
+    expect(results[2]).toMatchObject({
+      testName: "viewport:desktop",
+      status: "failed",
+    });
+    expect(results[2].errorMessage).toContain("3200px diff");
+    expect(results[2].errorMessage).toContain("layout-shift");
+    expect(results[2].errorMessage).toContain("geometry changes");
+  });
+});

--- a/tests/commands/collect-local-artifacts.test.ts
+++ b/tests/commands/collect-local-artifacts.test.ts
@@ -55,6 +55,28 @@ const playwrightReportFixture = JSON.stringify({
   ],
 });
 
+const vitestReportFixture = JSON.stringify({
+  testResults: [
+    {
+      name: "tests/math.test.ts",
+      assertionResults: [
+        {
+          fullName: "math > adds numbers",
+          status: "passed",
+          duration: 5,
+          failureMessages: [],
+        },
+        {
+          fullName: "math > subtracts numbers",
+          status: "failed",
+          duration: 8,
+          failureMessages: ["Expected 3 but got 4"],
+        },
+      ],
+    },
+  ],
+});
+
 function makeRunViewJson(runId: string) {
   return JSON.stringify({
     run_id: runId,
@@ -126,6 +148,23 @@ describe("extractTestReportsFromArtifacts", () => {
     expect(results[0].testName).toBe("GET /health");
     expect(results[0].status).toBe("passed");
     expect(results[1].testName).toBe("POST /login");
+    expect(results[1].status).toBe("failed");
+  });
+
+  it("extracts Vitest JSON reports from artifact directory", () => {
+    const reportDir = join(tmpDir, "vitest-report");
+    mkdirSync(reportDir, { recursive: true });
+    writeFileSync(join(reportDir, "report.json"), vitestReportFixture);
+
+    const results = extractTestReportsFromArtifacts([tmpDir], {
+      playwright: playwrightAdapter,
+      junit: junitAdapter,
+    });
+
+    expect(results.length).toBe(2);
+    expect(results[0].testName).toBe("adds numbers");
+    expect(results[0].status).toBe("passed");
+    expect(results[1].testName).toBe("subtracts numbers");
     expect(results[1].status).toBe("failed");
   });
 
@@ -228,5 +267,44 @@ describe("collect-local with artifacts", () => {
       "SELECT test_name FROM test_results",
     );
     expect(tests[0].test_name).toBe("e2e");
+  });
+
+  it("loads artifacts from actrun default _build run root", async () => {
+    const artifactDir = join(
+      tmpDir,
+      "_build",
+      "actrun",
+      "runs",
+      "run-3",
+      "artifacts",
+      "vitest-report",
+    );
+    mkdirSync(artifactDir, { recursive: true });
+    writeFileSync(join(artifactDir, "report.json"), vitestReportFixture);
+
+    const listJson = JSON.stringify([
+      { run_id: "run-3", conclusion: "failure", status: "completed" },
+    ]);
+
+    const result = await runCollectLocal({
+      store,
+      workspace: tmpDir,
+      exec: (cmd) => {
+        if (cmd.includes("run list")) return listJson;
+        if (cmd.includes("run view")) return makeRunViewJson("run-3");
+        return "";
+      },
+    });
+
+    expect(result.runsImported).toBe(1);
+    expect(result.testsImported).toBe(2);
+
+    const tests = await store.raw<{ test_name: string; status: string }>(
+      "SELECT test_name, status FROM test_results ORDER BY test_name",
+    );
+    expect(tests).toEqual([
+      { test_name: "adds numbers", status: "passed" },
+      { test_name: "subtracts numbers", status: "failed" },
+    ]);
   });
 });

--- a/tests/commands/collect.test.ts
+++ b/tests/commands/collect.test.ts
@@ -4,9 +4,9 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import AdmZip from "adm-zip";
 import { DuckDBStore } from "../../src/cli/storage/duckdb.js";
-import type { MetricStore } from "../../src/cli/storage/types.js";
 import {
   collectWorkflowRuns,
+  defaultArtifactNameForAdapter,
   type GitHubClient,
 } from "../../src/cli/commands/collect.js";
 
@@ -15,33 +15,69 @@ const fixtureReport = readFileSync(
   join(__dirname, "../fixtures/playwright-report.json"),
   "utf-8",
 );
+const migrationFixtureReport = readFileSync(
+  join(__dirname, "../fixtures/vrt-migration-report.json"),
+  "utf-8",
+);
+const benchFixtureReport = readFileSync(
+  join(__dirname, "../fixtures/vrt-bench-report.json"),
+  "utf-8",
+);
+
+interface MockArtifact {
+  name: string;
+  content: string;
+  expired?: boolean;
+  entryName?: string;
+}
 
 function createMockGitHubClient(
   runs: GitHubClient extends { listWorkflowRuns(): Promise<infer R> }
     ? R["workflow_runs"]
     : never,
-  artifactName: string,
-  reportContent: string,
+  artifactsByRunId: Record<number, MockArtifact[]>,
 ): GitHubClient {
+  const artifactContents = new Map<number, { content: string; entryName: string }>();
+
   return {
     async listWorkflowRuns() {
       return { total_count: runs.length, workflow_runs: runs };
     },
     async listArtifacts(runId: number) {
+      const artifacts = (artifactsByRunId[runId] ?? []).map((artifact, index) => {
+        const id = runId * 100 + index;
+        artifactContents.set(id, {
+          content: artifact.content,
+          entryName: artifact.entryName ?? "report.json",
+        });
+        return { id, name: artifact.name, expired: artifact.expired ?? false };
+      });
       return {
-        total_count: 1,
-        artifacts: [
-          { id: runId * 100, name: artifactName, expired: false },
-        ],
+        total_count: artifacts.length,
+        artifacts,
       };
     },
-    async downloadArtifact(_artifactId: number) {
+    async downloadArtifact(artifactId: number) {
+      const artifact = artifactContents.get(artifactId);
+      if (!artifact) {
+        throw new Error(`Unknown artifact id: ${artifactId}`);
+      }
       const zip = new AdmZip();
-      zip.addFile("report.json", Buffer.from(reportContent));
+      zip.addFile(artifact.entryName, Buffer.from(artifact.content));
       return zip.toBuffer();
     },
   };
 }
+
+describe("defaultArtifactNameForAdapter", () => {
+  it("returns adapter-specific defaults", () => {
+    expect(defaultArtifactNameForAdapter("playwright")).toBe("playwright-report");
+    expect(defaultArtifactNameForAdapter("junit")).toBe("junit-report");
+    expect(defaultArtifactNameForAdapter("vrt-migration")).toBe("migration-report");
+    expect(defaultArtifactNameForAdapter("vrt-bench")).toBe("bench-report");
+    expect(defaultArtifactNameForAdapter("custom")).toBe("custom-report");
+  });
+});
 
 describe("collectWorkflowRuns", () => {
   let store: DuckDBStore;
@@ -69,11 +105,9 @@ describe("collectWorkflowRuns", () => {
       },
     ];
 
-    const github = createMockGitHubClient(
-      mockRuns,
-      "playwright-report",
-      fixtureReport,
-    );
+    const github = createMockGitHubClient(mockRuns, {
+      1001: [{ name: "playwright-report", content: fixtureReport }],
+    });
 
     const result = await collectWorkflowRuns({
       store,
@@ -84,22 +118,235 @@ describe("collectWorkflowRuns", () => {
     });
 
     expect(result.runsCollected).toBe(1);
-    // The fixture has 4 specs with 1 test each
     expect(result.testsCollected).toBe(4);
 
-    // Verify workflow run was stored
     const runs = await store.raw<{ id: number }>(
       "SELECT id FROM workflow_runs WHERE id = ?",
       [1001],
     );
     expect(runs).toHaveLength(1);
 
-    // Verify test results were stored
     const tests = await store.raw<{ count: number }>(
       "SELECT COUNT(*)::INTEGER AS count FROM test_results WHERE workflow_run_id = ?",
       [1001],
     );
     expect(tests[0].count).toBe(4);
+  });
+
+  it("collects built-in vrt migration reports from artifacts", async () => {
+    const mockRuns = [
+      {
+        id: 1002,
+        head_branch: "main",
+        head_sha: "vrt123",
+        event: "workflow_dispatch",
+        conclusion: "success",
+        created_at: "2025-06-02T00:00:00Z",
+        run_started_at: "2025-06-02T00:00:00Z",
+        updated_at: "2025-06-02T00:03:00Z",
+      },
+    ];
+
+    const github = createMockGitHubClient(mockRuns, {
+      1002: [{ name: "migration-report", content: migrationFixtureReport }],
+    });
+
+    const result = await collectWorkflowRuns({
+      store,
+      github,
+      repo: "owner/repo",
+      adapterType: "vrt-migration",
+      artifactName: "migration-report",
+    });
+
+    expect(result.runsCollected).toBe(1);
+    expect(result.testsCollected).toBe(3);
+
+    const tests = await store.raw<{ status: string }>(
+      "SELECT status FROM test_results WHERE workflow_run_id = ? ORDER BY test_name",
+      [1002],
+    );
+    expect(tests.map((row) => row.status)).toEqual(["failed", "passed", "passed"]);
+  });
+
+  it("uses the default migration artifact name when omitted", async () => {
+    const mockRuns = [
+      {
+        id: 1003,
+        head_branch: "main",
+        head_sha: "vrt456",
+        event: "workflow_dispatch",
+        conclusion: "success",
+        created_at: "2025-06-03T00:00:00Z",
+        run_started_at: "2025-06-03T00:00:00Z",
+        updated_at: "2025-06-03T00:03:00Z",
+      },
+    ];
+
+    const github = createMockGitHubClient(mockRuns, {
+      1003: [{ name: "migration-report", content: migrationFixtureReport }],
+    });
+
+    const result = await collectWorkflowRuns({
+      store,
+      github,
+      repo: "owner/repo",
+      adapterType: "vrt-migration",
+    });
+
+    expect(result.runsCollected).toBe(1);
+    expect(result.testsCollected).toBe(3);
+  });
+
+  it("collects built-in vrt bench reports from artifacts", async () => {
+    const mockRuns = [
+      {
+        id: 1004,
+        head_branch: "main",
+        head_sha: "bench123",
+        event: "workflow_dispatch",
+        conclusion: "success",
+        created_at: "2025-06-04T00:00:00Z",
+        run_started_at: "2025-06-04T00:00:00Z",
+        updated_at: "2025-06-04T00:04:00Z",
+      },
+    ];
+
+    const github = createMockGitHubClient(mockRuns, {
+      1004: [{ name: "bench-report", content: benchFixtureReport }],
+    });
+
+    const result = await collectWorkflowRuns({
+      store,
+      github,
+      repo: "owner/repo",
+      adapterType: "vrt-bench",
+    });
+
+    expect(result.runsCollected).toBe(1);
+    expect(result.testsCollected).toBe(3);
+
+    const tests = await store.raw<{ status: string }>(
+      "SELECT status FROM test_results WHERE workflow_run_id = ? ORDER BY test_name",
+      [1004],
+    );
+    expect(tests.map((row) => row.status)).toEqual(["passed", "failed", "passed"]);
+  });
+
+  it("does not let an artifact miss block a later collect with another adapter", async () => {
+    const mockRuns = [
+      {
+        id: 1005,
+        head_branch: "main",
+        head_sha: "mix123",
+        event: "workflow_dispatch",
+        conclusion: "success",
+        created_at: "2025-06-05T00:00:00Z",
+        run_started_at: "2025-06-05T00:00:00Z",
+        updated_at: "2025-06-05T00:04:00Z",
+      },
+    ];
+
+    const github = createMockGitHubClient(mockRuns, {
+      1005: [{ name: "bench-report", content: benchFixtureReport }],
+    });
+
+    const migrationResult = await collectWorkflowRuns({
+      store,
+      github,
+      repo: "owner/repo",
+      adapterType: "vrt-migration",
+    });
+    expect(migrationResult.runsCollected).toBe(1);
+    expect(migrationResult.testsCollected).toBe(0);
+
+    const benchResult = await collectWorkflowRuns({
+      store,
+      github,
+      repo: "owner/repo",
+      adapterType: "vrt-bench",
+    });
+    expect(benchResult.runsCollected).toBe(1);
+    expect(benchResult.testsCollected).toBe(3);
+
+    const runCount = await store.raw<{ count: number }>(
+      "SELECT COUNT(*)::INTEGER AS count FROM workflow_runs WHERE id = ?",
+      [1005],
+    );
+    expect(runCount[0].count).toBe(1);
+
+    const testCount = await store.raw<{ count: number }>(
+      "SELECT COUNT(*)::INTEGER AS count FROM test_results WHERE workflow_run_id = ?",
+      [1005],
+    );
+    expect(testCount[0].count).toBe(3);
+  });
+
+  it("retries when the artifact is temporarily missing", async () => {
+    const mockRuns = [
+      {
+        id: 1006,
+        head_branch: "main",
+        head_sha: "retry123",
+        event: "workflow_dispatch",
+        conclusion: "success",
+        created_at: "2025-06-06T00:00:00Z",
+        run_started_at: "2025-06-06T00:00:00Z",
+        updated_at: "2025-06-06T00:04:00Z",
+      },
+    ];
+
+    let listArtifactsCalls = 0;
+    const github: GitHubClient = {
+      async listWorkflowRuns() {
+        return { total_count: mockRuns.length, workflow_runs: mockRuns };
+      },
+      async listArtifacts(runId: number) {
+        listArtifactsCalls += 1;
+        if (listArtifactsCalls === 1) {
+          return { total_count: 0, artifacts: [] };
+        }
+        return {
+          total_count: 1,
+          artifacts: [{ id: runId * 100, name: "bench-report", expired: false }],
+        };
+      },
+      async downloadArtifact() {
+        const zip = new AdmZip();
+        zip.addFile("report.json", Buffer.from(benchFixtureReport));
+        return zip.toBuffer();
+      },
+    };
+
+    const firstResult = await collectWorkflowRuns({
+      store,
+      github,
+      repo: "owner/repo",
+      adapterType: "vrt-bench",
+    });
+    expect(firstResult.runsCollected).toBe(1);
+    expect(firstResult.testsCollected).toBe(0);
+
+    const pendingCount = await store.raw<{ count: number }>(
+      "SELECT COUNT(*)::INTEGER AS count FROM collected_artifacts WHERE workflow_run_id = ? AND adapter_type = ?",
+      [1006, "vrt-bench"],
+    );
+    expect(pendingCount[0].count).toBe(0);
+
+    const secondResult = await collectWorkflowRuns({
+      store,
+      github,
+      repo: "owner/repo",
+      adapterType: "vrt-bench",
+    });
+    expect(secondResult.runsCollected).toBe(1);
+    expect(secondResult.testsCollected).toBe(3);
+
+    const testCount = await store.raw<{ count: number }>(
+      "SELECT COUNT(*)::INTEGER AS count FROM test_results WHERE workflow_run_id = ?",
+      [1006],
+    );
+    expect(testCount[0].count).toBe(3);
   });
 
   it("skips already collected runs (idempotent)", async () => {
@@ -116,13 +363,10 @@ describe("collectWorkflowRuns", () => {
       },
     ];
 
-    const github = createMockGitHubClient(
-      mockRuns,
-      "playwright-report",
-      fixtureReport,
-    );
+    const github = createMockGitHubClient(mockRuns, {
+      2001: [{ name: "playwright-report", content: fixtureReport }],
+    });
 
-    // First collection
     const result1 = await collectWorkflowRuns({
       store,
       github,
@@ -133,7 +377,6 @@ describe("collectWorkflowRuns", () => {
     expect(result1.runsCollected).toBe(1);
     expect(result1.testsCollected).toBe(4);
 
-    // Second collection - same runs should be skipped
     const result2 = await collectWorkflowRuns({
       store,
       github,
@@ -144,14 +387,12 @@ describe("collectWorkflowRuns", () => {
     expect(result2.runsCollected).toBe(0);
     expect(result2.testsCollected).toBe(0);
 
-    // Verify only one workflow run in DB
     const runs = await store.raw<{ count: number }>(
       "SELECT COUNT(*)::INTEGER AS count FROM workflow_runs WHERE id = ?",
       [2001],
     );
     expect(runs[0].count).toBe(1);
 
-    // Verify test results were not duplicated
     const tests = await store.raw<{ count: number }>(
       "SELECT COUNT(*)::INTEGER AS count FROM test_results WHERE workflow_run_id = ?",
       [2001],

--- a/tests/commands/import.test.ts
+++ b/tests/commands/import.test.ts
@@ -18,8 +18,12 @@ describe("import command", () => {
   it("imports Playwright JSON report", async () => {
     const fixture = resolve(import.meta.dirname, "../fixtures/playwright-report.json");
     const result = await runImport({
-      store, filePath: fixture, adapterType: "playwright",
-      commitSha: "abc123", branch: "main", repo: "mizchi/crater",
+      store,
+      filePath: fixture,
+      adapterType: "playwright",
+      commitSha: "abc123",
+      branch: "main",
+      repo: "mizchi/crater",
     });
     expect(result.testsImported).toBe(4);
 
@@ -30,20 +34,115 @@ describe("import command", () => {
   it("imports JUnit XML report", async () => {
     const fixture = resolve(import.meta.dirname, "../fixtures/junit-report.xml");
     const result = await runImport({
-      store, filePath: fixture, adapterType: "junit",
-      commitSha: "def456", branch: "main", repo: "mizchi/crater",
+      store,
+      filePath: fixture,
+      adapterType: "junit",
+      commitSha: "def456",
+      branch: "main",
+      repo: "mizchi/crater",
     });
     expect(result.testsImported).toBe(5);
+  });
+
+  it("imports built-in vrt migration reports", async () => {
+    const fixture = resolve(import.meta.dirname, "../fixtures/vrt-migration-report.json");
+    const result = await runImport({
+      store,
+      filePath: fixture,
+      adapterType: "vrt-migration",
+      commitSha: "vrt456",
+      branch: "main",
+      repo: "mizchi/vrt-harness",
+    });
+
+    expect(result.testsImported).toBe(3);
+    const rows = await store.raw<{ suite: string; status: string }>(
+      "SELECT suite, status FROM test_results ORDER BY test_name",
+    );
+    expect(rows).toEqual([
+      { suite: "fixtures/migration/reset-css/after.html", status: "failed" },
+      { suite: "fixtures/migration/reset-css/after.html", status: "passed" },
+      { suite: "fixtures/migration/reset-css/after.html", status: "passed" },
+    ]);
+  });
+
+  it("imports built-in vrt bench reports", async () => {
+    const fixture = resolve(import.meta.dirname, "../fixtures/vrt-bench-report.json");
+    const result = await runImport({
+      store,
+      filePath: fixture,
+      adapterType: "vrt-bench",
+      commitSha: "bench789",
+      branch: "main",
+      repo: "mizchi/vrt-harness",
+    });
+
+    expect(result.testsImported).toBe(3);
+    const rows = await store.raw<{ suite: string; status: string }>(
+      "SELECT suite, status FROM test_results ORDER BY test_name",
+    );
+    expect(rows).toEqual([
+      { suite: "fixtures/css-challenge/dashboard.html", status: "passed" },
+      { suite: "fixtures/css-challenge/dashboard.html", status: "failed" },
+      { suite: "fixtures/css-challenge/dashboard.html", status: "passed" },
+    ]);
   });
 
   it("creates synthetic workflow run", async () => {
     const fixture = resolve(import.meta.dirname, "../fixtures/playwright-report.json");
     await runImport({
-      store, filePath: fixture, adapterType: "playwright",
-      commitSha: "abc123", branch: "main", repo: "mizchi/crater",
+      store,
+      filePath: fixture,
+      adapterType: "playwright",
+      commitSha: "abc123",
+      branch: "main",
+      repo: "mizchi/crater",
     });
     const runs = await store.raw<{ event: string }>("SELECT event FROM workflow_runs");
     expect(runs).toHaveLength(1);
     expect(runs[0].event).toBe("local-import");
+  });
+
+  it("imports custom-adapted JSON via custom adapter command", async () => {
+    const fixture = resolve(import.meta.dirname, "../../../vrt-harness/test-results/migration/migration-report.json");
+    const adapterScript = resolve(import.meta.dirname, "../../../vrt-harness/src/flaker-vrt-report-adapter.ts");
+    const adapterCommand = [
+      "node",
+      "--experimental-strip-types",
+      adapterScript,
+      "--scenario-id",
+      "migration/tailwind-to-vanilla",
+      "--backend",
+      "chromium",
+    ].join(" ");
+
+    const result = await runImport({
+      store,
+      filePath: fixture,
+      adapterType: "custom",
+      customCommand: adapterCommand,
+      commitSha: "vrt123",
+      branch: "main",
+      repo: "mizchi/vrt-harness",
+    });
+
+    expect(result.testsImported).toBeGreaterThan(0);
+    const rows = await store.raw<{ cnt: number }>("SELECT COUNT(*)::INTEGER AS cnt FROM test_results");
+    expect(rows[0].cnt).toBe(result.testsImported);
+  });
+
+  it("requires a custom command when adapterType is custom", async () => {
+    const fixture = resolve(import.meta.dirname, "../fixtures/playwright-report.json");
+
+    await expect(() =>
+      runImport({
+        store,
+        filePath: fixture,
+        adapterType: "custom",
+        commitSha: "custom123",
+        branch: "main",
+        repo: "mizchi/vrt-harness",
+      }),
+    ).rejects.toThrow(/Custom adapter requires a command/);
   });
 });

--- a/tests/commands/init.test.ts
+++ b/tests/commands/init.test.ts
@@ -23,12 +23,13 @@ describe("runInit", () => {
     expect(content).toContain('name = "myrepo"');
     expect(content).toContain('[storage]');
     expect(content).toContain('[adapter]');
+    expect(content).toContain('type = "playwright"');
+    expect(content).toContain('artifact_name = "playwright-report"');
     expect(content).toContain('[runner]');
     expect(content).toContain('[affected]');
     expect(content).toContain('[quarantine]');
     expect(content).toContain('[flaky]');
 
-    // .flaker directory should be created
     expect(existsSync(join(dir, ".flaker"))).toBe(true);
   });
 });
@@ -42,7 +43,8 @@ describe("loadConfig", () => {
     expect(config.repo.owner).toBe("testowner");
     expect(config.repo.name).toBe("testrepo");
     expect(config.storage.path).toBe(".flaker/data");
-    expect(config.adapter.type).toBe("command");
+    expect(config.adapter.type).toBe("playwright");
+    expect(config.adapter.artifact_name).toBe("playwright-report");
     expect(config.runner.type).toBe("vitest");
     expect(config.quarantine.auto).toBe(true);
     expect(config.flaky.window_days).toBe(14);

--- a/tests/commands/report.test.ts
+++ b/tests/commands/report.test.ts
@@ -25,6 +25,16 @@ const junitFixture = readFileSync(
   "utf-8",
 );
 
+const vrtMigrationFixture = readFileSync(
+  join(import.meta.dirname, "../fixtures/vrt-migration-report.json"),
+  "utf-8",
+);
+
+const vrtBenchFixture = readFileSync(
+  join(import.meta.dirname, "../fixtures/vrt-bench-report.json"),
+  "utf-8",
+);
+
 describe("report summarize", () => {
   it("normalizes playwright report into totals, file summaries, and unstable tests", () => {
     const summary = runReportSummarize({
@@ -97,6 +107,68 @@ describe("report summarize", () => {
       expect.objectContaining({
         suite: "tests/login.spec.ts",
         testName: "should redirect after login",
+        status: "failed",
+      }),
+    ]);
+  });
+
+  it("normalizes vrt migration reports into the same summary shape", () => {
+    const summary = runReportSummarize({
+      adapter: "vrt-migration",
+      input: vrtMigrationFixture,
+    });
+
+    expect(summary.totals).toMatchObject({
+      total: 3,
+      passed: 2,
+      failed: 1,
+      flaky: 0,
+      skipped: 0,
+      retries: 0,
+      durationMs: 0,
+    });
+    expect(summary.files).toEqual([
+      expect.objectContaining({
+        suite: "fixtures/migration/reset-css/after.html",
+        totals: expect.objectContaining({ total: 3, passed: 2, failed: 1 }),
+      }),
+    ]);
+    expect(summary.unstable).toEqual([
+      expect.objectContaining({
+        suite: "fixtures/migration/reset-css/after.html",
+        testName: "viewport:desktop",
+        taskId: "migration/reset-css",
+        status: "failed",
+      }),
+    ]);
+  });
+
+  it("normalizes vrt bench reports into the same summary shape", () => {
+    const summary = runReportSummarize({
+      adapter: "vrt-bench",
+      input: vrtBenchFixture,
+    });
+
+    expect(summary.totals).toMatchObject({
+      total: 3,
+      passed: 2,
+      failed: 1,
+      flaky: 0,
+      skipped: 0,
+      retries: 0,
+      durationMs: 0,
+    });
+    expect(summary.files).toEqual([
+      expect.objectContaining({
+        suite: "fixtures/css-challenge/dashboard.html",
+        totals: expect.objectContaining({ total: 3, passed: 2, failed: 1 }),
+      }),
+    ]);
+    expect(summary.unstable).toEqual([
+      expect.objectContaining({
+        suite: "fixtures/css-challenge/dashboard.html",
+        testName: ".search-box input:focus { border-color: rgb(59, 130, 246) }",
+        taskId: "css-bench/dashboard",
         status: "failed",
       }),
     ]);

--- a/tests/fixtures/vrt-bench-report.json
+++ b/tests/fixtures/vrt-bench-report.json
@@ -1,0 +1,119 @@
+{
+  "meta": {
+    "fixture": "dashboard",
+    "trials": 3,
+    "startSeed": 1,
+    "elapsed": "6.1",
+    "viewports": [
+      { "width": 1440, "height": 900, "label": "wide" },
+      { "width": 375, "height": 812, "label": "mobile" }
+    ],
+    "llmEnabled": false,
+    "totalDeclarations": 412,
+    "strict": false,
+    "suggestApproval": false,
+    "approvalWarnings": [],
+    "prescanner": {
+      "craterResolved": 1,
+      "chromiumFallback": 1,
+      "noSignal": 1,
+      "total": 3
+    }
+  },
+  "detection": {
+    "visualDetected": 2,
+    "a11yDetected": 0,
+    "eitherDetected": 2,
+    "neitherDetected": 1,
+    "rate": 0.6666666667
+  },
+  "trials": [
+    {
+      "runId": "2026-04-02T08:00:00.000Z",
+      "fixture": "dashboard",
+      "backend": "chromium",
+      "fallbackUsed": false,
+      "backendResolvedBy": "chromium",
+      "selector": ".hero-card",
+      "property": "border-radius",
+      "value": "12px",
+      "category": "visual",
+      "selectorType": "class",
+      "isInteractive": false,
+      "mediaCondition": null,
+      "viewports": [
+        {
+          "width": 1440,
+          "height": 900,
+          "visualDiffDetected": true,
+          "visualDiffRatio": 0.0000123,
+          "a11yDiffDetected": false,
+          "a11yChangeCount": 0,
+          "computedStyleDiffCount": 1,
+          "hoverDiffDetected": false,
+          "paintTreeDiffCount": 0
+        }
+      ],
+      "detected": true,
+      "undetectedReason": null
+    },
+    {
+      "runId": "2026-04-02T08:00:00.000Z",
+      "fixture": "dashboard",
+      "backend": "crater",
+      "fallbackUsed": false,
+      "backendResolvedBy": "crater",
+      "selector": ".search-box input:focus",
+      "property": "border-color",
+      "value": "rgb(59, 130, 246)",
+      "category": "visual",
+      "selectorType": "compound",
+      "isInteractive": true,
+      "mediaCondition": "(max-width: 768px)",
+      "viewports": [
+        {
+          "width": 375,
+          "height": 812,
+          "visualDiffDetected": false,
+          "visualDiffRatio": 0,
+          "a11yDiffDetected": false,
+          "a11yChangeCount": 0,
+          "computedStyleDiffCount": 0,
+          "hoverDiffDetected": false,
+          "paintTreeDiffCount": 0
+        }
+      ],
+      "detected": false,
+      "undetectedReason": "hover-only"
+    },
+    {
+      "runId": "2026-04-02T08:00:00.000Z",
+      "fixture": "dashboard",
+      "backend": "prescanner",
+      "fallbackUsed": true,
+      "backendResolvedBy": "chromium",
+      "selector": ".toolbar",
+      "property": "padding-top",
+      "value": "24px",
+      "category": "layout",
+      "selectorType": "class",
+      "isInteractive": false,
+      "mediaCondition": null,
+      "viewports": [
+        {
+          "width": 1440,
+          "height": 900,
+          "visualDiffDetected": true,
+          "visualDiffRatio": 0.000042,
+          "a11yDiffDetected": false,
+          "a11yChangeCount": 0,
+          "computedStyleDiffCount": 1,
+          "hoverDiffDetected": false,
+          "paintTreeDiffCount": 1
+        }
+      ],
+      "detected": true,
+      "undetectedReason": null
+    }
+  ]
+}

--- a/tests/fixtures/vrt-migration-report.json
+++ b/tests/fixtures/vrt-migration-report.json
@@ -1,0 +1,62 @@
+{
+  "baseline": "fixtures/migration/reset-css/before.html",
+  "variants": [
+    "after.html"
+  ],
+  "dir": "fixtures/migration/reset-css",
+  "viewports": [
+    {
+      "width": 375,
+      "height": 900,
+      "label": "mobile",
+      "reason": "standard"
+    },
+    {
+      "width": 768,
+      "height": 900,
+      "label": "tablet",
+      "reason": "boundary"
+    },
+    {
+      "width": 1024,
+      "height": 900,
+      "label": "desktop",
+      "reason": "standard"
+    }
+  ],
+  "results": [
+    {
+      "variant": "after",
+      "viewport": "mobile",
+      "diffPixels": 0,
+      "approved": false,
+      "approvalReasons": [],
+      "dominantCategory": "none",
+      "categorySummary": "no changes",
+      "paintTreeSummary": "no changes"
+    },
+    {
+      "variant": "after",
+      "viewport": "tablet",
+      "diffPixels": 1600,
+      "approved": true,
+      "approvalReasons": [
+        "known spacing diff"
+      ],
+      "dominantCategory": "spacing",
+      "categorySummary": "spacing changes",
+      "paintTreeSummary": "paint changes"
+    },
+    {
+      "variant": "after",
+      "variantFile": "after.html",
+      "viewport": "desktop",
+      "diffPixels": 3200,
+      "approved": false,
+      "approvalReasons": [],
+      "dominantCategory": "layout-shift",
+      "categorySummary": "layout shift",
+      "paintTreeSummary": "geometry changes"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `vrt-bench` and `vrt-migration` adapters plus shared adapter factory wiring
- extend collect/import/report flows and storage bookkeeping to support adapter-specific artifact tracking
- document the VRT collection flow and add fixture-backed tests for collect/import/report coverage

## Verification
- `pnpm -s tsc --noEmit`
- `pnpm vitest run tests/adapters/vrt-bench.test.ts tests/adapters/vrt-migration.test.ts`
- `pnpm vitest run tests/core/loader.test.ts tests/core/resolve-affected-glob-parity.test.ts tests/resolvers/bitflow-native.test.ts tests/commands/doctor.test.ts tests/storage/duckdb-load.test.ts`
- `moon build --target js`
- `pnpm vitest run`
