### PR TITLE
feat: add eval-fixture command for sampling strategy evaluation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -169,5 +169,219 @@
 3. `config ownership analysis` を `core-policy` として MoonBit に移す
 4. `stable test identity` の adapter source 正規化を TS shell として維持しつつ、必要なら variant contract を bitflow/actrun に広げる
 
+## ML ベーステスト選択
+
+### 設計方針（確定）
+
+- ML はオプション。なくても現行ヒューリスティックで動作する
+- co-failure はマテリアライズせず、毎回 DuckDB クエリで導出
+- 学習: MoonBit native target で LightGBM C API (daily batch)
+- 推論: native では C API、JS target では TS フォールバック（ツリー走査）
+- モデルがなければヒューリスティックにフォールバック
+
+### Stage 1: Co-failure トラッキング（ML なし）
+
+`commit_changes` テーブルを追加し、co-failure をクエリで導出する。
+
+#### 新規テーブル
+
+```sql
+CREATE TABLE IF NOT EXISTS commit_changes (
+  commit_sha  VARCHAR NOT NULL,
+  file_path   VARCHAR NOT NULL,
+  change_type VARCHAR,          -- added / modified / deleted / renamed
+  additions   INTEGER DEFAULT 0,
+  deletions   INTEGER DEFAULT 0,
+  PRIMARY KEY (commit_sha, file_path)
+);
+```
+
+#### 収集ソース
+
+- `collect` (GitHub): `git diff-tree --no-commit-id --name-status -r {sha}`
+- `collect-local` (actrun): `git diff-tree` またはbit API
+- `import`: レポートに commit_sha があればその時点の diff を取得
+
+#### Co-failure 導出クエリ（毎回実行）
+
+```sql
+SELECT
+  cc.file_path, tr.test_id,
+  COUNT(*) AS co_runs,
+  COUNT(*) FILTER (WHERE tr.status IN ('failed','flaky')
+    OR (tr.retry_count > 0 AND tr.status = 'passed')) AS co_failures,
+  ROUND(co_failures * 100.0 / co_runs, 2) AS co_failure_rate
+FROM commit_changes cc
+JOIN test_results tr ON cc.commit_sha = tr.commit_sha
+WHERE cc.commit_sha IN (
+  SELECT commit_sha FROM commit_changes
+  WHERE commit_sha IN (SELECT commit_sha FROM test_results
+    WHERE created_at > CURRENT_TIMESTAMP - INTERVAL (? || ' days'))
+)
+GROUP BY cc.file_path, tr.test_id
+HAVING co_runs >= 3
+```
+
+時間窓は2種類サポート:
+- `--co-failure-days`: co-failure 集計の窓（デフォルト: 90日）
+- `--flaky-days`: 既存のフレーキー率の窓（デフォルト: 30日）
+
+#### Sampling への組み込み
+
+```
+既存:  weight = 1.0 + flaky_rate
+拡張:  weight = 1.0 + flaky_rate + α * max(co_failure_rate for changed_files)
+α は自動チューニング（eval の confusion matrix から最適化）
+```
+
+### Stage 2: GBDT 予測モデル（LightGBM）
+
+- 特徴量:
+  - co_failure_rate（Stage 1 のクエリから）
+  - dependency_graph_distance（既存の graph analyzer）
+  - flaky_rate（既存）
+  - change_size: `SUM(additions + deletions)` from `commit_changes`
+  - recency_weighted_failures: 指数減衰 `Σ fail * exp(-λ * days_ago)`
+  - is_new_test: `total_runs <= 1`
+- ラベル: CI でこのテストが落ちたか (0/1)
+- 学習: native target で LightGBM C API、daily batch で `init_model` 引き継ぎ
+- モデル保存: `.flaker/models/model-{date}.json`
+- モデルホスト: 未決定（S3? GitHub Releases? 後で決める）
+
+### Stage 3: Holdout サンプリング（フィードバックループ）
+
+- スキップしたテストの一部をランダム実行し「見逃し」を検出
+- これがないと「落ちるテストをスキップし続けて気づかない」問題が発生
+- 設計詳細: 未決定（`sampling_run_tests` に `is_holdout` を追加する案あり）
+
+### 自動チューニング
+
+α（co-failure の重み係数）を eval の結果から自動最適化:
+1. 過去の sampling_runs + CI 結果から confusion matrix を計算
+2. α を変化させて F1 スコアを最大化する値を探索（grid search / Bayesian opt）
+3. `.flaker/models/tuning.json` に保存
+4. `flaker sample` 時に自動ロード
+
+### 時系列的特徴量
+
+純粋な時系列予測（ARIMA, LSTM）はこの問題には不適。
+分類モデル（GBDT）に時系列的特徴量を組み込む:
+- Recency weighting（指数減衰で直近の失敗を重視）
+- フレーキーの周期性パターン検出（cron 的な外部依存）
+- Concept drift 対応（sliding window で学習窓を制御）
+
+### E2E テスト固有の課題
+
+- 非決定性: フレーキーな失敗が学習シグナルを汚染
+- 暗黙の状態依存: DB, キャッシュ, 外部サービスは静的解析で見えない
+- 多対多マッピング: バックエンドの小変更が UI フロー全体に波及
+- 疎なデータ: E2E は実行頻度が低く学習データが少ない
+- → 静的依存解析だけでは不十分。ML の追加価値が最も大きい領域
+
+## ストレージアーキテクチャ
+
+### 方針（確定）
+
+- Storage と Query を分離: Parquet (保存) + DuckDB (分析)
+- 出力先: `.flaker/artifacts/`
+- CI artifacts (GitHub Actions) とローカル (actrun) の両方を扱う
+
+### データフロー
+
+```
+GitHub Actions (collect)
+  → git diff-tree で commit_changes 収集
+  → adapter でテスト結果パース
+  → DuckDB に書き込み
+  → .flaker/artifacts/ に Parquet エクスポート
+  → actions/upload-artifact で保存
+
+actrun (collect-local)
+  → git diff-tree or bit API で commit_changes 収集
+  → actrun adapter でテスト結果パース
+  → DuckDB に書き込み
+  → .flaker/artifacts/ に Parquet エクスポート
+
+import (他環境からの取り込み)
+  → .flaker/artifacts/*.parquet を DuckDB に read_parquet() で読み込み
+  → または S3 / artifacts からダウンロード → import
+```
+
+### Parquet ファイル構成
+
+```
+.flaker/artifacts/
+  test_results/
+    {repo}-{date}-{run_id}.parquet
+  commit_changes/
+    {repo}-{date}-{run_id}.parquet
+  workflow_runs/
+    {repo}-{date}-{run_id}.parquet
+```
+
+### Parquet 実装
+
+- `mizchi/parquet` (MoonBit) で native target から直接読み書き可能
+- TS 側は DuckDB の `read_parquet()` で同じファイルを読める
+- 他言語実装（Python/Rust 等）への切り替えに備え、スキーマ規約は後で固める
+- 現段階ではスキーマは柔らかく保ち、実データが溜まってから正式に決定する
+
+### DuckDB との統合
+
+- DuckDB は `.flaker/artifacts/*.parquet` を `read_parquet()` で直読み可能
+- 既存テーブルへの INSERT も維持（後方互換）
+- 将来的に DuckDB テーブルを Parquet ビューに置き換え可能
+
+### モデルアーティファクト
+
+```
+.flaker/models/
+  model-{date}.json       -- LightGBM モデル
+  tuning.json             -- α 等のハイパーパラメータ
+```
+
+ホスト先: 未決定（S3, GitHub Releases 等。後で決める）
+
+## 評価フレームワーク
+
+### 目的
+
+flaker の各機能（サンプリング精度、フレーキー検出、CLI UX）を定量的に評価する。
+ML 導入前のベースラインと導入後の改善を比較可能にする。
+
+### アプローチ A: 合成フィクスチャ
+
+- 制御されたパラメータでテスト履歴データを生成
+  - テスト数: 100 / 1,000 / 10,000
+  - フレーキー率: 0% / 5% / 20%
+  - 依存グラフ: 線形 / ツリー / メッシュ
+  - co-failure パターン: 強相関 / 弱相関 / ランダム
+- ベースライン（現行ヒューリスティック）と ML モデルの比較が可能
+- 再現性が高い
+
+### アプローチ B: 実 OSS リポジトリ
+
+- vite, playwright, deno 等のテスト履歴を収集
+- 実データでの弱点特定
+- ただし再現性は低い
+
+### アプローチ C: Subagent 評価
+
+- Claude Code の subagent に flaker を使わせる
+- CLI の UX、エラーメッセージ、ドキュメントの改善フィードバック
+- 「初見のユーザーが使えるか」の評価
+
+## Coverage-guided テスト選択（検討中）
+
+coverage-guided fuzzing の知見をテスト選択に応用する。
+詳細設計: [docs/ml-test-selection-design.md](docs/ml-test-selection-design.md)
+
+- [ ] **乗算→加算分解**: カバレッジデータがあれば、変更関数ごとにテストを加算的に選択できる
+- [ ] **max-reduce 新規性検出**: テスト間の冗長性を排除（同じコードパスをカバーするテストを重複選択しない）
+- [ ] **バケット化**: co-failure rate / flaky_rate を AFL 式にバケット化してノイズ削減
+- [ ] **coverage-guided サンプリング戦略**: greedy set cover + weighted random（holdout 探索）
+- [ ] **Antithesis 的拡張**: 実行順序・タイミング・環境のミューテーションによるフレーキー原因特定
+- [ ] カバレッジデータの収集方法を決める（Istanbul/V8 coverage, playwright --coverage 等）
+
 ## 完了済み
 - [x] MoonBit 未ビルド時でも affected target を解決できる TypeScript fallback を実装

--- a/docs/ml-test-selection-design.md
+++ b/docs/ml-test-selection-design.md
@@ -1,0 +1,276 @@
+# ML ベーステスト選択 設計ドキュメント
+
+## 概要
+
+flaker に ML ベースのテスト選択を段階的に導入する設計。
+現行のヒューリスティック（依存グラフ + フレーキー率重み付け）を維持しつつ、オプションとして ML 予測を追加する。
+
+## 背景と動機
+
+### 現行アプローチの限界
+
+現在の flaker は完全にヒューリスティック/決定論的:
+
+- **依存グラフ解析**: 変更ファイルから BFS/DFS で影響テストを特定
+- **フレーキー率重み付け**: `weight = 1.0 + flaky_rate`
+- **ハイブリッドサンプリング**: affected > 過去失敗 > 新規 > 重み付きランダム
+
+静的依存解析は**プログラム言語レベルの依存関係**には有効だが、E2E テストのように暗黙の状態依存（DB、キャッシュ、外部サービス）がある場合は不十分。
+
+### 業界の実績
+
+| 組織 | 手法 | 結果 |
+|------|------|------|
+| Google | ロジスティック回帰 + co-failure 履歴 | テスト 95% 削減、失敗検出 99.5% |
+| Meta | 変更-テスト相関 + カバレッジ | 大規模に実運用 |
+| Microsoft | 強化学習 (RETECS) | 研究段階 |
+
+## 設計方針
+
+- **ML はオプション**: なくても現行ヒューリスティックで動作する
+- **co-failure はマテリアライズせず、毎回 DuckDB クエリで導出**
+- **学習**: MoonBit native target で LightGBM C API (daily batch)
+- **推論**: native では C API、JS target では TS フォールバック（ツリー走査）
+- **モデルがなければヒューリスティックにフォールバック**
+
+## 段階的導入計画
+
+### Stage 1: Co-failure トラッキング（ML なし）
+
+`commit_changes` テーブルを追加し、co-failure をクエリで導出する。
+
+#### 新規テーブル
+
+```sql
+CREATE TABLE IF NOT EXISTS commit_changes (
+  commit_sha  VARCHAR NOT NULL,
+  file_path   VARCHAR NOT NULL,
+  change_type VARCHAR,          -- added / modified / deleted / renamed
+  additions   INTEGER DEFAULT 0,
+  deletions   INTEGER DEFAULT 0,
+  PRIMARY KEY (commit_sha, file_path)
+);
+```
+
+#### 収集ソース
+
+- `collect` (GitHub): `git diff-tree --no-commit-id --name-status -r {sha}`
+- `collect-local` (actrun): `git diff-tree` または bit API
+- `import`: レポートに commit_sha があればその時点の diff を取得
+
+#### Co-failure 導出クエリ
+
+```sql
+SELECT
+  cc.file_path, tr.test_id,
+  COUNT(*) AS co_runs,
+  COUNT(*) FILTER (WHERE tr.status IN ('failed','flaky')
+    OR (tr.retry_count > 0 AND tr.status = 'passed')) AS co_failures,
+  ROUND(co_failures * 100.0 / co_runs, 2) AS co_failure_rate
+FROM commit_changes cc
+JOIN test_results tr ON cc.commit_sha = tr.commit_sha
+WHERE cc.commit_sha IN (
+  SELECT commit_sha FROM commit_changes
+  WHERE commit_sha IN (SELECT commit_sha FROM test_results
+    WHERE created_at > CURRENT_TIMESTAMP - INTERVAL (? || ' days'))
+)
+GROUP BY cc.file_path, tr.test_id
+HAVING co_runs >= 3
+```
+
+時間窓は 2 種類サポート:
+- `--co-failure-days`: co-failure 集計の窓（デフォルト: 90 日）
+- `--flaky-days`: 既存のフレーキー率の窓（デフォルト: 30 日）
+
+#### Sampling への組み込み
+
+```
+既存:  weight = 1.0 + flaky_rate
+拡張:  weight = 1.0 + flaky_rate + α * max(co_failure_rate for changed_files)
+α は自動チューニング（eval の confusion matrix から最適化）
+```
+
+### Stage 2: GBDT 予測モデル（LightGBM）
+
+- 特徴量:
+  - co_failure_rate（Stage 1 のクエリから）
+  - dependency_graph_distance（既存の graph analyzer）
+  - flaky_rate（既存）
+  - change_size: `SUM(additions + deletions)` from `commit_changes`
+  - recency_weighted_failures: 指数減衰 `Σ fail * exp(-λ * days_ago)`
+  - is_new_test: `total_runs <= 1`
+- ラベル: CI でこのテストが落ちたか (0/1)
+- 学習: native target で LightGBM C API、daily batch で `init_model` 引き継ぎ
+- モデル保存: `.flaker/models/model-{date}.json`
+
+### Stage 3: Holdout サンプリング（フィードバックループ）
+
+- スキップしたテストの一部をランダム実行し「見逃し」を検出
+- これがないと「落ちるテストをスキップし続けて気づかない」問題が発生
+- 設計詳細: 未決定
+
+### 自動チューニング
+
+α（co-failure の重み係数）を eval の結果から自動最適化:
+
+1. 過去の sampling_runs + CI 結果から confusion matrix を計算
+2. α を変化させて F1 スコアを最大化する値を探索（grid search / Bayesian opt）
+3. `.flaker/models/tuning.json` に保存
+4. `flaker sample` 時に自動ロード
+
+## 時系列的特徴量
+
+純粋な時系列予測（ARIMA, LSTM）はこの問題には不適。
+テスト選択は「この diff で何が落ちるか」の**条件付き分類**であり、「次に何が起きるか」の予測ではない。
+
+分類モデル（GBDT）に時系列的特徴量を組み込む:
+
+- **Recency weighting**: 指数減衰で直近の失敗を重視
+- **周期性パターン検出**: cron 的な外部依存によるフレーキー
+- **Concept drift 対応**: sliding window で学習窓を制御
+
+## Coverage-guided アプローチ
+
+Coverage-guided fuzzing の知見（参考: [Pierre Zemb, "Diving into coverage-guided fuzzing"](https://pierrezemb.fr/posts/diving-into-coverage-guided-fuzzing/)）をテスト選択に応用する。
+
+### 核心的アイデア: 乗算から加算への分解
+
+ランダムファジングで 3 バイト列を見つけるには 256³ = 1600 万回必要だが、カバレッジフィードバックがあれば 256×3 = 768 回で済む。
+
+テスト選択に当てはめると:
+- **乗算的（現状）**: テストを重み付きランダムで選ぶ
+- **加算的（目標）**: 「変更された関数 A をカバーするテスト」+「関数 B をカバーするテスト」と分解
+
+co-failure はカバレッジの近似として機能するが、直接カバレッジデータの方が精度は高い。
+
+### Max-reduce による新規性検出
+
+ファジングの max-reduce 戦略をテスト選択に応用:
+
+```
+各テスト選択時:
+  if このテストが、既に選択済みテストがカバーしていない
+     コードパスをカバーする:
+    → 選択（novel）
+  else:
+    → 冗長、スキップ
+```
+
+現在の flaker は「テストごとに独立して重みを計算 → 上位 N 件を選択」だが、テスト間の冗長性を考慮していない。同じコードパスをカバーする複数テストを全部選ぶのは無駄。
+
+### バケット化によるノイズ削減
+
+AFL の 8bit カウンタバケット化をメトリクスに応用:
+
+| 生値 | バケット | 意味 |
+|------|---------|------|
+| 0 | 0 | 未実行 / 相関なし |
+| 1 | 1 | 1 回 |
+| 2-3 | 2 | 少数 |
+| 4-7 | 3 | 中程度 |
+| 8+ | 4 | 強い相関 |
+
+co-failure rate や flaky_rate をバケット化すれば、37 回失敗 vs 38 回失敗の無意味な区別を消せる。GBDT の特徴量としても離散化した方が頑健。
+
+### 「目の良い馬鹿な手」原則
+
+> "Dumb hands with good eyes beat smart hands that are blind."
+
+単純なモデル（GBDT）+ 良いフィードバック（co-failure, カバレッジ）が、複雑なモデル（Transformer）+ フィードバックなしに勝つ。flaker の ML 戦略を支持する原則。
+
+### Antithesis 的拡張 — E2E テストへの応用
+
+Antithesis はバイト列ではなくスケジューリング決定、ネットワークイベント、障害注入をミューテーションする。E2E テストに当てはめると:
+
+- **テスト実行順序のミューテーション** → 順序依存のフレーキー検出
+- **タイミングのミューテーション（遅延注入）** → レースコンディション発見
+- **環境変数のミューテーション** → 環境依存のフレーキー検出
+
+「なぜこのテストがフレーキーか」の原因特定に使える。
+
+### Coverage-guided サンプリング戦略
+
+```
+1. changed_files から影響範囲を特定（既存の affected analysis）
+2. 各テストのカバレッジデータから、影響範囲をカバーするテストを列挙
+3. greedy set cover: カバレッジの新規性が最大のテストを順に選択
+4. カバレッジデータがなければ co-failure で近似
+5. 残り枠は weighted random で埋める（holdout 的な探索）
+```
+
+ステップ 5 が重要: ファジングの「ランダムミューテーションで未知の領域を探索する」に相当。全てをカバレッジで決めると、カバレッジデータにないバグを永遠に見つけられない。
+
+## E2E テスト固有の課題
+
+- **非決定性**: フレーキーな失敗が学習シグナルを汚染
+- **暗黙の状態依存**: DB, キャッシュ, 外部サービスは静的解析で見えない
+- **多対多マッピング**: バックエンドの小変更が UI フロー全体に波及
+- **疎なデータ**: E2E は実行頻度が低く学習データが少ない
+- **プロセス間カバレッジ**: ブラウザ + サーバ + DB をまたぐ計装が困難
+
+→ 静的依存解析だけでは不十分。ML の追加価値が最も大きい領域。
+
+## ストレージアーキテクチャ
+
+### 方針
+
+- Storage と Query を分離: Parquet (保存) + DuckDB (分析)
+- 出力先: `.flaker/artifacts/`
+- CI artifacts (GitHub Actions) とローカル (actrun) の両方を扱う
+
+### データフロー
+
+```
+GitHub Actions (collect)
+  → git diff-tree で commit_changes 収集
+  → adapter でテスト結果パース
+  → DuckDB に書き込み
+  → .flaker/artifacts/ に Parquet エクスポート
+  → actions/upload-artifact で保存
+
+actrun (collect-local)
+  → git diff-tree or bit API で commit_changes 収集
+  → actrun adapter でテスト結果パース
+  → DuckDB に書き込み
+  → .flaker/artifacts/ に Parquet エクスポート
+
+import (他環境からの取り込み)
+  → .flaker/artifacts/*.parquet を DuckDB に read_parquet() で読み込み
+  → または S3 / artifacts からダウンロード → import
+```
+
+### Parquet ファイル構成
+
+```
+.flaker/artifacts/
+  test_results/
+    {repo}-{date}-{run_id}.parquet
+  commit_changes/
+    {repo}-{date}-{run_id}.parquet
+  workflow_runs/
+    {repo}-{date}-{run_id}.parquet
+```
+
+### Parquet 実装
+
+- `mizchi/parquet` (MoonBit) で native target から直接読み書き可能
+- TS 側は DuckDB の `read_parquet()` で同じファイルを読める
+- 他言語実装への切り替えに備え、スキーマ規約は後で固める
+- 現段階ではスキーマは柔らかく保ち、実データが溜まってから正式に決定
+
+### モデルアーティファクト
+
+```
+.flaker/models/
+  model-{date}.json       -- LightGBM モデル
+  tuning.json             -- α 等のハイパーパラメータ
+```
+
+ホスト先: 未決定（S3, GitHub Releases 等）
+
+## 未決定事項
+
+- Holdout サンプリングの設計詳細（`sampling_run_tests` に `is_holdout` 追加する案あり）
+- モデルアーティファクトのホスト先
+- Parquet スキーマの正式規約（実データが溜まってから決定）
+- カバレッジデータの収集方法（Istanbul/V8 coverage, playwright `--coverage` 等）

--- a/docs/superpowers/plans/2026-04-03-co-failure-tracking.md
+++ b/docs/superpowers/plans/2026-04-03-co-failure-tracking.md
@@ -1,0 +1,917 @@
+# Co-failure Tracking Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `commit_changes` table and co-failure query to enable ML-based test selection (Stage 1)
+
+**Architecture:** Add a `commit_changes` table to DuckDB that records which files changed per commit. Collect data via `git diff-tree` during `collect` and `collect-local`. Expose a co-failure query that joins `commit_changes` with `test_results`. Integrate co-failure rate into `sample_weighted` and `sample_hybrid` via a new `co_failure_boost` field on `TestMeta`.
+
+**Tech Stack:** TypeScript (CLI/storage), MoonBit (sampling/contracts), DuckDB, vitest
+
+---
+
+### Task 1: Add `commit_changes` table to schema
+
+**Files:**
+- Modify: `src/cli/storage/schema.ts:1-95`
+- Modify: `src/cli/storage/types.ts`
+- Modify: `src/cli/storage/duckdb.ts`
+- Test: `tests/storage/commit-changes.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/storage/commit-changes.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { DuckDBStore } from "../../src/cli/storage/duckdb.js";
+
+describe("commit_changes storage", () => {
+  let store: DuckDBStore;
+
+  beforeEach(async () => {
+    store = new DuckDBStore(":memory:");
+    await store.initialize();
+  });
+
+  afterEach(async () => {
+    await store.close();
+  });
+
+  it("inserts and queries commit changes", async () => {
+    await store.insertCommitChanges("abc123", [
+      { filePath: "src/foo.ts", changeType: "modified", additions: 10, deletions: 5 },
+      { filePath: "src/bar.ts", changeType: "added", additions: 20, deletions: 0 },
+    ]);
+
+    const rows = await store.raw<{ file_path: string; change_type: string }>(
+      "SELECT file_path, change_type FROM commit_changes WHERE commit_sha = ?",
+      ["abc123"],
+    );
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.file_path).sort()).toEqual(["src/bar.ts", "src/foo.ts"]);
+  });
+
+  it("skips duplicates on re-insert", async () => {
+    const changes = [
+      { filePath: "src/foo.ts", changeType: "modified", additions: 10, deletions: 5 },
+    ];
+    await store.insertCommitChanges("abc123", changes);
+    await store.insertCommitChanges("abc123", changes);
+
+    const rows = await store.raw<{ cnt: number }>(
+      "SELECT COUNT(*)::INTEGER AS cnt FROM commit_changes WHERE commit_sha = ?",
+      ["abc123"],
+    );
+    expect(rows[0].cnt).toBe(1);
+  });
+
+  it("hasCommitChanges returns correct value", async () => {
+    expect(await store.hasCommitChanges("abc123")).toBe(false);
+    await store.insertCommitChanges("abc123", [
+      { filePath: "src/foo.ts", changeType: "modified", additions: 1, deletions: 1 },
+    ]);
+    expect(await store.hasCommitChanges("abc123")).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run tests/storage/commit-changes.test.ts`
+Expected: FAIL — `insertCommitChanges` and `hasCommitChanges` do not exist
+
+- [ ] **Step 3: Add types**
+
+In `src/cli/storage/types.ts`, add the interface and extend `MetricStore`:
+
+```typescript
+export interface CommitChange {
+  filePath: string;
+  changeType: string;
+  additions: number;
+  deletions: number;
+}
+```
+
+Add to `MetricStore` interface:
+
+```typescript
+  insertCommitChanges(commitSha: string, changes: CommitChange[]): Promise<void>;
+  hasCommitChanges(commitSha: string): Promise<boolean>;
+```
+
+- [ ] **Step 4: Add DDL to schema.ts**
+
+Append to `SCHEMA_DDL` in `src/cli/storage/schema.ts`, before the closing backtick:
+
+```sql
+CREATE TABLE IF NOT EXISTS commit_changes (
+  commit_sha  VARCHAR NOT NULL,
+  file_path   VARCHAR NOT NULL,
+  change_type VARCHAR,
+  additions   INTEGER DEFAULT 0,
+  deletions   INTEGER DEFAULT 0,
+  PRIMARY KEY (commit_sha, file_path)
+);
+```
+
+- [ ] **Step 5: Implement in duckdb.ts**
+
+Add methods to `DuckDBStore` class in `src/cli/storage/duckdb.ts`:
+
+```typescript
+  async insertCommitChanges(commitSha: string, changes: CommitChange[]): Promise<void> {
+    for (const change of changes) {
+      await this.run(
+        `INSERT INTO commit_changes (commit_sha, file_path, change_type, additions, deletions)
+         VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT (commit_sha, file_path) DO NOTHING`,
+        [commitSha, change.filePath, change.changeType, change.additions, change.deletions],
+      );
+    }
+  }
+
+  async hasCommitChanges(commitSha: string): Promise<boolean> {
+    const rows = await this.all(
+      `SELECT 1 FROM commit_changes WHERE commit_sha = ? LIMIT 1`,
+      [commitSha],
+    );
+    return rows.length > 0;
+  }
+```
+
+Add `CommitChange` to the import from `./types.js`.
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `pnpm vitest run tests/storage/commit-changes.test.ts`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tests/storage/commit-changes.test.ts src/cli/storage/schema.ts src/cli/storage/types.ts src/cli/storage/duckdb.ts
+git commit -m "feat: add commit_changes table for co-failure tracking"
+```
+
+---
+
+### Task 2: Add `git diff-tree` utility
+
+**Files:**
+- Modify: `src/cli/core/git.ts`
+- Test: `tests/core/git-diff-tree.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/core/git-diff-tree.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { parseGitDiffTree, resolveCommitChanges } from "../../src/cli/core/git.js";
+
+describe("parseGitDiffTree", () => {
+  it("parses name-status output", () => {
+    const output = "M\tsrc/foo.ts\nA\tsrc/bar.ts\nD\tsrc/old.ts\n";
+    const result = parseGitDiffTree(output);
+    expect(result).toEqual([
+      { filePath: "src/foo.ts", changeType: "modified", additions: 0, deletions: 0 },
+      { filePath: "src/bar.ts", changeType: "added", additions: 0, deletions: 0 },
+      { filePath: "src/old.ts", changeType: "deleted", additions: 0, deletions: 0 },
+    ]);
+  });
+
+  it("handles rename status", () => {
+    const output = "R100\told/path.ts\tnew/path.ts\n";
+    const result = parseGitDiffTree(output);
+    expect(result).toEqual([
+      { filePath: "new/path.ts", changeType: "renamed", additions: 0, deletions: 0 },
+    ]);
+  });
+
+  it("handles empty output", () => {
+    expect(parseGitDiffTree("")).toEqual([]);
+    expect(parseGitDiffTree("\n")).toEqual([]);
+  });
+});
+
+describe("resolveCommitChanges", () => {
+  it("returns changes for HEAD commit", () => {
+    // Uses the actual git repo — flaker itself
+    const changes = resolveCommitChanges(process.cwd(), "HEAD");
+    expect(changes).not.toBeNull();
+    if (changes) {
+      expect(changes.length).toBeGreaterThan(0);
+      expect(changes[0]).toHaveProperty("filePath");
+      expect(changes[0]).toHaveProperty("changeType");
+    }
+  });
+
+  it("returns null for invalid sha", () => {
+    const changes = resolveCommitChanges(process.cwd(), "0000000000000000000000000000000000000000");
+    expect(changes).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run tests/core/git-diff-tree.test.ts`
+Expected: FAIL — `parseGitDiffTree` and `resolveCommitChanges` do not exist
+
+- [ ] **Step 3: Implement**
+
+In `src/cli/core/git.ts`, add:
+
+```typescript
+import type { CommitChange } from "../storage/types.js";
+
+const CHANGE_TYPE_MAP: Record<string, string> = {
+  A: "added",
+  M: "modified",
+  D: "deleted",
+  C: "copied",
+};
+
+export function parseGitDiffTree(output: string): CommitChange[] {
+  const results: CommitChange[] = [];
+  for (const line of output.split("\n")) {
+    if (!line.trim()) continue;
+    const parts = line.split("\t");
+    if (parts.length < 2) continue;
+    const status = parts[0];
+    if (status.startsWith("R")) {
+      // Rename: R<score>\told\tnew
+      results.push({
+        filePath: parts[2] ?? parts[1],
+        changeType: "renamed",
+        additions: 0,
+        deletions: 0,
+      });
+    } else {
+      results.push({
+        filePath: parts[1],
+        changeType: CHANGE_TYPE_MAP[status] ?? status.toLowerCase(),
+        additions: 0,
+        deletions: 0,
+      });
+    }
+  }
+  return results;
+}
+
+export function resolveCommitChanges(cwd: string, commitSha: string): CommitChange[] | null {
+  try {
+    const output = execSync(
+      `git diff-tree --no-commit-id --name-status -r ${commitSha}`,
+      { cwd, stdio: ["ignore", "pipe", "ignore"] },
+    ).toString("utf8");
+    return parseGitDiffTree(output);
+  } catch {
+    return null;
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run tests/core/git-diff-tree.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli/core/git.ts tests/core/git-diff-tree.test.ts
+git commit -m "feat: add git diff-tree parser for commit change tracking"
+```
+
+---
+
+### Task 3: Collect commit changes during `collect` and `collect-local`
+
+**Files:**
+- Modify: `src/cli/commands/collect.ts`
+- Modify: `src/cli/commands/collect-local.ts`
+- Test: `tests/commands/collect.test.ts` (extend existing)
+
+- [ ] **Step 1: Write the failing test**
+
+Add a test to `tests/commands/collect.test.ts` (or a new file `tests/commands/collect-commit-changes.test.ts` if the existing file is complex):
+
+```typescript
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { DuckDBStore } from "../../src/cli/storage/duckdb.js";
+import { collectCommitChanges } from "../../src/cli/commands/collect-commit-changes.js";
+
+describe("collectCommitChanges", () => {
+  let store: DuckDBStore;
+
+  beforeEach(async () => {
+    store = new DuckDBStore(":memory:");
+    await store.initialize();
+  });
+
+  afterEach(async () => {
+    await store.close();
+  });
+
+  it("stores commit changes for a known commit", async () => {
+    // Use HEAD of the flaker repo itself
+    const result = await collectCommitChanges(store, process.cwd(), "HEAD");
+    expect(result).not.toBeNull();
+    if (result) {
+      expect(result.filesCollected).toBeGreaterThan(0);
+      const hasChanges = await store.hasCommitChanges("HEAD");
+      // hasCommitChanges checks exact sha, but we stored resolved HEAD
+      // Verify via raw query
+      const rows = await store.raw<{ cnt: number }>(
+        "SELECT COUNT(*)::INTEGER AS cnt FROM commit_changes",
+      );
+      expect(rows[0].cnt).toBeGreaterThan(0);
+    }
+  });
+
+  it("skips if commit changes already collected", async () => {
+    const sha = "abc123";
+    await store.insertCommitChanges(sha, [
+      { filePath: "src/foo.ts", changeType: "modified", additions: 0, deletions: 0 },
+    ]);
+    const result = await collectCommitChanges(store, process.cwd(), sha);
+    expect(result).toBeNull(); // Already collected, skipped
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run tests/commands/collect-commit-changes.test.ts`
+Expected: FAIL — module does not exist
+
+- [ ] **Step 3: Implement collectCommitChanges**
+
+Create `src/cli/commands/collect-commit-changes.ts`:
+
+```typescript
+import type { MetricStore } from "../storage/types.js";
+import { resolveCommitChanges } from "../core/git.js";
+
+interface CollectCommitChangesResult {
+  commitSha: string;
+  filesCollected: number;
+}
+
+export async function collectCommitChanges(
+  store: MetricStore,
+  cwd: string,
+  commitSha: string,
+): Promise<CollectCommitChangesResult | null> {
+  if (await store.hasCommitChanges(commitSha)) {
+    return null;
+  }
+  const changes = resolveCommitChanges(cwd, commitSha);
+  if (!changes || changes.length === 0) {
+    return null;
+  }
+  await store.insertCommitChanges(commitSha, changes);
+  return { commitSha, filesCollected: changes.length };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run tests/commands/collect-commit-changes.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Wire into collect.ts**
+
+In `src/cli/commands/collect.ts`, after `insertWorkflowRun(workflowRun)` and test result insertion, add:
+
+```typescript
+import { collectCommitChanges } from "./collect-commit-changes.js";
+
+// Inside the workflow run loop, after insertTestResults:
+await collectCommitChanges(store, cwd, run.head_sha);
+```
+
+- [ ] **Step 6: Wire into collect-local.ts**
+
+In `src/cli/commands/collect-local.ts`, after test result insertion, add:
+
+```typescript
+import { collectCommitChanges } from "./collect-commit-changes.js";
+import { resolveCurrentCommitSha } from "../core/git.js";
+
+// After insertTestResults, resolve real commit sha and collect:
+const realCommitSha = resolveCurrentCommitSha(cwd);
+if (realCommitSha) {
+  await collectCommitChanges(store, cwd, realCommitSha);
+}
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/cli/commands/collect-commit-changes.ts src/cli/commands/collect.ts src/cli/commands/collect-local.ts tests/commands/collect-commit-changes.test.ts
+git commit -m "feat: collect commit changes during collect and collect-local"
+```
+
+---
+
+### Task 4: Add co-failure query
+
+**Files:**
+- Modify: `src/cli/storage/schema.ts`
+- Modify: `src/cli/storage/types.ts`
+- Modify: `src/cli/storage/duckdb.ts`
+- Test: `tests/storage/co-failure.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/storage/co-failure.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { DuckDBStore } from "../../src/cli/storage/duckdb.js";
+
+describe("co-failure query", () => {
+  let store: DuckDBStore;
+
+  beforeEach(async () => {
+    store = new DuckDBStore(":memory:");
+    await store.initialize();
+
+    // Create 3 workflow runs with different commits
+    for (let i = 1; i <= 3; i++) {
+      await store.insertWorkflowRun({
+        id: i,
+        repo: "test/repo",
+        branch: "main",
+        commitSha: `sha${i}`,
+        event: "push",
+        status: "completed",
+        createdAt: new Date(Date.now() - (4 - i) * 86400000),
+        durationMs: 60000,
+      });
+    }
+
+    // sha1: changed src/auth.ts -> test-login failed
+    await store.insertCommitChanges("sha1", [
+      { filePath: "src/auth.ts", changeType: "modified", additions: 5, deletions: 2 },
+    ]);
+    await store.insertTestResults([
+      {
+        workflowRunId: 1, suite: "tests/login.spec.ts", testName: "login works",
+        status: "failed", durationMs: 100, retryCount: 0, errorMessage: "err",
+        commitSha: "sha1", variant: null, createdAt: new Date(Date.now() - 3 * 86400000),
+      },
+      {
+        workflowRunId: 1, suite: "tests/signup.spec.ts", testName: "signup works",
+        status: "passed", durationMs: 100, retryCount: 0, errorMessage: null,
+        commitSha: "sha1", variant: null, createdAt: new Date(Date.now() - 3 * 86400000),
+      },
+    ]);
+
+    // sha2: changed src/auth.ts again -> test-login failed again
+    await store.insertCommitChanges("sha2", [
+      { filePath: "src/auth.ts", changeType: "modified", additions: 3, deletions: 1 },
+    ]);
+    await store.insertTestResults([
+      {
+        workflowRunId: 2, suite: "tests/login.spec.ts", testName: "login works",
+        status: "failed", durationMs: 100, retryCount: 0, errorMessage: "err",
+        commitSha: "sha2", variant: null, createdAt: new Date(Date.now() - 2 * 86400000),
+      },
+      {
+        workflowRunId: 2, suite: "tests/signup.spec.ts", testName: "signup works",
+        status: "passed", durationMs: 100, retryCount: 0, errorMessage: null,
+        commitSha: "sha2", variant: null, createdAt: new Date(Date.now() - 2 * 86400000),
+      },
+    ]);
+
+    // sha3: changed src/ui.ts -> everything passed
+    await store.insertCommitChanges("sha3", [
+      { filePath: "src/ui.ts", changeType: "modified", additions: 10, deletions: 0 },
+    ]);
+    await store.insertTestResults([
+      {
+        workflowRunId: 3, suite: "tests/login.spec.ts", testName: "login works",
+        status: "passed", durationMs: 100, retryCount: 0, errorMessage: null,
+        commitSha: "sha3", variant: null, createdAt: new Date(Date.now() - 86400000),
+      },
+      {
+        workflowRunId: 3, suite: "tests/signup.spec.ts", testName: "signup works",
+        status: "passed", durationMs: 100, retryCount: 0, errorMessage: null,
+        commitSha: "sha3", variant: null, createdAt: new Date(Date.now() - 86400000),
+      },
+    ]);
+  });
+
+  afterEach(async () => {
+    await store.close();
+  });
+
+  it("computes co-failure rates", async () => {
+    const results = await store.queryCoFailures({ windowDays: 90, minCoRuns: 2 });
+    // src/auth.ts + login: 2 co-runs, 2 failures = 100%
+    const authLogin = results.find(
+      (r) => r.filePath === "src/auth.ts" && r.suite === "tests/login.spec.ts",
+    );
+    expect(authLogin).toBeDefined();
+    expect(authLogin!.coFailureRate).toBe(100);
+    expect(authLogin!.coRuns).toBe(2);
+    expect(authLogin!.coFailures).toBe(2);
+
+    // src/auth.ts + signup: 2 co-runs, 0 failures = 0% (should not appear)
+    const authSignup = results.find(
+      (r) => r.filePath === "src/auth.ts" && r.suite === "tests/signup.spec.ts",
+    );
+    expect(authSignup).toBeUndefined();
+  });
+
+  it("respects minCoRuns filter", async () => {
+    const results = await store.queryCoFailures({ windowDays: 90, minCoRuns: 3 });
+    // src/auth.ts only has 2 co-runs with login, so nothing qualifies at minCoRuns=3
+    expect(results).toHaveLength(0);
+  });
+
+  it("getCoFailureBoosts returns boost for changed files", async () => {
+    const boosts = await store.getCoFailureBoosts(
+      ["src/auth.ts"],
+      { windowDays: 90, minCoRuns: 2 },
+    );
+    // login test should have high boost
+    expect(boosts.size).toBeGreaterThan(0);
+    const loginBoost = [...boosts.entries()].find(([, v]) => v > 0);
+    expect(loginBoost).toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run tests/storage/co-failure.test.ts`
+Expected: FAIL — `queryCoFailures` and `getCoFailureBoosts` do not exist
+
+- [ ] **Step 3: Add types**
+
+In `src/cli/storage/types.ts`, add:
+
+```typescript
+export interface CoFailureResult {
+  filePath: string;
+  testId: string;
+  suite: string;
+  testName: string;
+  coRuns: number;
+  coFailures: number;
+  coFailureRate: number;
+}
+
+export interface CoFailureQueryOpts {
+  windowDays?: number;
+  minCoRuns?: number;
+}
+```
+
+Add to `MetricStore` interface:
+
+```typescript
+  queryCoFailures(opts: CoFailureQueryOpts): Promise<CoFailureResult[]>;
+  getCoFailureBoosts(changedFiles: string[], opts?: CoFailureQueryOpts): Promise<Map<string, number>>;
+```
+
+- [ ] **Step 4: Add co-failure query constant to schema.ts**
+
+In `src/cli/storage/schema.ts`, add after `FLAKY_QUERY`:
+
+```typescript
+export const CO_FAILURE_QUERY = `
+SELECT
+  cc.file_path,
+  COALESCE(tr.test_id, '') AS test_id,
+  tr.suite,
+  tr.test_name,
+  COUNT(*)::INTEGER AS co_runs,
+  COUNT(*) FILTER (WHERE tr.status IN ('failed', 'flaky')
+    OR (tr.retry_count > 0 AND tr.status = 'passed'))::INTEGER AS co_failures,
+  ROUND(
+    COUNT(*) FILTER (WHERE tr.status IN ('failed', 'flaky')
+      OR (tr.retry_count > 0 AND tr.status = 'passed'))
+    * 100.0 / COUNT(*), 2
+  )::DOUBLE AS co_failure_rate
+FROM commit_changes cc
+JOIN test_results tr ON cc.commit_sha = tr.commit_sha
+WHERE tr.created_at > CURRENT_TIMESTAMP - INTERVAL (? || ' days')
+GROUP BY cc.file_path, tr.test_id, tr.suite, tr.test_name
+HAVING co_runs >= ? AND co_failures > 0
+ORDER BY co_failure_rate DESC
+`;
+```
+
+- [ ] **Step 5: Implement in duckdb.ts**
+
+Add methods to `DuckDBStore`:
+
+```typescript
+  async queryCoFailures(opts: CoFailureQueryOpts): Promise<CoFailureResult[]> {
+    const windowDays = opts.windowDays ?? 90;
+    const minCoRuns = opts.minCoRuns ?? 3;
+    const rows = await this.all(CO_FAILURE_QUERY, [windowDays.toString(), minCoRuns]);
+    return rows.map((r: any) => ({
+      filePath: r.file_path,
+      testId: r.test_id,
+      suite: r.suite,
+      testName: r.test_name,
+      coRuns: r.co_runs,
+      coFailures: r.co_failures,
+      coFailureRate: r.co_failure_rate,
+    }));
+  }
+
+  async getCoFailureBoosts(
+    changedFiles: string[],
+    opts?: CoFailureQueryOpts,
+  ): Promise<Map<string, number>> {
+    if (changedFiles.length === 0) {
+      return new Map();
+    }
+    const allCoFailures = await this.queryCoFailures(opts ?? {});
+    const changedSet = new Set(changedFiles);
+    const boosts = new Map<string, number>();
+    for (const cf of allCoFailures) {
+      if (!changedSet.has(cf.filePath)) continue;
+      const existing = boosts.get(cf.testId) ?? 0;
+      boosts.set(cf.testId, Math.max(existing, cf.coFailureRate / 100));
+    }
+    return boosts;
+  }
+```
+
+Add imports: `CO_FAILURE_QUERY` from schema, `CoFailureResult`, `CoFailureQueryOpts` from types.
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `pnpm vitest run tests/storage/co-failure.test.ts`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/cli/storage/schema.ts src/cli/storage/types.ts src/cli/storage/duckdb.ts tests/storage/co-failure.test.ts
+git commit -m "feat: add co-failure query for file-test correlation tracking"
+```
+
+---
+
+### Task 5: Add `co_failure_boost` to TestMeta and sampling
+
+**Files:**
+- Modify: `src/contracts/types.mbt` (TestMeta struct)
+- Modify: `src/sampling/sampler.mbt` (sample_weighted, sample_hybrid)
+- Modify: `src/cli/core/loader.ts` (TestMeta TS interface)
+- Modify: `src/cli/commands/sample.ts` (pass co-failure data)
+- Test: `tests/commands/sample-co-failure.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/commands/sample-co-failure.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { DuckDBStore } from "../../src/cli/storage/duckdb.js";
+import type { TestResult, WorkflowRun } from "../../src/cli/storage/types.js";
+import { planSample } from "../../src/cli/commands/sample.js";
+
+describe("sample with co-failure boost", () => {
+  let store: DuckDBStore;
+
+  beforeEach(async () => {
+    store = new DuckDBStore(":memory:");
+    await store.initialize();
+
+    // 3 commits: sha1, sha2, sha3
+    for (let i = 1; i <= 3; i++) {
+      await store.insertWorkflowRun({
+        id: i, repo: "test/repo", branch: "main", commitSha: `sha${i}`,
+        event: "push", status: "completed",
+        createdAt: new Date(Date.now() - (4 - i) * 86400000), durationMs: 60000,
+      });
+    }
+
+    // sha1 and sha2 both change src/auth.ts and test-login fails
+    for (const [sha, runId] of [["sha1", 1], ["sha2", 2]] as const) {
+      await store.insertCommitChanges(sha, [
+        { filePath: "src/auth.ts", changeType: "modified", additions: 5, deletions: 2 },
+      ]);
+      await store.insertTestResults([
+        {
+          workflowRunId: runId, suite: "tests/login.spec.ts", testName: "login works",
+          status: "failed", durationMs: 100, retryCount: 0, errorMessage: "err",
+          commitSha: sha, variant: null, createdAt: new Date(Date.now() - (4 - runId) * 86400000),
+        },
+        {
+          workflowRunId: runId, suite: "tests/signup.spec.ts", testName: "signup works",
+          status: "passed", durationMs: 100, retryCount: 0, errorMessage: null,
+          commitSha: sha, variant: null, createdAt: new Date(Date.now() - (4 - runId) * 86400000),
+        },
+        {
+          workflowRunId: runId, suite: "tests/dashboard.spec.ts", testName: "dashboard loads",
+          status: "passed", durationMs: 100, retryCount: 0, errorMessage: null,
+          commitSha: sha, variant: null, createdAt: new Date(Date.now() - (4 - runId) * 86400000),
+        },
+      ]);
+    }
+
+    // sha3 changes src/ui.ts, everything passes
+    await store.insertCommitChanges("sha3", [
+      { filePath: "src/ui.ts", changeType: "modified", additions: 10, deletions: 0 },
+    ]);
+    await store.insertTestResults([
+      {
+        workflowRunId: 3, suite: "tests/login.spec.ts", testName: "login works",
+        status: "passed", durationMs: 100, retryCount: 0, errorMessage: null,
+        commitSha: "sha3", variant: null, createdAt: new Date(Date.now() - 86400000),
+      },
+      {
+        workflowRunId: 3, suite: "tests/signup.spec.ts", testName: "signup works",
+        status: "passed", durationMs: 100, retryCount: 0, errorMessage: null,
+        commitSha: "sha3", variant: null, createdAt: new Date(Date.now() - 86400000),
+      },
+      {
+        workflowRunId: 3, suite: "tests/dashboard.spec.ts", testName: "dashboard loads",
+        status: "passed", durationMs: 100, retryCount: 0, errorMessage: null,
+        commitSha: "sha3", variant: null, createdAt: new Date(Date.now() - 86400000),
+      },
+    ]);
+  });
+
+  afterEach(async () => {
+    await store.close();
+  });
+
+  it("weighted sampling with co-failure boost prioritizes correlated tests", async () => {
+    const plan = await planSample({
+      store,
+      count: 1,
+      mode: "weighted",
+      seed: 42,
+      changedFiles: ["src/auth.ts"],
+    });
+
+    // With co-failure boost, the login test (100% co-failure with src/auth.ts)
+    // should be strongly favored over the others
+    expect(plan.sampled).toHaveLength(1);
+    // The login test has both flaky_rate AND co-failure boost, highest weight
+    expect(plan.sampled[0].suite).toBe("tests/login.spec.ts");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run tests/commands/sample-co-failure.test.ts`
+Expected: FAIL — co-failure boost not integrated
+
+- [ ] **Step 3: Add `co_failure_boost` to MoonBit TestMeta**
+
+In `src/contracts/types.mbt`, add field to `TestMeta`:
+
+```moonbit
+pub(all) struct TestMeta {
+  suite : String
+  test_name : String
+  flaky_rate : Double
+  total_runs : Int
+  fail_count : Int
+  last_run_at : String
+  avg_duration_ms : Int
+  previously_failed : Bool
+  is_new : Bool
+  task_id : String?
+  filter : String?
+  test_id : String?
+  co_failure_boost : Double  // NEW: 0.0-1.0, max co-failure rate for changed files
+} derive(Eq, Show, FromJson, ToJson)
+```
+
+- [ ] **Step 4: Update MoonBit sampling to use co_failure_boost**
+
+In `src/sampling/sampler.mbt`, update `sample_weighted` weight calculation (line 58):
+
+```moonbit
+  let weights = Array::makei(n, fn(i) { 1.0 + meta[i].flaky_rate + meta[i].co_failure_boost })
+```
+
+- [ ] **Step 5: Update TS TestMeta interface**
+
+In `src/cli/core/loader.ts`, add to `TestMeta` interface:
+
+```typescript
+  co_failure_boost: number;
+```
+
+- [ ] **Step 6: Update MoonBit sampling_meta to set default**
+
+In `src/sampling/sampling_meta.mbt`, where TestMeta is constructed, add:
+
+```moonbit
+  co_failure_boost: 0.0,
+```
+
+- [ ] **Step 7: Wire co-failure boosts into sample.ts**
+
+In `src/cli/commands/sample.ts`, update `planSample`:
+
+```typescript
+export async function planSample(opts: SampleOpts): Promise<SamplePlan> {
+  const core = await loadCore();
+  const listedTests = opts.listedTests ?? [];
+  const meta = await buildSamplingMeta(opts.store, listedTests, core);
+  let allTests = meta.tests;
+
+  // Apply co-failure boosts if changedFiles are provided
+  if (opts.changedFiles && opts.changedFiles.length > 0) {
+    const boosts = await opts.store.getCoFailureBoosts(opts.changedFiles);
+    if (boosts.size > 0) {
+      allTests = allTests.map((test) => {
+        const key = test.test_id ?? createStableTestId({
+          suite: test.suite,
+          testName: test.test_name,
+          taskId: test.task_id,
+          filter: test.filter,
+        });
+        const boost = boosts.get(key) ?? 0;
+        return boost > 0 ? { ...test, co_failure_boost: boost } : test;
+      });
+    }
+  }
+
+  // ... rest of existing code
+```
+
+- [ ] **Step 8: Run test to verify it passes**
+
+Run: `pnpm vitest run tests/commands/sample-co-failure.test.ts`
+Expected: PASS
+
+- [ ] **Step 9: Run all existing tests to verify no regressions**
+
+Run: `pnpm vitest run`
+Expected: All tests pass. The `co_failure_boost: 0.0` default means existing behavior is unchanged.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/contracts/types.mbt src/sampling/sampler.mbt src/sampling/sampling_meta.mbt src/cli/core/loader.ts src/cli/commands/sample.ts tests/commands/sample-co-failure.test.ts
+git commit -m "feat: integrate co-failure boost into weighted and hybrid sampling"
+```
+
+---
+
+### Task 6: Add `SampleOpts.coFailureDays` option
+
+**Files:**
+- Modify: `src/cli/commands/sample.ts`
+- Modify: `src/cli/commands/sampling-options.ts`
+- Modify: `src/cli/main.ts` (CLI option)
+- Test: `tests/commands/sampling-options.test.ts` (extend)
+
+- [ ] **Step 1: Add option to SampleOpts**
+
+In `src/cli/commands/sample.ts`, add to `SampleOpts`:
+
+```typescript
+  coFailureDays?: number;
+```
+
+Update the `getCoFailureBoosts` call in `planSample` to pass the option:
+
+```typescript
+    const boosts = await opts.store.getCoFailureBoosts(
+      opts.changedFiles,
+      { windowDays: opts.coFailureDays ?? 90 },
+    );
+```
+
+- [ ] **Step 2: Add CLI option**
+
+In the CLI command registration for `sample` in `src/cli/main.ts`, add:
+
+```typescript
+  .option("--co-failure-days <days>", "co-failure window in days", "90")
+```
+
+And pass `coFailureDays: parseInt(opts.coFailureDays)` to `planSample`.
+
+- [ ] **Step 3: Run existing tests**
+
+Run: `pnpm vitest run tests/commands/sampling-options.test.ts tests/commands/sample.test.ts`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/cli/commands/sample.ts src/cli/main.ts
+git commit -m "feat: add --co-failure-days CLI option for sampling"
+```

--- a/docs/superpowers/plans/2026-04-03-eval-fixture.md
+++ b/docs/superpowers/plans/2026-04-03-eval-fixture.md
@@ -1,0 +1,852 @@
+# Evaluation Fixture Framework Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a synthetic data generator and evaluation pipeline to measure co-failure tracking accuracy with controlled parameters.
+
+**Architecture:** A fixture generator creates deterministic test history data in DuckDB. An evaluator runs `planSample` with different strategies on the same data and compares results against ground truth. A reporter formats the comparison as a markdown table.
+
+**Tech Stack:** TypeScript, DuckDB (in-memory), vitest, existing `planSample` from `src/cli/commands/sample.ts`
+
+---
+
+### Task 1: Fixture Generator
+
+**Files:**
+- Create: `src/cli/eval/fixture-generator.ts`
+- Test: `tests/eval/fixture-generator.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/eval/fixture-generator.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { generateFixture, type FixtureConfig } from "../../src/cli/eval/fixture-generator.js";
+
+const defaultConfig: FixtureConfig = {
+  testCount: 20,
+  commitCount: 10,
+  flakyRate: 0.1,
+  coFailureStrength: 0.8,
+  filesPerCommit: 2,
+  testsPerFile: 4,
+  samplePercentage: 20,
+  seed: 42,
+};
+
+describe("generateFixture", () => {
+  it("generates correct number of tests and commits", () => {
+    const fixture = generateFixture(defaultConfig);
+    expect(fixture.tests.length).toBe(20);
+    expect(fixture.commits.length).toBe(10);
+  });
+
+  it("generates file-to-test dependency map", () => {
+    const fixture = generateFixture(defaultConfig);
+    expect(fixture.fileDeps.size).toBeGreaterThan(0);
+    // Each file maps to testsPerFile tests
+    for (const [, tests] of fixture.fileDeps) {
+      expect(tests.length).toBe(4);
+    }
+  });
+
+  it("marks correct number of flaky tests", () => {
+    const fixture = generateFixture(defaultConfig);
+    const flakyCount = fixture.tests.filter((t) => t.isFlaky).length;
+    expect(flakyCount).toBe(2); // 20 * 0.1 = 2
+  });
+
+  it("generates commit changes and test results", () => {
+    const fixture = generateFixture(defaultConfig);
+    for (const commit of fixture.commits) {
+      expect(commit.changedFiles.length).toBe(2); // filesPerCommit
+      expect(commit.testResults.length).toBe(20); // all tests run per commit
+    }
+  });
+
+  it("is deterministic with same seed", () => {
+    const a = generateFixture(defaultConfig);
+    const b = generateFixture(defaultConfig);
+    expect(a.commits.map((c) => c.sha)).toEqual(b.commits.map((c) => c.sha));
+    expect(a.commits.map((c) => c.testResults.map((r) => r.status))).toEqual(
+      b.commits.map((c) => c.testResults.map((r) => r.status)),
+    );
+  });
+
+  it("co-failure strength controls failure correlation", () => {
+    const strong = generateFixture({ ...defaultConfig, coFailureStrength: 1.0, commitCount: 50 });
+    const none = generateFixture({ ...defaultConfig, coFailureStrength: 0.0, commitCount: 50 });
+
+    // With strength=1.0, dependent tests should fail when their file changes
+    const strongFailures = strong.commits.flatMap((c) => c.testResults.filter((r) => r.status === "failed"));
+    const noneFailures = none.commits.flatMap((c) => c.testResults.filter((r) => r.status === "failed"));
+
+    // Strong co-failure should produce more failures (dependent tests always fail)
+    expect(strongFailures.length).toBeGreaterThan(noneFailures.length);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run tests/eval/fixture-generator.test.ts`
+Expected: FAIL — module does not exist
+
+- [ ] **Step 3: Implement fixture generator**
+
+Create `src/cli/eval/fixture-generator.ts`:
+
+```typescript
+export interface FixtureConfig {
+  testCount: number;
+  commitCount: number;
+  flakyRate: number;
+  coFailureStrength: number;
+  filesPerCommit: number;
+  testsPerFile: number;
+  samplePercentage: number;
+  seed: number;
+}
+
+export interface FixtureTest {
+  suite: string;
+  testName: string;
+  isFlaky: boolean;
+}
+
+interface FixtureCommitResult {
+  suite: string;
+  testName: string;
+  status: "passed" | "failed";
+}
+
+export interface FixtureCommit {
+  sha: string;
+  changedFiles: { filePath: string; changeType: string }[];
+  testResults: FixtureCommitResult[];
+}
+
+export interface FixtureData {
+  tests: FixtureTest[];
+  files: string[];
+  fileDeps: Map<string, string[]>; // file -> test suites
+  commits: FixtureCommit[];
+  config: FixtureConfig;
+}
+
+function lcgNext(state: number): { next: number; value: number } {
+  const next = (state * 1664525 + 1013904223) >>> 0;
+  return { next, value: next / 0x100000000 };
+}
+
+export function generateFixture(config: FixtureConfig): FixtureData {
+  let rng = config.seed >>> 0;
+  function rand(): number {
+    const r = lcgNext(rng);
+    rng = r.next;
+    return r.value;
+  }
+
+  // Generate files
+  const fileCount = Math.max(1, Math.ceil(config.testCount / config.testsPerFile));
+  const files: string[] = [];
+  for (let i = 0; i < fileCount; i++) {
+    files.push(`src/module_${i}.ts`);
+  }
+
+  // Generate tests and assign to files
+  const tests: FixtureTest[] = [];
+  const fileDeps = new Map<string, string[]>();
+  for (let i = 0; i < fileCount; i++) {
+    fileDeps.set(files[i], []);
+  }
+
+  const flakyCount = Math.round(config.testCount * config.flakyRate);
+  for (let i = 0; i < config.testCount; i++) {
+    const fileIdx = i % fileCount;
+    const suite = `tests/module_${fileIdx}/test_${i}.spec.ts`;
+    tests.push({
+      suite,
+      testName: `test_${i}`,
+      isFlaky: i < flakyCount,
+    });
+    fileDeps.get(files[fileIdx])!.push(suite);
+  }
+
+  // Generate commits
+  const commits: FixtureCommit[] = [];
+  for (let c = 0; c < config.commitCount; c++) {
+    const sha = `fixture-sha-${c.toString().padStart(4, "0")}`;
+
+    // Pick random files to change
+    const changedFiles: { filePath: string; changeType: string }[] = [];
+    const changedFileSet = new Set<string>();
+    for (let f = 0; f < config.filesPerCommit; f++) {
+      const idx = Math.floor(rand() * fileCount);
+      const file = files[idx];
+      if (!changedFileSet.has(file)) {
+        changedFileSet.add(file);
+        changedFiles.push({ filePath: file, changeType: "modified" });
+      }
+    }
+
+    // Determine test results
+    const dependentSuites = new Set<string>();
+    for (const file of changedFileSet) {
+      for (const suite of fileDeps.get(file) ?? []) {
+        dependentSuites.add(suite);
+      }
+    }
+
+    const testResults: FixtureCommitResult[] = tests.map((test) => {
+      const isDependent = dependentSuites.has(test.suite);
+      let failed = false;
+
+      // Co-failure: dependent test fails with probability = coFailureStrength
+      if (isDependent && rand() < config.coFailureStrength) {
+        failed = true;
+      }
+
+      // Flaky: fails with flakyRate regardless of dependency
+      if (test.isFlaky && rand() < config.flakyRate) {
+        failed = true;
+      }
+
+      return {
+        suite: test.suite,
+        testName: test.testName,
+        status: failed ? "failed" : "passed",
+      };
+    });
+
+    commits.push({ sha, changedFiles, testResults });
+  }
+
+  return { tests, files, fileDeps, commits, config };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run tests/eval/fixture-generator.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli/eval/fixture-generator.ts tests/eval/fixture-generator.test.ts
+git commit -m "feat: add synthetic fixture generator for evaluation"
+```
+
+---
+
+### Task 2: Fixture Data Loader (DuckDB)
+
+**Files:**
+- Create: `src/cli/eval/fixture-loader.ts`
+- Test: `tests/eval/fixture-loader.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/eval/fixture-loader.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { DuckDBStore } from "../../src/cli/storage/duckdb.js";
+import { generateFixture, type FixtureConfig } from "../../src/cli/eval/fixture-generator.js";
+import { loadFixtureIntoStore } from "../../src/cli/eval/fixture-loader.js";
+
+const config: FixtureConfig = {
+  testCount: 20,
+  commitCount: 10,
+  flakyRate: 0.1,
+  coFailureStrength: 0.8,
+  filesPerCommit: 2,
+  testsPerFile: 4,
+  samplePercentage: 20,
+  seed: 42,
+};
+
+describe("loadFixtureIntoStore", () => {
+  let store: DuckDBStore;
+
+  beforeEach(async () => {
+    store = new DuckDBStore(":memory:");
+    await store.initialize();
+  });
+
+  afterEach(async () => {
+    await store.close();
+  });
+
+  it("loads all workflow runs", async () => {
+    const fixture = generateFixture(config);
+    await loadFixtureIntoStore(store, fixture);
+
+    const rows = await store.raw<{ cnt: number }>(
+      "SELECT COUNT(*)::INTEGER AS cnt FROM workflow_runs",
+    );
+    expect(rows[0].cnt).toBe(10);
+  });
+
+  it("loads all test results", async () => {
+    const fixture = generateFixture(config);
+    await loadFixtureIntoStore(store, fixture);
+
+    const rows = await store.raw<{ cnt: number }>(
+      "SELECT COUNT(*)::INTEGER AS cnt FROM test_results",
+    );
+    // 10 commits * 20 tests = 200
+    expect(rows[0].cnt).toBe(200);
+  });
+
+  it("loads all commit changes", async () => {
+    const fixture = generateFixture(config);
+    await loadFixtureIntoStore(store, fixture);
+
+    const rows = await store.raw<{ cnt: number }>(
+      "SELECT COUNT(*)::INTEGER AS cnt FROM commit_changes",
+    );
+    expect(rows[0].cnt).toBeGreaterThan(0);
+  });
+
+  it("co-failure query returns results after loading", async () => {
+    const fixture = generateFixture(config);
+    await loadFixtureIntoStore(store, fixture);
+
+    const coFailures = await store.queryCoFailures({ windowDays: 365, minCoRuns: 2 });
+    expect(coFailures.length).toBeGreaterThan(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run tests/eval/fixture-loader.test.ts`
+Expected: FAIL — module does not exist
+
+- [ ] **Step 3: Implement loader**
+
+Create `src/cli/eval/fixture-loader.ts`:
+
+```typescript
+import type { MetricStore } from "../storage/types.js";
+import type { FixtureData } from "./fixture-generator.js";
+
+export async function loadFixtureIntoStore(
+  store: MetricStore,
+  fixture: FixtureData,
+): Promise<void> {
+  const baseTime = Date.now() - fixture.commits.length * 86400000;
+
+  for (let i = 0; i < fixture.commits.length; i++) {
+    const commit = fixture.commits[i];
+    const createdAt = new Date(baseTime + i * 86400000);
+    const runId = i + 1;
+
+    await store.insertWorkflowRun({
+      id: runId,
+      repo: "fixture/repo",
+      branch: "main",
+      commitSha: commit.sha,
+      event: "push",
+      status: "completed",
+      createdAt,
+      durationMs: 60000,
+    });
+
+    await store.insertCommitChanges(
+      commit.sha,
+      commit.changedFiles.map((f) => ({
+        filePath: f.filePath,
+        changeType: f.changeType,
+        additions: 10,
+        deletions: 5,
+      })),
+    );
+
+    await store.insertTestResults(
+      commit.testResults.map((r) => ({
+        workflowRunId: runId,
+        suite: r.suite,
+        testName: r.testName,
+        status: r.status,
+        durationMs: 100,
+        retryCount: 0,
+        errorMessage: r.status === "failed" ? "fixture failure" : null,
+        commitSha: commit.sha,
+        variant: null,
+        createdAt,
+      })),
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run tests/eval/fixture-loader.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli/eval/fixture-loader.ts tests/eval/fixture-loader.test.ts
+git commit -m "feat: add fixture data loader for DuckDB"
+```
+
+---
+
+### Task 3: Fixture Evaluator
+
+**Files:**
+- Create: `src/cli/eval/fixture-evaluator.ts`
+- Test: `tests/eval/fixture-evaluator.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/eval/fixture-evaluator.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { DuckDBStore } from "../../src/cli/storage/duckdb.js";
+import { generateFixture } from "../../src/cli/eval/fixture-generator.js";
+import { loadFixtureIntoStore } from "../../src/cli/eval/fixture-loader.js";
+import { evaluateFixture, type EvalStrategyResult } from "../../src/cli/eval/fixture-evaluator.js";
+
+describe("evaluateFixture", () => {
+  let store: DuckDBStore;
+
+  beforeEach(async () => {
+    store = new DuckDBStore(":memory:");
+    await store.initialize();
+  });
+
+  afterEach(async () => {
+    await store.close();
+  });
+
+  it("returns results for all strategies", async () => {
+    const fixture = generateFixture({
+      testCount: 30,
+      commitCount: 20,
+      flakyRate: 0.1,
+      coFailureStrength: 0.8,
+      filesPerCommit: 2,
+      testsPerFile: 5,
+      samplePercentage: 30,
+      seed: 42,
+    });
+    await loadFixtureIntoStore(store, fixture);
+
+    const results = await evaluateFixture(store, fixture);
+    expect(results).toHaveLength(3); // random, weighted, weighted+co-failure
+    expect(results.map((r) => r.strategy)).toEqual([
+      "random",
+      "weighted",
+      "weighted+co-failure",
+    ]);
+  });
+
+  it("all strategies have valid metrics", async () => {
+    const fixture = generateFixture({
+      testCount: 30,
+      commitCount: 20,
+      flakyRate: 0.1,
+      coFailureStrength: 0.8,
+      filesPerCommit: 2,
+      testsPerFile: 5,
+      samplePercentage: 30,
+      seed: 42,
+    });
+    await loadFixtureIntoStore(store, fixture);
+
+    const results = await evaluateFixture(store, fixture);
+    for (const result of results) {
+      expect(result.recall).toBeGreaterThanOrEqual(0);
+      expect(result.recall).toBeLessThanOrEqual(1);
+      expect(result.falseNegativeRate).toBeGreaterThanOrEqual(0);
+      expect(result.falseNegativeRate).toBeLessThanOrEqual(1);
+      expect(result.sampleRatio).toBeGreaterThan(0);
+      expect(result.sampleRatio).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("co-failure strategy outperforms random when correlation is strong", async () => {
+    const fixture = generateFixture({
+      testCount: 50,
+      commitCount: 40,
+      flakyRate: 0.05,
+      coFailureStrength: 1.0,
+      filesPerCommit: 2,
+      testsPerFile: 5,
+      samplePercentage: 20,
+      seed: 42,
+    });
+    await loadFixtureIntoStore(store, fixture);
+
+    const results = await evaluateFixture(store, fixture);
+    const random = results.find((r) => r.strategy === "random")!;
+    const coFailure = results.find((r) => r.strategy === "weighted+co-failure")!;
+
+    // With strong co-failure (1.0) and low flaky rate (5%),
+    // co-failure strategy should detect more failures
+    expect(coFailure.recall).toBeGreaterThanOrEqual(random.recall);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run tests/eval/fixture-evaluator.test.ts`
+Expected: FAIL — module does not exist
+
+- [ ] **Step 3: Implement evaluator**
+
+Create `src/cli/eval/fixture-evaluator.ts`:
+
+```typescript
+import type { MetricStore } from "../storage/types.js";
+import type { FixtureData } from "./fixture-generator.js";
+import { planSample } from "../commands/sample.js";
+
+export interface EvalStrategyResult {
+  strategy: string;
+  recall: number;
+  precision: number;
+  f1: number;
+  falseNegativeRate: number;
+  sampleRatio: number;
+  efficiency: number;
+  totalFailures: number;
+  detectedFailures: number;
+  totalSampled: number;
+}
+
+export async function evaluateFixture(
+  store: MetricStore,
+  fixture: FixtureData,
+): Promise<EvalStrategyResult[]> {
+  const strategies = [
+    { name: "random", mode: "random" as const, useCoFailure: false },
+    { name: "weighted", mode: "weighted" as const, useCoFailure: false },
+    { name: "weighted+co-failure", mode: "weighted" as const, useCoFailure: true },
+  ];
+
+  // Use last 25% of commits as evaluation set
+  const evalStart = Math.floor(fixture.commits.length * 0.75);
+  const evalCommits = fixture.commits.slice(evalStart);
+  const sampleCount = Math.round(
+    fixture.tests.length * (fixture.config.samplePercentage / 100),
+  );
+
+  const results: EvalStrategyResult[] = [];
+
+  for (const strategy of strategies) {
+    let totalFailures = 0;
+    let detectedFailures = 0;
+    let totalSampled = 0;
+    let totalSampledFailures = 0;
+
+    for (const commit of evalCommits) {
+      const changedFiles = strategy.useCoFailure
+        ? commit.changedFiles.map((f) => f.filePath)
+        : undefined;
+
+      const plan = await planSample({
+        store,
+        count: sampleCount,
+        mode: strategy.mode,
+        seed: 42,
+        changedFiles,
+      });
+
+      const sampledSuites = new Set(plan.sampled.map((t) => t.suite));
+      const actualFailures = commit.testResults.filter((r) => r.status === "failed");
+      const detectedInSample = actualFailures.filter((f) => sampledSuites.has(f.suite));
+
+      totalFailures += actualFailures.length;
+      detectedFailures += detectedInSample.length;
+      totalSampled += plan.sampled.length;
+      totalSampledFailures += plan.sampled.filter((t) =>
+        commit.testResults.some((r) => r.suite === t.suite && r.status === "failed"),
+      ).length;
+    }
+
+    const recall = totalFailures > 0 ? detectedFailures / totalFailures : 1;
+    const precision = totalSampled > 0 ? totalSampledFailures / totalSampled : 0;
+    const f1 = recall + precision > 0 ? (2 * recall * precision) / (recall + precision) : 0;
+    const sampleRatio = fixture.tests.length > 0 ? sampleCount / fixture.tests.length : 0;
+    const efficiency = sampleRatio > 0 ? recall / sampleRatio : 0;
+
+    results.push({
+      strategy: strategy.name,
+      recall: Math.round(recall * 1000) / 1000,
+      precision: Math.round(precision * 1000) / 1000,
+      f1: Math.round(f1 * 1000) / 1000,
+      falseNegativeRate: Math.round((1 - recall) * 1000) / 1000,
+      sampleRatio: Math.round(sampleRatio * 1000) / 1000,
+      efficiency: Math.round(efficiency * 100) / 100,
+      totalFailures,
+      detectedFailures,
+      totalSampled,
+    });
+  }
+
+  return results;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run tests/eval/fixture-evaluator.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli/eval/fixture-evaluator.ts tests/eval/fixture-evaluator.test.ts
+git commit -m "feat: add fixture evaluator comparing sampling strategies"
+```
+
+---
+
+### Task 4: Report Formatter and CLI Command
+
+**Files:**
+- Create: `src/cli/eval/fixture-report.ts`
+- Modify: `src/cli/main.ts`
+- Test: `tests/eval/fixture-report.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/eval/fixture-report.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { formatEvalFixtureReport, type EvalFixtureReport } from "../../src/cli/eval/fixture-report.js";
+import type { EvalStrategyResult } from "../../src/cli/eval/fixture-evaluator.js";
+import type { FixtureConfig } from "../../src/cli/eval/fixture-generator.js";
+
+describe("formatEvalFixtureReport", () => {
+  it("formats a readable markdown table", () => {
+    const config: FixtureConfig = {
+      testCount: 500,
+      commitCount: 100,
+      flakyRate: 0.1,
+      coFailureStrength: 0.8,
+      filesPerCommit: 2,
+      testsPerFile: 5,
+      samplePercentage: 20,
+      seed: 42,
+    };
+
+    const results: EvalStrategyResult[] = [
+      {
+        strategy: "random",
+        recall: 0.2,
+        precision: 0.05,
+        f1: 0.08,
+        falseNegativeRate: 0.8,
+        sampleRatio: 0.2,
+        efficiency: 1.0,
+        totalFailures: 100,
+        detectedFailures: 20,
+        totalSampled: 400,
+      },
+      {
+        strategy: "weighted",
+        recall: 0.35,
+        precision: 0.08,
+        f1: 0.13,
+        falseNegativeRate: 0.65,
+        sampleRatio: 0.2,
+        efficiency: 1.75,
+        totalFailures: 100,
+        detectedFailures: 35,
+        totalSampled: 400,
+      },
+      {
+        strategy: "weighted+co-failure",
+        recall: 0.72,
+        precision: 0.15,
+        f1: 0.25,
+        falseNegativeRate: 0.28,
+        sampleRatio: 0.2,
+        efficiency: 3.6,
+        totalFailures: 100,
+        detectedFailures: 72,
+        totalSampled: 400,
+      },
+    ];
+
+    const report: EvalFixtureReport = { config, results };
+    const output = formatEvalFixtureReport(report);
+
+    expect(output).toContain("Evaluation Report");
+    expect(output).toContain("random");
+    expect(output).toContain("weighted+co-failure");
+    expect(output).toContain("Recall");
+    expect(output).toContain("Efficiency");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run tests/eval/fixture-report.test.ts`
+Expected: FAIL — module does not exist
+
+- [ ] **Step 3: Implement report formatter**
+
+Create `src/cli/eval/fixture-report.ts`:
+
+```typescript
+import type { FixtureConfig } from "./fixture-generator.js";
+import type { EvalStrategyResult } from "./fixture-evaluator.js";
+
+export interface EvalFixtureReport {
+  config: FixtureConfig;
+  results: EvalStrategyResult[];
+}
+
+function pct(v: number): string {
+  return `${(v * 100).toFixed(1)}%`;
+}
+
+function pad(s: string, width: number): string {
+  return s.padEnd(width);
+}
+
+export function formatEvalFixtureReport(report: EvalFixtureReport): string {
+  const c = report.config;
+  const lines: string[] = [
+    "# Evaluation Report",
+    "",
+    `Config: tests=${c.testCount}, commits=${c.commitCount}, flaky=${pct(c.flakyRate)}, co-failure=${c.coFailureStrength}, sample=${c.samplePercentage}%`,
+    "",
+    `| ${pad("Strategy", 22)} | ${pad("Recall", 8)} | ${pad("Prec", 8)} | ${pad("F1", 6)} | ${pad("FNR", 8)} | ${pad("Sample%", 8)} | ${pad("Efficiency", 10)} |`,
+    `|${"-".repeat(24)}|${"-".repeat(10)}|${"-".repeat(10)}|${"-".repeat(8)}|${"-".repeat(10)}|${"-".repeat(10)}|${"-".repeat(12)}|`,
+  ];
+
+  for (const r of report.results) {
+    lines.push(
+      `| ${pad(r.strategy, 22)} | ${pad(pct(r.recall), 8)} | ${pad(pct(r.precision), 8)} | ${pad(r.f1.toFixed(2), 6)} | ${pad(pct(r.falseNegativeRate), 8)} | ${pad(pct(r.sampleRatio), 8)} | ${pad(r.efficiency.toFixed(2), 10)} |`,
+    );
+  }
+
+  lines.push(
+    "",
+    `Efficiency = Recall / Sample%. >1.0 means better than random.`,
+  );
+
+  return lines.join("\n");
+}
+
+export function formatSweepReport(reports: EvalFixtureReport[]): string {
+  const lines: string[] = [
+    "# Co-failure Strength Sweep",
+    "",
+    `| ${pad("Strength", 10)} | ${pad("Random", 8)} | ${pad("Weighted", 10)} | ${pad("W+CoFail", 10)} | ${pad("Gain", 6)} |`,
+    `|${"-".repeat(12)}|${"-".repeat(10)}|${"-".repeat(12)}|${"-".repeat(12)}|${"-".repeat(8)}|`,
+  ];
+
+  for (const report of reports) {
+    const random = report.results.find((r) => r.strategy === "random")!;
+    const weighted = report.results.find((r) => r.strategy === "weighted")!;
+    const coFailure = report.results.find((r) => r.strategy === "weighted+co-failure")!;
+    const gain = random.recall > 0
+      ? `${((coFailure.recall / random.recall - 1) * 100).toFixed(0)}%`
+      : "N/A";
+
+    lines.push(
+      `| ${pad(report.config.coFailureStrength.toFixed(2), 10)} | ${pad(pct(random.recall), 8)} | ${pad(pct(weighted.recall), 10)} | ${pad(pct(coFailure.recall), 10)} | ${pad(gain, 6)} |`,
+    );
+  }
+
+  return lines.join("\n");
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run tests/eval/fixture-report.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Add CLI command**
+
+In `src/cli/main.ts`, add the `eval-fixture` command. Find the eval command section and add after it:
+
+```typescript
+import { generateFixture } from "./eval/fixture-generator.js";
+import { loadFixtureIntoStore } from "./eval/fixture-loader.js";
+import { evaluateFixture } from "./eval/fixture-evaluator.js";
+import { formatEvalFixtureReport, formatSweepReport } from "./eval/fixture-report.js";
+```
+
+Add the command registration:
+
+```typescript
+// --- eval-fixture ---
+program
+  .command("eval-fixture")
+  .description("Evaluate sampling strategies with synthetic data")
+  .option("--tests <n>", "Number of tests", "100")
+  .option("--commits <n>", "Number of commits", "50")
+  .option("--flaky-rate <n>", "Flaky rate (0-1)", "0.1")
+  .option("--co-failure-strength <n>", "Co-failure correlation (0-1)", "0.8")
+  .option("--files-per-commit <n>", "Files changed per commit", "2")
+  .option("--tests-per-file <n>", "Tests per source file", "5")
+  .option("--sample-percentage <n>", "Sample percentage", "20")
+  .option("--seed <n>", "Random seed", "42")
+  .option("--sweep", "Sweep co-failure strength 0.0-1.0")
+  .action(async (opts) => {
+    const baseConfig = {
+      testCount: parseInt(opts.tests, 10),
+      commitCount: parseInt(opts.commits, 10),
+      flakyRate: parseFloat(opts.flakyRate),
+      coFailureStrength: parseFloat(opts.coFailureStrength),
+      filesPerCommit: parseInt(opts.filesPerCommit, 10),
+      testsPerFile: parseInt(opts.testsPerFile, 10),
+      samplePercentage: parseInt(opts.samplePercentage, 10),
+      seed: parseInt(opts.seed, 10),
+    };
+
+    if (opts.sweep) {
+      const strengths = [0.0, 0.25, 0.5, 0.75, 1.0];
+      const reports = [];
+      for (const strength of strengths) {
+        const config = { ...baseConfig, coFailureStrength: strength };
+        const store = new DuckDBStore(":memory:");
+        await store.initialize();
+        const fixture = generateFixture(config);
+        await loadFixtureIntoStore(store, fixture);
+        const results = await evaluateFixture(store, fixture);
+        reports.push({ config, results });
+        await store.close();
+      }
+      console.log(formatSweepReport(reports));
+    } else {
+      const store = new DuckDBStore(":memory:");
+      await store.initialize();
+      const fixture = generateFixture(baseConfig);
+      await loadFixtureIntoStore(store, fixture);
+      const results = await evaluateFixture(store, fixture);
+      console.log(formatEvalFixtureReport({ config: baseConfig, results }));
+      await store.close();
+    }
+  });
+```
+
+- [ ] **Step 6: Run all tests**
+
+Run: `pnpm vitest run tests/eval/`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/cli/eval/fixture-report.ts tests/eval/fixture-report.test.ts src/cli/main.ts
+git commit -m "feat: add eval-fixture command with report formatting and sweep mode"
+```

--- a/docs/superpowers/specs/2026-04-03-eval-fixture-design.md
+++ b/docs/superpowers/specs/2026-04-03-eval-fixture-design.md
@@ -1,0 +1,110 @@
+# Evaluation Fixture Framework Design
+
+## Goal
+
+Co-failure tracking (Stage 1) の精度を定量的に測定するための合成フィクスチャジェネレータと評価パイプラインを構築する。
+
+## Architecture
+
+合成データを DuckDB に投入し、既存の `planSample` を各戦略で実行、結果を confusion matrix で比較する。新規コマンド `flaker eval-fixture` として提供。
+
+## Data Generation
+
+### Parameters
+
+```typescript
+interface FixtureConfig {
+  testCount: number;           // テスト数 (100 / 500 / 1000)
+  commitCount: number;         // コミット数 (50 / 100 / 200)
+  flakyRate: number;           // フレーキー率 (0.05 / 0.10 / 0.20)
+  coFailureStrength: number;   // co-failure 相関強度 (0.0-1.0)
+  filesPerCommit: number;      // コミットあたりの変更ファイル数 (1-5)
+  testsPerFile: number;        // ファイルあたりの関連テスト数 (3-10)
+  samplePercentage: number;    // サンプリング率 (10 / 20 / 50)
+  seed: number;                // 再現用シード
+}
+```
+
+### Generation Logic
+
+1. **テスト一覧生成**: `tests/module_{i}/test_{j}.spec.ts` (testCount 個)
+2. **ファイル一覧生成**: `src/module_{i}.ts` (testCount / testsPerFile 個)
+3. **依存マップ作成**: 各ファイルに `testsPerFile` 個のテストを紐付け (ground truth)
+4. **フレーキーテスト選定**: `testCount * flakyRate` 個のテストをフレーキーとしてマーク
+5. **各 commit の生成**:
+   - ランダムに `filesPerCommit` 個のファイルを選択 → `commit_changes`
+   - 各テストの失敗判定:
+     - 変更ファイルに依存するテスト: `coFailureStrength` の確率で失敗
+     - フレーキーテスト: `flakyRate` の確率で追加失敗
+     - それ以外: 常に pass
+   - `workflow_runs` + `test_results` に記録
+
+### Deterministic Seeding
+
+全てのランダム判定は seed ベースの LCG で行い、同一パラメータで同一結果を保証する。
+
+## Evaluation Pipeline
+
+### Process
+
+1. In-memory DuckDB にフィクスチャデータを投入
+2. 最後の N commits を「評価対象」として分離（train/test split 的）
+3. 各評価 commit について:
+   - `changed_files` を取得
+   - 各戦略で `planSample` を実行（samplePercentage で件数決定）
+   - サンプリング結果と実際の CI 結果を比較
+4. 全 commit の結果を集計
+
+### Compared Strategies
+
+| Strategy | Description |
+|----------|-------------|
+| `random` | Baseline: ランダムサンプリング |
+| `weighted` | flaky_rate のみの重み付け |
+| `weighted+co-failure` | flaky_rate + co_failure_boost |
+
+### Metrics
+
+- **Recall**: 実際に失敗したテストのうち、サンプリングで選択された割合
+- **Precision**: サンプリングで選択されたテストのうち、実際に失敗した割合
+- **F1 Score**: Recall と Precision の調和平均
+- **False Negative Rate**: サンプリングで漏れた失敗テストの割合
+- **Sample Ratio**: 全テストに対する選択率
+- **Efficiency**: Recall / Sample Ratio (1.0 超なら random より良い)
+
+### Output Format
+
+```
+# Evaluation Report
+
+Config: tests=500, commits=100, flaky=10%, co-failure=0.8, sample=20%
+
+| Strategy            | Recall | Precision | F1    | FNR   | Sample% | Efficiency |
+|---------------------|--------|-----------|-------|-------|---------|------------|
+| random              | 20.0%  | 5.0%      | 0.08  | 80.0% | 20.0%   | 1.00       |
+| weighted            | 35.0%  | 8.0%      | 0.13  | 65.0% | 20.0%   | 1.75       |
+| weighted+co-failure | 72.0%  | 15.0%     | 0.25  | 28.0% | 20.0%   | 3.60       |
+```
+
+## File Structure
+
+- `src/cli/eval/fixture-generator.ts` — データ生成ロジック (pure, no I/O)
+- `src/cli/eval/fixture-evaluator.ts` — 評価パイプライン
+- `src/cli/eval/fixture-report.ts` — レポートフォーマット
+- `tests/eval/fixture-generator.test.ts` — ジェネレータのユニットテスト
+- `tests/eval/fixture-evaluator.test.ts` — 評価パイプラインの統合テスト
+
+## CLI
+
+```bash
+# デフォルトパラメータで実行
+flaker eval-fixture
+
+# パラメータ指定
+flaker eval-fixture --tests 500 --commits 100 --flaky-rate 0.1 --co-failure-strength 0.8 --sample-percentage 20
+
+# 複数パラメータセットを sweep
+flaker eval-fixture --sweep
+```
+
+`--sweep` は co-failure-strength を 0.0, 0.25, 0.5, 0.75, 1.0 で変化させて比較テーブルを出力。

--- a/src/cli/core/loader.ts
+++ b/src/cli/core/loader.ts
@@ -492,19 +492,45 @@ function deserializeReverseDeps(entries: ReverseDepEntry[]): Map<string, string[
   return reverse;
 }
 
+/** Restore co_failure_boost from input meta after MoonBit round-trip (MoonBit Option<Double> may serialize differently) */
+function normalizeMetaBoosts(result: TestMeta[], inputMeta: TestMeta[]): TestMeta[] {
+  const boostByKey = new Map<string, number>();
+  for (const m of inputMeta) {
+    const key = m.test_id ?? `${m.suite}\0${m.test_name}`;
+    if (m.co_failure_boost && m.co_failure_boost > 0) {
+      boostByKey.set(key, m.co_failure_boost);
+    }
+  }
+  if (boostByKey.size === 0) return result;
+  return result.map((m) => {
+    const key = m.test_id ?? `${m.suite}\0${m.test_name}`;
+    const boost = boostByKey.get(key);
+    return boost != null ? { ...m, co_failure_boost: boost } : { ...m, co_failure_boost: m.co_failure_boost ?? 0 };
+  });
+}
+
 function wrapMbtCore(mbt: MbtJsExports): MetriciCore {
   return {
     detectFlaky(input: DetectInput): DetectOutput {
       return JSON.parse(mbt.detect_flaky_json(JSON.stringify(input)));
     },
     sampleRandom(meta: TestMeta[], count: number, seed: number): TestMeta[] {
-      return JSON.parse(mbt.sample_random_json(JSON.stringify(meta), count, seed));
+      return normalizeMetaBoosts(
+        JSON.parse(mbt.sample_random_json(JSON.stringify(meta), count, seed)),
+        meta,
+      );
     },
     sampleWeighted(meta: TestMeta[], count: number, seed: number): TestMeta[] {
-      return JSON.parse(mbt.sample_weighted_json(JSON.stringify(meta), count, seed));
+      return normalizeMetaBoosts(
+        JSON.parse(mbt.sample_weighted_json(JSON.stringify(meta), count, seed)),
+        meta,
+      );
     },
     sampleHybrid(meta: TestMeta[], affectedSuites: string[], count: number, seed: number): TestMeta[] {
-      return JSON.parse(mbt.sample_hybrid_json(JSON.stringify(meta), JSON.stringify(affectedSuites), count, seed));
+      return normalizeMetaBoosts(
+        JSON.parse(mbt.sample_hybrid_json(JSON.stringify(meta), JSON.stringify(affectedSuites), count, seed)),
+        meta,
+      );
     },
     buildSamplingMeta(
       historyRows: SamplingHistoryRowInput[],

--- a/src/cli/eval/fixture-evaluator.ts
+++ b/src/cli/eval/fixture-evaluator.ts
@@ -1,0 +1,89 @@
+import type { MetricStore } from "../storage/types.js";
+import type { FixtureData } from "./fixture-generator.js";
+import { planSample } from "../commands/sample.js";
+
+export interface EvalStrategyResult {
+  strategy: string;
+  recall: number;
+  precision: number;
+  f1: number;
+  falseNegativeRate: number;
+  sampleRatio: number;
+  efficiency: number;
+  totalFailures: number;
+  detectedFailures: number;
+  totalSampled: number;
+}
+
+export async function evaluateFixture(
+  store: MetricStore,
+  fixture: FixtureData,
+): Promise<EvalStrategyResult[]> {
+  const strategies = [
+    { name: "random", mode: "random" as const, useCoFailure: false },
+    { name: "weighted", mode: "weighted" as const, useCoFailure: false },
+    { name: "weighted+co-failure", mode: "weighted" as const, useCoFailure: true },
+  ];
+
+  // Use last 25% of commits as evaluation set
+  const evalStart = Math.floor(fixture.commits.length * 0.75);
+  const evalCommits = fixture.commits.slice(evalStart);
+  const sampleCount = Math.round(
+    fixture.tests.length * (fixture.config.samplePercentage / 100),
+  );
+
+  const results: EvalStrategyResult[] = [];
+
+  for (const strategy of strategies) {
+    let totalFailures = 0;
+    let detectedFailures = 0;
+    let totalSampled = 0;
+    let totalSampledFailures = 0;
+
+    for (const commit of evalCommits) {
+      const changedFiles = strategy.useCoFailure
+        ? commit.changedFiles.map((f) => f.filePath)
+        : undefined;
+
+      const plan = await planSample({
+        store,
+        count: sampleCount,
+        mode: strategy.mode,
+        seed: 42,
+        changedFiles,
+      });
+
+      const sampledSuites = new Set(plan.sampled.map((t) => t.suite));
+      const actualFailures = commit.testResults.filter((r) => r.status === "failed");
+      const detectedInSample = actualFailures.filter((f) => sampledSuites.has(f.suite));
+
+      totalFailures += actualFailures.length;
+      detectedFailures += detectedInSample.length;
+      totalSampled += plan.sampled.length;
+      totalSampledFailures += plan.sampled.filter((t) =>
+        commit.testResults.some((r) => r.suite === t.suite && r.status === "failed"),
+      ).length;
+    }
+
+    const recall = totalFailures > 0 ? detectedFailures / totalFailures : 1;
+    const precision = totalSampled > 0 ? totalSampledFailures / totalSampled : 0;
+    const f1 = recall + precision > 0 ? (2 * recall * precision) / (recall + precision) : 0;
+    const sampleRatio = fixture.tests.length > 0 ? sampleCount / fixture.tests.length : 0;
+    const efficiency = sampleRatio > 0 ? recall / sampleRatio : 0;
+
+    results.push({
+      strategy: strategy.name,
+      recall: Math.round(recall * 1000) / 1000,
+      precision: Math.round(precision * 1000) / 1000,
+      f1: Math.round(f1 * 1000) / 1000,
+      falseNegativeRate: Math.round((1 - recall) * 1000) / 1000,
+      sampleRatio: Math.round(sampleRatio * 1000) / 1000,
+      efficiency: Math.round(efficiency * 100) / 100,
+      totalFailures,
+      detectedFailures,
+      totalSampled,
+    });
+  }
+
+  return results;
+}

--- a/src/cli/eval/fixture-generator.ts
+++ b/src/cli/eval/fixture-generator.ts
@@ -1,0 +1,121 @@
+export interface FixtureConfig {
+  testCount: number;
+  commitCount: number;
+  flakyRate: number;
+  coFailureStrength: number;
+  filesPerCommit: number;
+  testsPerFile: number;
+  samplePercentage: number;
+  seed: number;
+}
+
+export interface FixtureTest {
+  suite: string;
+  testName: string;
+  isFlaky: boolean;
+}
+
+interface FixtureCommitResult {
+  suite: string;
+  testName: string;
+  status: "passed" | "failed";
+}
+
+export interface FixtureCommit {
+  sha: string;
+  changedFiles: { filePath: string; changeType: string }[];
+  testResults: FixtureCommitResult[];
+}
+
+export interface FixtureData {
+  tests: FixtureTest[];
+  files: string[];
+  fileDeps: Map<string, string[]>;
+  commits: FixtureCommit[];
+  config: FixtureConfig;
+}
+
+function lcgNext(state: number): { next: number; value: number } {
+  const next = (state * 1664525 + 1013904223) >>> 0;
+  return { next, value: next / 0x100000000 };
+}
+
+export function generateFixture(config: FixtureConfig): FixtureData {
+  let rng = config.seed >>> 0;
+  function rand(): number {
+    const r = lcgNext(rng);
+    rng = r.next;
+    return r.value;
+  }
+
+  const fileCount = Math.max(1, Math.ceil(config.testCount / config.testsPerFile));
+  const files: string[] = [];
+  for (let i = 0; i < fileCount; i++) {
+    files.push(`src/module_${i}.ts`);
+  }
+
+  const tests: FixtureTest[] = [];
+  const fileDeps = new Map<string, string[]>();
+  for (let i = 0; i < fileCount; i++) {
+    fileDeps.set(files[i], []);
+  }
+
+  const flakyCount = Math.round(config.testCount * config.flakyRate);
+  for (let i = 0; i < config.testCount; i++) {
+    const fileIdx = i % fileCount;
+    const suite = `tests/module_${fileIdx}/test_${i}.spec.ts`;
+    tests.push({
+      suite,
+      testName: `test_${i}`,
+      isFlaky: i < flakyCount,
+    });
+    fileDeps.get(files[fileIdx])!.push(suite);
+  }
+
+  const commits: FixtureCommit[] = [];
+  for (let c = 0; c < config.commitCount; c++) {
+    const sha = `fixture-sha-${c.toString().padStart(4, "0")}`;
+
+    const changedFiles: { filePath: string; changeType: string }[] = [];
+    const changedFileSet = new Set<string>();
+    const targetCount = Math.min(config.filesPerCommit, fileCount);
+    while (changedFileSet.size < targetCount) {
+      const idx = Math.floor(rand() * fileCount);
+      const file = files[idx];
+      if (!changedFileSet.has(file)) {
+        changedFileSet.add(file);
+        changedFiles.push({ filePath: file, changeType: "modified" });
+      }
+    }
+
+    const dependentSuites = new Set<string>();
+    for (const file of changedFileSet) {
+      for (const suite of fileDeps.get(file) ?? []) {
+        dependentSuites.add(suite);
+      }
+    }
+
+    const testResults: FixtureCommitResult[] = tests.map((test) => {
+      const isDependent = dependentSuites.has(test.suite);
+      let failed = false;
+
+      if (isDependent && rand() < config.coFailureStrength) {
+        failed = true;
+      }
+
+      if (test.isFlaky && rand() < config.flakyRate) {
+        failed = true;
+      }
+
+      return {
+        suite: test.suite,
+        testName: test.testName,
+        status: failed ? "failed" : "passed",
+      };
+    });
+
+    commits.push({ sha, changedFiles, testResults });
+  }
+
+  return { tests, files, fileDeps, commits, config };
+}

--- a/src/cli/eval/fixture-loader.ts
+++ b/src/cli/eval/fixture-loader.ts
@@ -1,0 +1,51 @@
+import type { MetricStore } from "../storage/types.js";
+import type { FixtureData } from "./fixture-generator.js";
+
+export async function loadFixtureIntoStore(
+  store: MetricStore,
+  fixture: FixtureData,
+): Promise<void> {
+  const baseTime = Date.now() - fixture.commits.length * 86400000;
+
+  for (let i = 0; i < fixture.commits.length; i++) {
+    const commit = fixture.commits[i];
+    const createdAt = new Date(baseTime + i * 86400000);
+    const runId = i + 1;
+
+    await store.insertWorkflowRun({
+      id: runId,
+      repo: "fixture/repo",
+      branch: "main",
+      commitSha: commit.sha,
+      event: "push",
+      status: "completed",
+      createdAt,
+      durationMs: 60000,
+    });
+
+    await store.insertCommitChanges(
+      commit.sha,
+      commit.changedFiles.map((f) => ({
+        filePath: f.filePath,
+        changeType: f.changeType,
+        additions: 10,
+        deletions: 5,
+      })),
+    );
+
+    await store.insertTestResults(
+      commit.testResults.map((r) => ({
+        workflowRunId: runId,
+        suite: r.suite,
+        testName: r.testName,
+        status: r.status,
+        durationMs: 100,
+        retryCount: 0,
+        errorMessage: r.status === "failed" ? "fixture failure" : null,
+        commitSha: commit.sha,
+        variant: null,
+        createdAt,
+      })),
+    );
+  }
+}

--- a/src/cli/eval/fixture-report.ts
+++ b/src/cli/eval/fixture-report.ts
@@ -1,0 +1,60 @@
+import type { FixtureConfig } from "./fixture-generator.js";
+import type { EvalStrategyResult } from "./fixture-evaluator.js";
+
+export interface EvalFixtureReport {
+  config: FixtureConfig;
+  results: EvalStrategyResult[];
+}
+
+function pct(v: number): string {
+  return `${(v * 100).toFixed(1)}%`;
+}
+
+function pad(s: string, width: number): string {
+  return s.padEnd(width);
+}
+
+export function formatEvalFixtureReport(report: EvalFixtureReport): string {
+  const c = report.config;
+  const lines: string[] = [
+    "# Evaluation Report",
+    "",
+    `Config: tests=${c.testCount}, commits=${c.commitCount}, flaky=${pct(c.flakyRate)}, co-failure=${c.coFailureStrength}, sample=${c.samplePercentage}%`,
+    "",
+    `| ${pad("Strategy", 22)} | ${pad("Recall", 8)} | ${pad("Prec", 8)} | ${pad("F1", 6)} | ${pad("FNR", 8)} | ${pad("Sample%", 8)} | ${pad("Efficiency", 10)} |`,
+    `|${"-".repeat(24)}|${"-".repeat(10)}|${"-".repeat(10)}|${"-".repeat(8)}|${"-".repeat(10)}|${"-".repeat(10)}|${"-".repeat(12)}|`,
+  ];
+
+  for (const r of report.results) {
+    lines.push(
+      `| ${pad(r.strategy, 22)} | ${pad(pct(r.recall), 8)} | ${pad(pct(r.precision), 8)} | ${pad(r.f1.toFixed(2), 6)} | ${pad(pct(r.falseNegativeRate), 8)} | ${pad(pct(r.sampleRatio), 8)} | ${pad(r.efficiency.toFixed(2), 10)} |`,
+    );
+  }
+
+  lines.push("", `Efficiency = Recall / Sample%. >1.0 means better than random.`);
+  return lines.join("\n");
+}
+
+export function formatSweepReport(reports: EvalFixtureReport[]): string {
+  const lines: string[] = [
+    "# Co-failure Strength Sweep",
+    "",
+    `| ${pad("Strength", 10)} | ${pad("Random", 8)} | ${pad("Weighted", 10)} | ${pad("W+CoFail", 10)} | ${pad("Gain", 6)} |`,
+    `|${"-".repeat(12)}|${"-".repeat(10)}|${"-".repeat(12)}|${"-".repeat(12)}|${"-".repeat(8)}|`,
+  ];
+
+  for (const report of reports) {
+    const random = report.results.find((r) => r.strategy === "random")!;
+    const weighted = report.results.find((r) => r.strategy === "weighted")!;
+    const coFailure = report.results.find((r) => r.strategy === "weighted+co-failure")!;
+    const gain = random.recall > 0
+      ? `${((coFailure.recall / random.recall - 1) * 100).toFixed(0)}%`
+      : "N/A";
+
+    lines.push(
+      `| ${pad(report.config.coFailureStrength.toFixed(2), 10)} | ${pad(pct(random.recall), 8)} | ${pad(pct(weighted.recall), 10)} | ${pad(pct(coFailure.recall), 10)} | ${pad(gain, 6)} |`,
+    );
+  }
+
+  return lines.join("\n");
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -41,6 +41,10 @@ import {
 } from "./commands/eval.js";
 import { runReason, formatReasoningReport } from "./commands/reason.js";
 import { runSelfEval, formatSelfEvalReport } from "./commands/self-eval.js";
+import { generateFixture } from "./eval/fixture-generator.js";
+import { loadFixtureIntoStore } from "./eval/fixture-loader.js";
+import { evaluateFixture } from "./eval/fixture-evaluator.js";
+import { formatEvalFixtureReport, formatSweepReport } from "./eval/fixture-report.js";
 import { runDoctor, formatDoctorReport } from "./commands/doctor.js";
 import {
   runAffected,
@@ -1110,6 +1114,56 @@ program
       console.log(formatSelfEvalReport(report));
     }
     process.exit(report.overallScore >= 80 ? 0 : 1);
+  });
+
+// --- eval-fixture ---
+program
+  .command("eval-fixture")
+  .description("Evaluate sampling strategies with synthetic data")
+  .option("--tests <n>", "Number of tests", "100")
+  .option("--commits <n>", "Number of commits", "50")
+  .option("--flaky-rate <n>", "Flaky rate (0-1)", "0.1")
+  .option("--co-failure-strength <n>", "Co-failure correlation (0-1)", "0.8")
+  .option("--files-per-commit <n>", "Files changed per commit", "2")
+  .option("--tests-per-file <n>", "Tests per source file", "5")
+  .option("--sample-percentage <n>", "Sample percentage", "20")
+  .option("--seed <n>", "Random seed", "42")
+  .option("--sweep", "Sweep co-failure strength 0.0-1.0")
+  .action(async (opts) => {
+    const baseConfig = {
+      testCount: parseInt(opts.tests, 10),
+      commitCount: parseInt(opts.commits, 10),
+      flakyRate: parseFloat(opts.flakyRate),
+      coFailureStrength: parseFloat(opts.coFailureStrength),
+      filesPerCommit: parseInt(opts.filesPerCommit, 10),
+      testsPerFile: parseInt(opts.testsPerFile, 10),
+      samplePercentage: parseInt(opts.samplePercentage, 10),
+      seed: parseInt(opts.seed, 10),
+    };
+
+    if (opts.sweep) {
+      const strengths = [0.0, 0.25, 0.5, 0.75, 1.0];
+      const reports = [];
+      for (const strength of strengths) {
+        const config = { ...baseConfig, coFailureStrength: strength };
+        const store = new DuckDBStore(":memory:");
+        await store.initialize();
+        const fixture = generateFixture(config);
+        await loadFixtureIntoStore(store, fixture);
+        const results = await evaluateFixture(store, fixture);
+        reports.push({ config, results });
+        await store.close();
+      }
+      console.log(formatSweepReport(reports));
+    } else {
+      const store = new DuckDBStore(":memory:");
+      await store.initialize();
+      const fixture = generateFixture(baseConfig);
+      await loadFixtureIntoStore(store, fixture);
+      const results = await evaluateFixture(store, fixture);
+      console.log(formatEvalFixtureReport({ config: baseConfig, results }));
+      await store.close();
+    }
   });
 
 // --- doctor ---

--- a/src/cli/storage/duckdb.ts
+++ b/src/cli/storage/duckdb.ts
@@ -503,7 +503,7 @@ export class DuckDBStore implements MetricStore {
     for (const cf of allCoFailures) {
       if (!changedSet.has(cf.filePath)) continue;
       const existing = boosts.get(cf.testId) ?? 0;
-      boosts.set(cf.testId, Math.max(existing, cf.coFailureRate / 100));
+      boosts.set(cf.testId, Math.max(existing, cf.coFailureRate));
     }
     return boosts;
   }

--- a/tests/commands/sample-co-failure.test.ts
+++ b/tests/commands/sample-co-failure.test.ts
@@ -108,7 +108,7 @@ describe("sample with co-failure boost", () => {
 
     const loginTest = plan.allTests.find((t) => t.suite === "tests/login.spec.ts");
     expect(loginTest).toBeDefined();
-    expect(loginTest!.co_failure_boost).toBe(1.0);
+    expect(loginTest!.co_failure_boost).toBe(100);
 
     const signupTest = plan.allTests.find((t) => t.suite === "tests/signup.spec.ts");
     expect(signupTest).toBeDefined();

--- a/tests/eval/fixture-evaluator.test.ts
+++ b/tests/eval/fixture-evaluator.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { DuckDBStore } from "../../src/cli/storage/duckdb.js";
+import { generateFixture } from "../../src/cli/eval/fixture-generator.js";
+import { loadFixtureIntoStore } from "../../src/cli/eval/fixture-loader.js";
+import { evaluateFixture, type EvalStrategyResult } from "../../src/cli/eval/fixture-evaluator.js";
+
+describe("evaluateFixture", () => {
+  let store: DuckDBStore;
+
+  beforeEach(async () => {
+    store = new DuckDBStore(":memory:");
+    await store.initialize();
+  });
+
+  afterEach(async () => {
+    await store.close();
+  });
+
+  it("returns results for all strategies", async () => {
+    const fixture = generateFixture({
+      testCount: 30,
+      commitCount: 20,
+      flakyRate: 0.1,
+      coFailureStrength: 0.8,
+      filesPerCommit: 2,
+      testsPerFile: 5,
+      samplePercentage: 30,
+      seed: 42,
+    });
+    await loadFixtureIntoStore(store, fixture);
+
+    const results = await evaluateFixture(store, fixture);
+    expect(results).toHaveLength(3);
+    expect(results.map((r) => r.strategy)).toEqual([
+      "random",
+      "weighted",
+      "weighted+co-failure",
+    ]);
+  });
+
+  it("all strategies have valid metrics", async () => {
+    const fixture = generateFixture({
+      testCount: 30,
+      commitCount: 20,
+      flakyRate: 0.1,
+      coFailureStrength: 0.8,
+      filesPerCommit: 2,
+      testsPerFile: 5,
+      samplePercentage: 30,
+      seed: 42,
+    });
+    await loadFixtureIntoStore(store, fixture);
+
+    const results = await evaluateFixture(store, fixture);
+    for (const result of results) {
+      expect(result.recall).toBeGreaterThanOrEqual(0);
+      expect(result.recall).toBeLessThanOrEqual(1);
+      expect(result.falseNegativeRate).toBeGreaterThanOrEqual(0);
+      expect(result.falseNegativeRate).toBeLessThanOrEqual(1);
+      expect(result.sampleRatio).toBeGreaterThan(0);
+      expect(result.sampleRatio).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("co-failure strategy outperforms random when correlation is strong", async () => {
+    const fixture = generateFixture({
+      testCount: 50,
+      commitCount: 40,
+      flakyRate: 0.05,
+      coFailureStrength: 1.0,
+      filesPerCommit: 2,
+      testsPerFile: 5,
+      samplePercentage: 20,
+      seed: 42,
+    });
+    await loadFixtureIntoStore(store, fixture);
+
+    const results = await evaluateFixture(store, fixture);
+    const random = results.find((r) => r.strategy === "random")!;
+    const coFailure = results.find((r) => r.strategy === "weighted+co-failure")!;
+
+    expect(coFailure.recall).toBeGreaterThanOrEqual(random.recall);
+  });
+});

--- a/tests/eval/fixture-generator.test.ts
+++ b/tests/eval/fixture-generator.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { generateFixture, type FixtureConfig } from "../../src/cli/eval/fixture-generator.js";
+
+const defaultConfig: FixtureConfig = {
+  testCount: 20,
+  commitCount: 10,
+  flakyRate: 0.1,
+  coFailureStrength: 0.8,
+  filesPerCommit: 2,
+  testsPerFile: 4,
+  samplePercentage: 20,
+  seed: 42,
+};
+
+describe("generateFixture", () => {
+  it("generates correct number of tests and commits", () => {
+    const fixture = generateFixture(defaultConfig);
+    expect(fixture.tests.length).toBe(20);
+    expect(fixture.commits.length).toBe(10);
+  });
+
+  it("generates file-to-test dependency map", () => {
+    const fixture = generateFixture(defaultConfig);
+    expect(fixture.fileDeps.size).toBeGreaterThan(0);
+    for (const [, tests] of fixture.fileDeps) {
+      expect(tests.length).toBe(4);
+    }
+  });
+
+  it("marks correct number of flaky tests", () => {
+    const fixture = generateFixture(defaultConfig);
+    const flakyCount = fixture.tests.filter((t) => t.isFlaky).length;
+    expect(flakyCount).toBe(2); // 20 * 0.1 = 2
+  });
+
+  it("generates commit changes and test results", () => {
+    const fixture = generateFixture(defaultConfig);
+    for (const commit of fixture.commits) {
+      expect(commit.changedFiles.length).toBe(2);
+      expect(commit.testResults.length).toBe(20);
+    }
+  });
+
+  it("is deterministic with same seed", () => {
+    const a = generateFixture(defaultConfig);
+    const b = generateFixture(defaultConfig);
+    expect(a.commits.map((c) => c.sha)).toEqual(b.commits.map((c) => c.sha));
+    expect(a.commits.map((c) => c.testResults.map((r) => r.status))).toEqual(
+      b.commits.map((c) => c.testResults.map((r) => r.status)),
+    );
+  });
+
+  it("co-failure strength controls failure correlation", () => {
+    const strong = generateFixture({ ...defaultConfig, coFailureStrength: 1.0, commitCount: 50 });
+    const none = generateFixture({ ...defaultConfig, coFailureStrength: 0.0, commitCount: 50 });
+
+    const strongFailures = strong.commits.flatMap((c) => c.testResults.filter((r) => r.status === "failed"));
+    const noneFailures = none.commits.flatMap((c) => c.testResults.filter((r) => r.status === "failed"));
+
+    expect(strongFailures.length).toBeGreaterThan(noneFailures.length);
+  });
+});

--- a/tests/eval/fixture-loader.test.ts
+++ b/tests/eval/fixture-loader.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { DuckDBStore } from "../../src/cli/storage/duckdb.js";
+import { generateFixture, type FixtureConfig } from "../../src/cli/eval/fixture-generator.js";
+import { loadFixtureIntoStore } from "../../src/cli/eval/fixture-loader.js";
+
+const config: FixtureConfig = {
+  testCount: 20,
+  commitCount: 10,
+  flakyRate: 0.1,
+  coFailureStrength: 0.8,
+  filesPerCommit: 2,
+  testsPerFile: 4,
+  samplePercentage: 20,
+  seed: 42,
+};
+
+describe("loadFixtureIntoStore", () => {
+  let store: DuckDBStore;
+
+  beforeEach(async () => {
+    store = new DuckDBStore(":memory:");
+    await store.initialize();
+  });
+
+  afterEach(async () => {
+    await store.close();
+  });
+
+  it("loads all workflow runs", async () => {
+    const fixture = generateFixture(config);
+    await loadFixtureIntoStore(store, fixture);
+
+    const rows = await store.raw<{ cnt: number }>(
+      "SELECT COUNT(*)::INTEGER AS cnt FROM workflow_runs",
+    );
+    expect(rows[0].cnt).toBe(10);
+  });
+
+  it("loads all test results", async () => {
+    const fixture = generateFixture(config);
+    await loadFixtureIntoStore(store, fixture);
+
+    const rows = await store.raw<{ cnt: number }>(
+      "SELECT COUNT(*)::INTEGER AS cnt FROM test_results",
+    );
+    expect(rows[0].cnt).toBe(200); // 10 commits * 20 tests
+  });
+
+  it("loads all commit changes", async () => {
+    const fixture = generateFixture(config);
+    await loadFixtureIntoStore(store, fixture);
+
+    const rows = await store.raw<{ cnt: number }>(
+      "SELECT COUNT(*)::INTEGER AS cnt FROM commit_changes",
+    );
+    expect(rows[0].cnt).toBeGreaterThan(0);
+  });
+
+  it("co-failure query returns results after loading", async () => {
+    const fixture = generateFixture(config);
+    await loadFixtureIntoStore(store, fixture);
+
+    const coFailures = await store.queryCoFailures({ windowDays: 365, minCoRuns: 2 });
+    expect(coFailures.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/eval/fixture-report.test.ts
+++ b/tests/eval/fixture-report.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { formatEvalFixtureReport, type EvalFixtureReport } from "../../src/cli/eval/fixture-report.js";
+import type { EvalStrategyResult } from "../../src/cli/eval/fixture-evaluator.js";
+import type { FixtureConfig } from "../../src/cli/eval/fixture-generator.js";
+
+describe("formatEvalFixtureReport", () => {
+  it("formats a readable markdown table", () => {
+    const config: FixtureConfig = {
+      testCount: 500,
+      commitCount: 100,
+      flakyRate: 0.1,
+      coFailureStrength: 0.8,
+      filesPerCommit: 2,
+      testsPerFile: 5,
+      samplePercentage: 20,
+      seed: 42,
+    };
+
+    const results: EvalStrategyResult[] = [
+      {
+        strategy: "random",
+        recall: 0.2, precision: 0.05, f1: 0.08,
+        falseNegativeRate: 0.8, sampleRatio: 0.2, efficiency: 1.0,
+        totalFailures: 100, detectedFailures: 20, totalSampled: 400,
+      },
+      {
+        strategy: "weighted",
+        recall: 0.35, precision: 0.08, f1: 0.13,
+        falseNegativeRate: 0.65, sampleRatio: 0.2, efficiency: 1.75,
+        totalFailures: 100, detectedFailures: 35, totalSampled: 400,
+      },
+      {
+        strategy: "weighted+co-failure",
+        recall: 0.72, precision: 0.15, f1: 0.25,
+        falseNegativeRate: 0.28, sampleRatio: 0.2, efficiency: 3.6,
+        totalFailures: 100, detectedFailures: 72, totalSampled: 400,
+      },
+    ];
+
+    const report: EvalFixtureReport = { config, results };
+    const output = formatEvalFixtureReport(report);
+
+    expect(output).toContain("Evaluation Report");
+    expect(output).toContain("random");
+    expect(output).toContain("weighted+co-failure");
+    expect(output).toContain("Recall");
+    expect(output).toContain("Efficiency");
+  });
+});

--- a/tests/storage/co-failure.test.ts
+++ b/tests/storage/co-failure.test.ts
@@ -107,9 +107,9 @@ describe("co-failure query", () => {
       { windowDays: 90, minCoRuns: 2 },
     );
     expect(boosts.size).toBeGreaterThan(0);
-    // login test should have boost of 1.0 (100% co-failure rate / 100)
+    // login test should have boost of 100 (100% co-failure rate)
     const loginBoost = [...boosts.values()].find((v) => v > 0);
-    expect(loginBoost).toBe(1.0);
+    expect(loginBoost).toBe(100);
   });
 
   it("getCoFailureBoosts returns empty for unrelated files", async () => {


### PR DESCRIPTION
## Summary

- Add synthetic fixture generator with deterministic seeding for controlled evaluation
- Add fixture data loader for DuckDB
- Add fixture evaluator comparing random / weighted / weighted+co-failure strategies
- Add `flaker eval-fixture` command with markdown report and `--sweep` mode
- Fix co_failure_boost scale (0-100, matching flaky_rate) and MoonBit bridge round-trip

## How it works

```bash
# Single evaluation
flaker eval-fixture --tests 200 --commits 100 --co-failure-strength 0.8

# Sweep co-failure strength
flaker eval-fixture --sweep
```

Generates synthetic test history, loads into in-memory DuckDB, runs `planSample` with each strategy, and compares recall/precision/F1 against ground truth.

## Key finding

Current co-failure boost implementation shows modest improvement over random in synthetic benchmarks. The weighted sampling's randomness dilutes the boost effect. This validates the evaluation framework works and identifies the next improvement target (deterministic co-failure-based selection).

## Test plan

- [x] Fixture generator: count, deps, flaky marking, determinism, co-failure strength (6 tests)
- [x] Fixture loader: workflow runs, test results, commit changes, co-failure query (4 tests)
- [x] Fixture evaluator: strategy count, valid metrics, co-failure outperforms random (3 tests)
- [x] Report formatter: readable markdown table output (1 test)
- [x] Full test suite: 386 tests passing, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)