### PR TITLE
Add collect summary output and workflow example

### DIFF
--- a/docs/how-to-use.ja.md
+++ b/docs/how-to-use.ja.md
@@ -132,12 +132,18 @@ detection_threshold = 2.0     # この % 以上で flaky と判定
 ### `flaker collect` — CI からデータ収集
 
 ```bash
-flaker collect                    # 直近 30 日分
-flaker collect --last 90          # 直近 90 日分
-flaker collect --branch main      # main ブランチのみ
+flaker collect                                           # 直近 30 日分
+flaker collect --last 90                                 # 直近 90 日分
+flaker collect --branch main                             # main ブランチのみ
+flaker collect --json --output .artifacts/collect.json   # 機械可読 summary を保存
+flaker collect --json --output .artifacts/collect.json --fail-on-errors
 ```
 
 GitHub Actions の artifact からテストレポートを自動抽出します。既定の artifact 名は `playwright` が `playwright-report`、`junit` が `junit-report`、`vrt-migration` が `migration-report`、`vrt-bench` が `bench-report` です。workflow 側で別名を使う場合は `[adapter].artifact_name` で上書きします。`GITHUB_TOKEN` 環境変数が必要です。
+
+`--json` は機械可読 summary が欲しいとき、`--output <file>` は summary を artifact に残したいとき、`--fail-on-errors` は partial failure を CI failure として扱いたいときに使います。
+
+GitHub Actions の完全な例は [examples/github-actions/collect-summary.yml](../examples/github-actions/collect-summary.yml) を参照してください。
 
 ### `flaker import` — ローカルレポートの取り込み
 

--- a/docs/how-to-use.md
+++ b/docs/how-to-use.md
@@ -132,12 +132,18 @@ detection_threshold = 2.0     # Mark as flaky above this %
 ### `flaker collect` — Collect from CI
 
 ```bash
-flaker collect                    # Last 30 days
-flaker collect --last 90          # Last 90 days
-flaker collect --branch main      # main branch only
+flaker collect                                           # Last 30 days
+flaker collect --last 90                                 # Last 90 days
+flaker collect --branch main                             # main branch only
+flaker collect --json --output .artifacts/collect.json   # Machine-readable summary
+flaker collect --json --output .artifacts/collect.json --fail-on-errors
 ```
 
 Auto-extracts test reports from GitHub Actions artifacts. The default artifact name is `playwright-report` for `playwright`, `junit-report` for `junit`, `migration-report` for `vrt-migration`, and `bench-report` for `vrt-bench`. Override it with `[adapter].artifact_name` when your workflow uses a different artifact name. Requires `GITHUB_TOKEN` environment variable.
+
+Use `--json` when you want a machine-readable summary, `--output <file>` when you want to persist that summary as a workflow artifact, and `--fail-on-errors` when partial collection failures should fail CI.
+
+A complete GitHub Actions example is available at [examples/github-actions/collect-summary.yml](../examples/github-actions/collect-summary.yml).
 
 ### `flaker import` — Import Local Reports
 

--- a/examples/github-actions/collect-summary.yml
+++ b/examples/github-actions/collect-summary.yml
@@ -1,0 +1,83 @@
+name: flaker-collect-summary
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 3 * * *"
+
+jobs:
+  collect:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Collect flaker history
+        id: collect
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pnpm exec flaker collect \
+            --last 14 \
+            --json \
+            --output .artifacts/flaker/collect-summary.json \
+            --fail-on-errors
+
+      - name: Append GitHub step summary
+        if: always()
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs');
+          const path = '.artifacts/flaker/collect-summary.json';
+          if (!fs.existsSync(path)) {
+            fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, '## flaker collect\n\nNo collect summary was generated.\n');
+            process.exit(0);
+          }
+          const summary = JSON.parse(fs.readFileSync(path, 'utf8'));
+          const lines = [
+            '## flaker collect',
+            '',
+            `- runsCollected: ${summary.runsCollected}`,
+            `- testsCollected: ${summary.testsCollected}`,
+            `- failedRuns: ${summary.failedRuns}`,
+          ];
+          if (summary.failures.length > 0) {
+            lines.push('');
+            lines.push('| runId | message |');
+            lines.push('| --- | --- |');
+            for (const failure of summary.failures) {
+              lines.push(`| ${failure.runId} | ${failure.message.replace(/\|/g, '\\|')} |`);
+            }
+          }
+          fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${lines.join('\n')}\n`);
+          NODE
+
+      - name: Upload collect summary artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: flaker-collect-summary
+          path: .artifacts/flaker/collect-summary.json
+          if-no-files-found: error
+
+      - name: Fail when collect saw errors
+        if: steps.collect.outcome == 'failure'
+        run: exit 1


### PR DESCRIPTION
## Summary
- add collect JSON output, file output, and fail-on-errors exit control
- extend collect tests for summary formatting, persisted output, and exit behavior
- document the collect summary workflow and add a GitHub Actions example under examples/github-actions

## Verification
- pnpm vitest run tests/commands/collect.test.ts
- pnpm -s tsc --noEmit