### PR TITLE
Add collect JSON output and exit control

### DIFF
--- a/src/cli/commands/collect.ts
+++ b/src/cli/commands/collect.ts
@@ -1,3 +1,5 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
 import AdmZip from "adm-zip";
 import { createTestResultAdapter } from "../adapters/index.js";
 import type { TestResultAdapter } from "../adapters/types.js";
@@ -47,7 +49,13 @@ export interface CollectResult {
   failures: CollectFailure[];
 }
 
-export function formatCollectSummary(result: CollectResult): string {
+export function formatCollectSummary(
+  result: CollectResult,
+  format: "text" | "json" = "text",
+): string {
+  if (format === "json") {
+    return JSON.stringify(result, null, 2);
+  }
   const base = `Collected ${result.runsCollected} runs, ${result.testsCollected} test results`;
   if (result.failedRuns === 0) {
     return base;
@@ -56,6 +64,21 @@ export function formatCollectSummary(result: CollectResult): string {
     ? ` (${result.failedRunIds.join(", ")})`
     : "";
   return `${base}, ${result.failedRuns} failed runs${suffix}`;
+}
+
+export function resolveCollectExitCode(
+  result: CollectResult,
+  opts: { failOnErrors?: boolean } = {},
+): number {
+  if (!opts.failOnErrors) {
+    return 0;
+  }
+  return result.failedRuns > 0 ? 1 : 0;
+}
+
+export function writeCollectSummary(path: string, content: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content, "utf-8");
 }
 
 export function defaultArtifactNameForAdapter(adapterType: string): string {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -8,6 +8,8 @@ import { runInit } from "./commands/init.js";
 import {
   collectWorkflowRuns,
   formatCollectSummary,
+  resolveCollectExitCode,
+  writeCollectSummary,
   type GitHubClient,
 } from "./commands/collect.js";
 import { runFlaky, formatFlakyTable, runFlakyTrend, formatFlakyTrend, runTrueFlaky, formatTrueFlakyTable } from "./commands/flaky.js";
@@ -184,7 +186,10 @@ program
   .description("Collect workflow runs from GitHub")
   .option("--last <days>", "Number of days to look back", "30")
   .option("--branch <branch>", "Filter by branch")
-  .action(async (opts: { last: string; branch?: string }) => {
+  .option("--json", "Output JSON summary")
+  .option("--output <file>", "Write collect summary to a file")
+  .option("--fail-on-errors", "Exit with status 1 when any workflow run fails to collect")
+  .action(async (opts: { last: string; branch?: string; json?: boolean; output?: string; failOnErrors?: boolean }) => {
     const config = loadConfig(process.cwd());
     const store = new DuckDBStore(resolve(config.storage.path));
     await store.initialize();
@@ -252,7 +257,15 @@ program
         artifactName: config.adapter.artifact_name,
         customCommand: config.adapter.command,
       });
-      console.log(formatCollectSummary(result));
+      const formatted = formatCollectSummary(result, opts.json ? "json" : "text");
+      console.log(formatted);
+      if (opts.output) {
+        writeCollectSummary(resolve(process.cwd(), opts.output), formatted);
+      }
+      const exitCode = resolveCollectExitCode(result, { failOnErrors: opts.failOnErrors });
+      if (exitCode !== 0) {
+        process.exitCode = exitCode;
+      }
     } finally {
       await store.close();
     }

--- a/tests/commands/collect.test.ts
+++ b/tests/commands/collect.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, readFileSync as readTextFileSync, existsSync } from "node:fs";
 import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import AdmZip from "adm-zip";
 import { DuckDBStore } from "../../src/cli/storage/duckdb.js";
@@ -8,6 +9,8 @@ import {
   collectWorkflowRuns,
   defaultArtifactNameForAdapter,
   formatCollectSummary,
+  resolveCollectExitCode,
+  writeCollectSummary,
   type GitHubClient,
 } from "../../src/cli/commands/collect.js";
 
@@ -127,6 +130,28 @@ describe("formatCollectSummary", () => {
     }
   });
 
+  it("formats collect summaries as json", () => {
+    expect(JSON.parse(formatCollectSummary({
+      runsCollected: 1,
+      testsCollected: 3,
+      failedRuns: 2,
+      failedRunIds: [1007, 1009],
+      failures: [
+        { runId: 1007, message: "temporary artifact download error" },
+        { runId: 1009, message: "invalid zip" },
+      ],
+    }, "json"))).toEqual({
+      runsCollected: 1,
+      testsCollected: 3,
+      failedRuns: 2,
+      failedRunIds: [1007, 1009],
+      failures: [
+        { runId: 1007, message: "temporary artifact download error" },
+        { runId: 1009, message: "invalid zip" },
+      ],
+    });
+  });
+
   it("keeps the summary short when there are no failures", () => {
     expect(formatCollectSummary({
       runsCollected: 1,
@@ -135,6 +160,60 @@ describe("formatCollectSummary", () => {
       failedRunIds: [],
       failures: [],
     })).toBe("Collected 1 runs, 3 test results");
+  });
+});
+
+describe("resolveCollectExitCode", () => {
+  it("returns 0 by default even when there are partial failures", () => {
+    expect(resolveCollectExitCode({
+      runsCollected: 1,
+      testsCollected: 3,
+      failedRuns: 1,
+      failedRunIds: [1007],
+      failures: [{ runId: 1007, message: "temporary artifact download error" }],
+    })).toBe(0);
+  });
+
+  it("returns 1 when failOnErrors is enabled and failures exist", () => {
+    expect(resolveCollectExitCode({
+      runsCollected: 1,
+      testsCollected: 3,
+      failedRuns: 1,
+      failedRunIds: [1007],
+      failures: [{ runId: 1007, message: "temporary artifact download error" }],
+    }, { failOnErrors: true })).toBe(1);
+  });
+
+  it("returns 0 when failOnErrors is enabled but there are no failures", () => {
+    expect(resolveCollectExitCode({
+      runsCollected: 1,
+      testsCollected: 3,
+      failedRuns: 0,
+      failedRunIds: [],
+      failures: [],
+    }, { failOnErrors: true })).toBe(0);
+  });
+});
+
+describe("writeCollectSummary", () => {
+  it("writes collect summaries to a file", () => {
+    const dir = mkdtempSync(join(tmpdir(), "flaker-collect-"));
+    const outputPath = join(dir, "collect-summary.json");
+    writeCollectSummary(outputPath, formatCollectSummary({
+      runsCollected: 1,
+      testsCollected: 3,
+      failedRuns: 1,
+      failedRunIds: [1007],
+      failures: [{ runId: 1007, message: "temporary artifact download error" }],
+    }, "json"));
+    expect(existsSync(outputPath)).toBe(true);
+    expect(JSON.parse(readTextFileSync(outputPath, "utf-8"))).toEqual({
+      runsCollected: 1,
+      testsCollected: 3,
+      failedRuns: 1,
+      failedRunIds: [1007],
+      failures: [{ runId: 1007, message: "temporary artifact download error" }],
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- add JSON output mode for collect summaries
- add fail-on-errors exit code control for partial collection failures
- extend collect tests around summary formatting and exit behavior

## Verification
- pnpm vitest run tests/commands/collect.test.ts
- pnpm -s tsc --noEmit