### PR TITLE
Add MoonBit JS fallback, doctor command, resilient DuckDB loading, and CI matrix

### DIFF
--- a/.github/workflows/core-fallback-matrix.yml
+++ b/.github/workflows/core-fallback-matrix.yml
@@ -1,0 +1,66 @@
+name: core-fallback-matrix
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: core-fallback-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  core-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        moonbit_mode: [without_moonbit_build, with_moonbit_build]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      # These tests do not require native duckdb bindings.
+      - name: Install dependencies (skip native build scripts)
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Setup MoonBit (with build mode only)
+        if: matrix.moonbit_mode == 'with_moonbit_build'
+        uses: hustcer/setup-moonbit@v1
+
+      - name: Verify MoonBit toolchain
+        if: matrix.moonbit_mode == 'with_moonbit_build'
+        run: moon version
+
+      - name: Prepare no-MoonBit-build mode
+        if: matrix.moonbit_mode == 'without_moonbit_build'
+        run: rm -rf src/core/_build
+
+      - name: Build MoonBit JS core
+        if: matrix.moonbit_mode == 'with_moonbit_build'
+        run: |
+          cd src/core
+          moon build --target js
+          test -f _build/js/debug/build/src/main/main.js
+
+      - name: Assert MoonBit build is absent in fallback mode
+        if: matrix.moonbit_mode == 'without_moonbit_build'
+        run: test ! -f src/core/_build/js/debug/build/src/main/main.js
+
+      - name: Run core/fallback parity tests
+        run: pnpm vitest run tests/core/loader.test.ts tests/core/resolve-affected-glob-parity.test.ts tests/resolvers/bitflow-native.test.ts tests/commands/doctor.test.ts tests/storage/duckdb-load.test.ts
+
+      - name: Type check CLI/core
+        run: pnpm -s tsc --noEmit

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,13 @@
+# TODO
+
+## 進行中
+- [x] DuckDB のネイティブバイナリが無い環境で CLI が即死しないよう、`duckdb` 初期化を遅延ロード + エラーメッセージ改善する
+- [x] `resolveAffectedFallback` のパーサを複数行 `task(...)` 定義に対応させる
+- [x] `resolveAffectedFallback` の glob 解釈を MoonBit 実装仕様と突き合わせる（差分テスト追加）
+
+## 次のマイルストーン
+- [x] `flaker doctor` コマンドを追加し、DuckDB/MoonBit の実行環境チェックを 1 コマンドで確認可能にする
+- [x] CI で「MoonBit あり / なし」の 2 パターンを回し、フォールバック経路を常時検証する
+
+## 完了済み
+- [x] MoonBit 未ビルド時でも affected target を解決できる TypeScript fallback を実装

--- a/docs/duckdb-debug.md
+++ b/docs/duckdb-debug.md
@@ -1,0 +1,18 @@
+# DuckDB デバッグメモ
+
+`duckdb.node` が見つからない場合は、次の順に確認してください。
+
+1. `pnpm ignored-builds` で `duckdb` が無視されていないか確認
+2. `package.json` の `pnpm.onlyBuiltDependencies` に `duckdb` を追加
+3. Node ヘッダをローカル指定して再ビルド
+
+```bash
+npm_config_nodedir=$(dirname $(dirname $(which node))) pnpm rebuild duckdb
+```
+
+## この環境で確認したこと
+
+- 事象: `Cannot find module .../duckdb/lib/binding/duckdb.node`
+- 原因1: `pnpm` が `duckdb` のビルドスクリプトを自動無視していた
+- 原因2: プロキシ下で `node-gyp` が Node ヘッダを外部取得しようとして 403 になり得る
+- 対策: `npm_config_nodedir` を指定してローカル Node ヘッダを使う

--- a/package.json
+++ b/package.json
@@ -15,6 +15,11 @@
   "author": "",
   "license": "ISC",
   "packageManager": "pnpm@10.27.0",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "duckdb"
+    ]
+  },
   "dependencies": {
     "@octokit/rest": "^22.0.1",
     "adm-zip": "^0.5.16",

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -1,0 +1,102 @@
+import { loadConfig } from "../config.js";
+import { hasMoonBitJsBuild } from "../core/loader.js";
+
+export interface DoctorCheck {
+  name: string;
+  ok: boolean;
+  detail: string;
+}
+
+export interface DoctorReport {
+  checks: DoctorCheck[];
+  ok: boolean;
+}
+
+export interface DoctorDeps {
+  createStore: () => { initialize: () => Promise<void>; close: () => Promise<void> };
+  hasMoonBitBuild: () => Promise<boolean>;
+  canLoadConfig: () => boolean;
+}
+
+export async function runDoctor(cwd: string, deps?: Partial<DoctorDeps>): Promise<DoctorReport> {
+  const resolved: DoctorDeps = {
+    createStore: deps?.createStore ?? (() => { throw new Error("createStore is not configured"); }),
+    hasMoonBitBuild: deps?.hasMoonBitBuild ?? hasMoonBitJsBuild,
+    canLoadConfig: deps?.canLoadConfig ?? (() => {
+      loadConfig(cwd);
+      return true;
+    }),
+  };
+
+  const checks: DoctorCheck[] = [];
+
+  // Config check
+  try {
+    const ok = resolved.canLoadConfig();
+    checks.push({
+      name: "config",
+      ok,
+      detail: ok ? "flaker.toml is readable" : "flaker.toml check returned false",
+    });
+  } catch (error) {
+    checks.push({
+      name: "config",
+      ok: false,
+      detail: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  // DuckDB check
+  const store = resolved.createStore();
+  let storeInitialized = false;
+  try {
+    await store.initialize();
+    storeInitialized = true;
+    await store.close();
+    checks.push({ name: "duckdb", ok: true, detail: "DuckDB initialized successfully" });
+  } catch (error) {
+    checks.push({
+      name: "duckdb",
+      ok: false,
+      detail: error instanceof Error ? error.message : String(error),
+    });
+  } finally {
+    if (storeInitialized) {
+      try {
+        await store.close();
+      } catch {
+        // best effort
+      }
+    }
+  }
+
+  // MoonBit build check
+  try {
+    const hasBuild = await resolved.hasMoonBitBuild();
+    checks.push({
+      name: "moonbit",
+      ok: true,
+      detail: hasBuild
+        ? "MoonBit JS build detected"
+        : "MoonBit JS build not found (TypeScript fallback will be used)",
+    });
+  } catch (error) {
+    checks.push({
+      name: "moonbit",
+      ok: false,
+      detail: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  return {
+    checks,
+    ok: checks.every((c) => c.ok),
+  };
+}
+
+export function formatDoctorReport(report: DoctorReport): string {
+  const lines = report.checks.map((c) => `${c.ok ? "OK" : "NG"} ${c.name}: ${c.detail}`);
+  lines.push("");
+  lines.push(report.ok ? "Doctor checks passed." : "Doctor checks failed.");
+  return lines.join("\n");
+}

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -28,11 +28,8 @@ const DEFAULT_CONFIG: FlakerConfig = {
   flaky: { window_days: 14, detection_threshold: 0.1 },
 };
 
-function deepMerge<T extends Record<string, unknown>>(
-  target: T,
-  source: Record<string, unknown>,
-): T {
-  const result = { ...target } as Record<string, unknown>;
+function deepMerge<T>(target: T, source: Record<string, unknown>): T {
+  const result = { ...(target as Record<string, unknown>) };
   for (const key of Object.keys(source)) {
     const sv = source[key];
     const tv = result[key];

--- a/src/cli/core/loader.ts
+++ b/src/cli/core/loader.ts
@@ -190,14 +190,15 @@ function wrapMbtCore(mbt: MbtJsExports): MetriciCore {
 }
 
 let cachedCore: MetriciCore | undefined;
+const MOONBIT_JS_BUILD_URL = new URL(
+  "../../../src/core/_build/js/debug/build/src/main/main.js",
+  import.meta.url,
+);
 
 export async function loadCore(): Promise<MetriciCore> {
   if (cachedCore) return cachedCore;
   try {
-    const mbtPath = new URL(
-      "../../../src/core/_build/js/debug/build/src/main/main.js",
-      import.meta.url,
-    ).href;
+    const mbtPath = MOONBIT_JS_BUILD_URL.href;
     const mbt = (await import(mbtPath)) as MbtJsExports;
     if (
       typeof mbt.detect_flaky_json === "function" &&
@@ -222,6 +223,15 @@ export async function loadCore(): Promise<MetriciCore> {
   return cachedCore;
 }
 
+export async function hasMoonBitJsBuild(): Promise<boolean> {
+  try {
+    await access(MOONBIT_JS_BUILD_URL);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /** Synchronous fallback for contexts where async is not possible */
 export function loadCoreSync(): MetriciCore {
   return {
@@ -233,7 +243,151 @@ export function loadCoreSync(): MetriciCore {
   };
 }
 
-/** TS fallback: returns empty (no workflow parsing without MoonBit) */
-function resolveAffectedFallback(_workflowText: string, _changedPaths: string[]): string[] {
-  return [];
+interface FallbackTask {
+  id: string;
+  needs: string[];
+  srcs: string[];
 }
+
+/** TS fallback for affected-target resolution when MoonBit build is unavailable. */
+function resolveAffectedFallback(workflowText: string, changedPaths: string[]): string[] {
+  const tasks = parseWorkflowTasks(workflowText);
+  if (tasks.length === 0 || changedPaths.length === 0) return [];
+
+  const initial = new Set<string>();
+  for (const task of tasks) {
+    if (task.srcs.length === 0) continue;
+    const matched = changedPaths.some((path) => task.srcs.some((pattern) => matchGlob(pattern, path)));
+    if (matched) {
+      initial.add(task.id);
+    }
+  }
+  if (initial.size === 0) return [];
+
+  const byNeed = new Map<string, string[]>();
+  for (const task of tasks) {
+    for (const need of task.needs) {
+      const dependents = byNeed.get(need);
+      if (dependents) dependents.push(task.id);
+      else byNeed.set(need, [task.id]);
+    }
+  }
+
+  // Expand transitive dependents (A needed by B => A change affects B)
+  const affected = new Set(initial);
+  const queue = [...initial];
+  for (let i = 0; i < queue.length; i++) {
+    const current = queue[i];
+    for (const dependent of byNeed.get(current) ?? []) {
+      if (!affected.has(dependent)) {
+        affected.add(dependent);
+        queue.push(dependent);
+      }
+    }
+  }
+  return [...affected];
+}
+
+function parseWorkflowTasks(workflowText: string): FallbackTask[] {
+  const blocks = extractTaskBlocks(workflowText);
+  const tasks: FallbackTask[] = [];
+  for (const block of blocks) {
+    const id = getQuotedValue(block, "id");
+    if (!id) continue;
+
+    tasks.push({
+      id,
+      needs: getQuotedArrayValue(block, "needs"),
+      srcs: getQuotedArrayValue(block, "srcs"),
+    });
+  }
+  return tasks;
+}
+
+function extractTaskBlocks(workflowText: string): string[] {
+  const blocks: string[] = [];
+  let i = 0;
+  while (i < workflowText.length) {
+    const idx = workflowText.indexOf("task(", i);
+    if (idx === -1) break;
+
+    let depth = 0;
+    let inString = false;
+    let end = idx;
+    for (; end < workflowText.length; end++) {
+      const ch = workflowText[end];
+      const prev = end > 0 ? workflowText[end - 1] : "";
+
+      if (ch === "\"" && prev !== "\\") {
+        inString = !inString;
+      }
+      if (inString) continue;
+
+      if (ch === "(") depth++;
+      if (ch === ")") {
+        depth--;
+        if (depth === 0) {
+          end++;
+          break;
+        }
+      }
+    }
+    if (end > idx) {
+      blocks.push(workflowText.slice(idx, end));
+      i = end;
+    } else {
+      i = idx + 5;
+    }
+  }
+  return blocks;
+}
+
+function getQuotedValue(line: string, key: string): string | null {
+  const m = new RegExp(`${key}\\s*=\\s*(['"])(.*?)\\1`, "s").exec(line);
+  return m?.[2] ?? null;
+}
+
+function getQuotedArrayValue(line: string, key: string): string[] {
+  const m = new RegExp(`${key}\\s*=\\s*\\[(.*?)\\]`, "s").exec(line);
+  if (!m) return [];
+  const inner = m[1].trim();
+  if (!inner) return [];
+  const values: string[] = [];
+  const re = /(['"])(.*?)\1/g;
+  for (const match of inner.matchAll(re)) {
+    values.push(match[2]);
+  }
+  return values;
+}
+
+function matchGlob(pattern: string, target: string): boolean {
+  const normalizedPattern = pattern.replaceAll("\\", "/");
+  const normalizedTarget = target.replaceAll("\\", "/");
+  const regex = globToRegex(normalizedPattern);
+  return regex.test(normalizedTarget);
+}
+
+function globToRegex(pattern: string): RegExp {
+  let out = "^";
+  for (let i = 0; i < pattern.length; i++) {
+    const ch = pattern[i];
+    if (ch === "*") {
+      const next = pattern[i + 1];
+      if (next === "*") {
+        out += ".*";
+        i++;
+      } else {
+        out += "[^/]*";
+      }
+      continue;
+    }
+    if (".+?^${}()|[]\\".includes(ch)) {
+      out += `\\${ch}`;
+    } else {
+      out += ch;
+    }
+  }
+  out += "$";
+  return new RegExp(out);
+}
+import { access } from "node:fs/promises";

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -23,6 +23,7 @@ import {
 import { runEval, formatEvalReport } from "./commands/eval.js";
 import { runReason, formatReasoningReport } from "./commands/reason.js";
 import { runSelfEval, formatSelfEvalReport } from "./commands/self-eval.js";
+import { runDoctor, formatDoctorReport } from "./commands/doctor.js";
 import { DuckDBStore } from "./storage/duckdb.js";
 
 const program = new Command();
@@ -75,7 +76,19 @@ program
           created: `>=${created.toISOString().split("T")[0]}`,
           per_page: 100,
         });
-        return response.data;
+        return {
+          total_count: response.data.total_count,
+          workflow_runs: response.data.workflow_runs.map((run) => ({
+            id: run.id,
+            head_branch: run.head_branch ?? "",
+            head_sha: run.head_sha,
+            event: run.event,
+            conclusion: run.conclusion ?? "",
+            created_at: run.created_at,
+            run_started_at: run.run_started_at ?? run.created_at,
+            updated_at: run.updated_at,
+          })),
+        };
       },
       async listArtifacts(runId: number) {
         const response = await octokit.actions.listWorkflowRunArtifacts({
@@ -517,6 +530,18 @@ program
       console.log(formatSelfEvalReport(report));
     }
     process.exit(report.overallScore >= 80 ? 0 : 1);
+  });
+
+// --- doctor ---
+program
+  .command("doctor")
+  .description("Check local flaker runtime requirements")
+  .action(async () => {
+    const report = await runDoctor(process.cwd(), {
+      createStore: () => new DuckDBStore(":memory:"),
+    });
+    console.log(formatDoctorReport(report));
+    process.exit(report.ok ? 0 : 1);
   });
 
 program.parse();

--- a/src/cli/storage/duckdb.ts
+++ b/src/cli/storage/duckdb.ts
@@ -1,4 +1,3 @@
-import duckdb from "duckdb";
 import { SCHEMA_DDL, FLAKY_QUERY } from "./schema.js";
 import type {
   MetricStore,
@@ -13,8 +12,8 @@ import type {
 } from "./types.js";
 
 export class DuckDBStore implements MetricStore {
-  private db: duckdb.Database | null = null;
-  private conn: duckdb.Connection | null = null;
+  private db: DuckDBDatabase | null = null;
+  private conn: DuckDBConnection | null = null;
   private dbPath: string;
 
   constructor(dbPath: string) {
@@ -22,14 +21,40 @@ export class DuckDBStore implements MetricStore {
   }
 
   async initialize(): Promise<void> {
-    this.db = await new Promise<duckdb.Database>((resolve, reject) => {
-      const db = new duckdb.Database(this.dbPath, (err: any) => {
-        if (err) reject(err);
-        else resolve(db);
-      });
+    let duckdb: DuckDBModule;
+    try {
+      duckdb = await this.loadDuckDBModule();
+    } catch (error) {
+      throw this.buildDuckDBLoadError(error);
+    }
+    this.db = await new Promise<DuckDBDatabase>((resolve, reject) => {
+      try {
+        const db = new duckdb.Database(this.dbPath, (err: any) => {
+          if (err) reject(err);
+          else resolve(db);
+        });
+      } catch (err) {
+        reject(err);
+      }
     });
     this.conn = this.db.connect();
     await this.exec(SCHEMA_DDL);
+  }
+
+  private async loadDuckDBModule(): Promise<DuckDBModule> {
+    const mod = (await import("duckdb")) as unknown as { default?: DuckDBModule } & DuckDBModule;
+    return mod.default ?? mod;
+  }
+
+  private buildDuckDBLoadError(error: unknown): Error {
+    return new Error(
+      [
+        "Failed to load DuckDB native binding.",
+        "Install/rebuild dependencies and ensure the runtime can load native modules.",
+        "Try: npm_config_nodedir=$(dirname $(dirname $(which node))) pnpm rebuild duckdb",
+        `Original error: ${error instanceof Error ? error.message : String(error)}`,
+      ].join(" ")
+    );
   }
 
   async close(): Promise<void> {
@@ -277,3 +302,18 @@ export class DuckDBStore implements MetricStore {
     });
   }
 }
+
+type DuckDBModule = {
+  Database: new (...args: unknown[]) => DuckDBDatabase;
+};
+
+type DuckDBDatabase = {
+  connect: () => DuckDBConnection;
+  close: (callback: (err: unknown) => void) => void;
+};
+
+type DuckDBConnection = {
+  all: (sql: string, ...params: unknown[]) => void;
+  run: (sql: string, ...params: unknown[]) => void;
+  exec: (sql: string, callback: (err: unknown) => void) => void;
+};

--- a/tests/commands/doctor.test.ts
+++ b/tests/commands/doctor.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { runDoctor, formatDoctorReport } from "../../src/cli/commands/doctor.js";
+
+describe("runDoctor", () => {
+  it("reports success when all checks pass", async () => {
+    const report = await runDoctor(process.cwd(), {
+      canLoadConfig: () => true,
+      hasMoonBitBuild: async () => false,
+      createStore: () => ({
+        initialize: async () => {},
+        close: async () => {},
+      }),
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.checks.find((c) => c.name === "config")?.ok).toBe(true);
+    expect(report.checks.find((c) => c.name === "duckdb")?.ok).toBe(true);
+    expect(report.checks.find((c) => c.name === "moonbit")?.detail).toContain("TypeScript fallback");
+  });
+
+  it("reports failure when duckdb cannot initialize", async () => {
+    const report = await runDoctor(process.cwd(), {
+      canLoadConfig: () => true,
+      hasMoonBitBuild: async () => true,
+      createStore: () => ({
+        initialize: async () => {
+          throw new Error("duckdb missing");
+        },
+        close: async () => {},
+      }),
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.checks.find((c) => c.name === "duckdb")?.ok).toBe(false);
+    expect(formatDoctorReport(report)).toContain("Doctor checks failed.");
+  });
+});

--- a/tests/core/resolve-affected-glob-parity.test.ts
+++ b/tests/core/resolve-affected-glob-parity.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { loadCoreSync } from "../../src/cli/core/loader.js";
+
+describe("resolveAffectedFallback glob parity", () => {
+  const core = loadCoreSync();
+
+  it("treats * as single path segment", () => {
+    const workflow = [
+      'workflow(name="ci")',
+      'node(id="auth", depends_on=[])',
+      'task(id="test-auth", node="auth", cmd="test", needs=[], srcs=["src/*/index.ts"])',
+    ].join("\n");
+
+    expect(core.resolveAffected(workflow, ["src/auth/index.ts"])).toContain("test-auth");
+    expect(core.resolveAffected(workflow, ["src/auth/ui/index.ts"])).toEqual([]);
+  });
+
+  it("treats ** as multi-segment wildcard", () => {
+    const workflow = [
+      'workflow(name="ci")',
+      'node(id="auth", depends_on=[])',
+      'task(id="test-auth", node="auth", cmd="test", needs=[], srcs=["src/**/index.ts"])',
+    ].join("\n");
+
+    expect(core.resolveAffected(workflow, ["src/auth/index.ts"])).toContain("test-auth");
+    expect(core.resolveAffected(workflow, ["src/auth/ui/index.ts"])).toContain("test-auth");
+  });
+
+  it("supports mixed quote style in src arrays", () => {
+    const workflow = [
+      "workflow(name='ci')",
+      "node(id='auth', depends_on=[])",
+      "task(id='test-auth', node='auth', cmd='test', needs=[], srcs=['src/auth/**', \"src/shared/**\"])",
+    ].join("\n");
+
+    expect(core.resolveAffected(workflow, ["src/shared/util.ts"])).toContain("test-auth");
+  });
+});

--- a/tests/resolvers/bitflow-native.test.ts
+++ b/tests/resolvers/bitflow-native.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { loadCore } from "../../src/cli/core/loader.js";
 
 describe("BitflowNativeResolver", () => {
@@ -56,5 +56,45 @@ describe("BitflowNativeResolver", () => {
     const allTestFiles = new Set(["test-auth"]);
     const filtered = affectedTargets.filter(t => allTestFiles.has(t));
     expect(filtered).toEqual(["test-auth"]);
+  });
+
+  it("supports multi-line task definitions in TS fallback parser", async () => {
+    const core = await loadCore();
+    const workflow = [
+      'workflow(name="ci")',
+      'node(id="auth", depends_on=[])',
+      "task(",
+      '  id="test-auth",',
+      '  node="auth",',
+      '  cmd="test",',
+      '  needs=[],',
+      '  srcs=["src/auth/**"]',
+      ")",
+    ].join("\n");
+
+    const result = core.resolveAffected(workflow, ["src/auth/login.ts"]);
+    expect(result).toContain("test-auth");
+  });
+
+  it("supports single-quoted workflow values in TS fallback parser", async () => {
+    const core = await loadCore();
+    const workflow = [
+      "workflow(name='ci')",
+      "node(id='auth', depends_on=[])",
+      "task(id='test-auth', node='auth', cmd='test', needs=[], srcs=['src/auth/**'])",
+    ].join("\n");
+    const result = core.resolveAffected(workflow, ["src/auth/login.ts"]);
+    expect(result).toContain("test-auth");
+  });
+
+  it("matches changed paths with Windows separators", async () => {
+    const core = await loadCore();
+    const workflow = [
+      'workflow(name="ci")',
+      'node(id="auth", depends_on=[])',
+      'task(id="test-auth", node="auth", cmd="test", needs=[], srcs=["src/auth/**"])',
+    ].join("\n");
+    const result = core.resolveAffected(workflow, ["src\\auth\\login.ts"]);
+    expect(result).toContain("test-auth");
   });
 });

--- a/tests/storage/duckdb-load.test.ts
+++ b/tests/storage/duckdb-load.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from "vitest";
+import { DuckDBStore } from "../../src/cli/storage/duckdb.js";
+
+describe("DuckDBStore module loading", () => {
+  it("wraps module load failures with actionable error message", async () => {
+    const store = new DuckDBStore(":memory:");
+    (store as any).loadDuckDBModule = async () => {
+      throw new Error("cannot find duckdb.node");
+    };
+
+    await expect(store.initialize()).rejects.toThrow("Failed to load DuckDB native binding.");
+  });
+});


### PR DESCRIPTION
### Motivation

- Ensure parity between the native MoonBit JS build and a TypeScript fallback parser for affected-target resolution and continuously validate both paths in CI.
- Make the CLI resilient in environments that lack the DuckDB native binding by delaying load and improving error diagnostics.
- Provide a single `doctor` command to surface common runtime/environment issues for users.

### Description

- Add a GitHub Actions matrix workflow `core-fallback-matrix.yml` that runs tests in two modes: `with_moonbit_build` and `without_moonbit_build` to validate fallback parity.
- Implement a robust TypeScript fallback in `src/cli/core/loader.ts` including `resolveAffectedFallback` with a multi-line-safe parser, glob matching (`*` and `**`), and a `hasMoonBitJsBuild` probe, and centralize the MoonBit build path into `MOONBIT_JS_BUILD_URL`.
- Add `src/cli/commands/doctor.ts` and wire a `doctor` subcommand in `src/cli/main.ts` to run config, DuckDB initialization, and MoonBit build checks programmatically and to format a human-readable report.
- Make DuckDB loading resilient in `src/cli/storage/duckdb.ts` by lazily importing the `duckdb` module, wrapping load failures with actionable error messages, and adding lightweight DuckDB types; also add `pnpm.onlyBuiltDependencies: ["duckdb"]` to `package.json`.
- Add documentation and project notes in `docs/duckdb-debug.md` and `TODO.md`, and add tests covering the fallback parser, DuckDB load error wrapping, and the `doctor` command in `tests/`.

### Testing

- Ran the targeted test suite with `pnpm vitest run tests/core/loader.test.ts tests/core/resolve-affected-glob-parity.test.ts tests/resolvers/bitflow-native.test.ts tests/commands/doctor.test.ts tests/storage/duckdb-load.test.ts` and all tests passed.
- Ran type checking with `pnpm -s tsc --noEmit` with no errors.
- The new CI workflow exercises both `with_moonbit_build` and `without_moonbit_build` modes to ensure the fallback path and MoonBit build behave equivalently.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd01d919c4832d8006b2b54f224a88)