### PR TITLE
feat: add Parquet export/import and auto-export on collect

### DIFF
--- a/moon.mod.json
+++ b/moon.mod.json
@@ -2,12 +2,13 @@
   "name": "mizchi/flaker",
   "version": "0.1.0",
   "deps": {
-    "mizchi/bitflow": "0.3.1"
+    "mizchi/bitflow": "0.3.1",
+    "mizchi/parquet": "0.2.0"
   },
-  "source": "src",
   "readme": "README.md",
   "repository": "",
   "license": "MIT",
   "keywords": [],
-  "description": "flaker core computation engine"
+  "description": "flaker core computation engine",
+  "source": "src"
 }

--- a/src/cli/commands/collect-local.ts
+++ b/src/cli/commands/collect-local.ts
@@ -8,12 +8,14 @@ import type { MetricStore, WorkflowRun, TestResult } from "../storage/types.js";
 import { toStoredTestResult } from "../storage/test-result-mapper.js";
 import { collectCommitChanges } from "./collect-commit-changes.js";
 import { resolveCurrentCommitSha } from "../core/git.js";
+import { exportRunParquet } from "./export-parquet.js";
 
 export interface CollectLocalOpts {
   store: MetricStore;
   last?: number;
   exec?: (cmd: string) => string;
   workspace?: string;
+  storagePath?: string;
 }
 
 export interface CollectLocalResult {
@@ -113,6 +115,9 @@ export async function runCollectLocal(opts: CollectLocalOpts): Promise<CollectLo
     const realCommitSha = resolveCurrentCommitSha(workspace);
     if (realCommitSha) {
       await collectCommitChanges(store, workspace, realCommitSha);
+    }
+    if (opts.storagePath) {
+      await exportRunParquet(store, runId, opts.storagePath);
     }
 
     runsImported++;

--- a/src/cli/commands/collect.ts
+++ b/src/cli/commands/collect.ts
@@ -6,6 +6,7 @@ import type { TestResultAdapter } from "../adapters/types.js";
 import type { MetricStore, WorkflowRun, TestResult } from "../storage/types.js";
 import { toStoredTestResult } from "../storage/test-result-mapper.js";
 import { collectCommitChanges } from "./collect-commit-changes.js";
+import { exportRunParquet } from "./export-parquet.js";
 
 export interface GitHubClient {
   listWorkflowRuns(): Promise<{
@@ -35,6 +36,7 @@ export interface CollectOpts {
   adapterType: string;
   artifactName?: string;
   customCommand?: string;
+  storagePath?: string;
 }
 
 export interface CollectFailure {
@@ -116,6 +118,7 @@ export async function collectWorkflowRuns(
     repo,
     adapterType,
     customCommand,
+    storagePath,
   } = opts;
   const artifactName = opts.artifactName ?? defaultArtifactNameForAdapter(adapterType);
   const adapterConfig = customCommand ?? "";
@@ -221,6 +224,9 @@ export async function collectWorkflowRuns(
       }
       await collectCommitChanges(store, process.cwd(), run.head_sha);
       await store.recordCollectedArtifact(collectedRecord);
+      if (storagePath) {
+        await exportRunParquet(store, run.id, storagePath);
+      }
 
       runsCollected++;
       testsCollected += testResults.length;

--- a/src/cli/commands/export-parquet.ts
+++ b/src/cli/commands/export-parquet.ts
@@ -1,0 +1,19 @@
+import { resolve, dirname } from "node:path";
+import type { MetricStore } from "../storage/types.js";
+
+export async function exportRunParquet(
+  store: MetricStore,
+  workflowRunId: number,
+  storagePath: string,
+): Promise<void> {
+  const artifactsDir = resolve(dirname(storagePath), "artifacts");
+  try {
+    const result = await store.exportRunToParquet(workflowRunId, artifactsDir);
+    console.log(
+      `Exported to Parquet: ${result.testResultsCount} test results, ${result.commitChangesCount} commit changes`,
+    );
+  } catch (err) {
+    // Non-fatal: log warning but don't fail the collect
+    console.warn(`Warning: Parquet export failed: ${err instanceof Error ? err.message : err}`);
+  }
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -317,6 +317,7 @@ program
         adapterType: config.adapter.type,
         artifactName: config.adapter.artifact_name,
         customCommand: config.adapter.command,
+        storagePath: config.storage.path,
       });
       const formatted = formatCollectSummary(result, opts.json ? "json" : "text");
       console.log(formatted);
@@ -1084,6 +1085,7 @@ program
       const result = await runCollectLocal({
         store,
         last: opts.last ? Number(opts.last) : undefined,
+        storagePath: config.storage.path,
       });
       console.log(`Imported ${result.runsImported} runs, ${result.testsImported} test results`);
       if (result.runsImported > 0) {

--- a/src/cli/storage/duckdb.ts
+++ b/src/cli/storage/duckdb.ts
@@ -1,5 +1,5 @@
 import { mkdirSync } from "node:fs";
-import { dirname } from "node:path";
+import { dirname, join } from "node:path";
 import { SCHEMA_DDL, FLAKY_QUERY, CO_FAILURE_QUERY } from "./schema.js";
 import { createStableTestId, resolveTestIdentity } from "../identity.js";
 import type {
@@ -19,6 +19,8 @@ import type {
   CommitChange,
   CoFailureResult,
   CoFailureQueryOpts,
+  ExportResult,
+  ImportResult,
 } from "./types.js";
 
 export class DuckDBStore implements MetricStore {
@@ -506,6 +508,100 @@ export class DuckDBStore implements MetricStore {
       boosts.set(cf.testId, Math.max(existing, cf.coFailureRate));
     }
     return boosts;
+  }
+
+  async exportRunToParquet(workflowRunId: number, outputDir: string): Promise<ExportResult> {
+    mkdirSync(outputDir, { recursive: true });
+
+    const wrPath = join(outputDir, `workflow_run_${workflowRunId}.parquet`);
+    const trPath = join(outputDir, `test_results_${workflowRunId}.parquet`);
+    const ccPath = join(outputDir, `commit_changes_${workflowRunId}.parquet`);
+
+    // Get commit_sha for this run
+    const [run] = await this.all(
+      `SELECT commit_sha FROM workflow_runs WHERE id = ?`,
+      [workflowRunId],
+    );
+    if (!run) throw new Error(`Workflow run ${workflowRunId} not found`);
+    const commitSha = run.commit_sha;
+
+    // Export workflow_runs
+    await this.run(
+      `COPY (SELECT * FROM workflow_runs WHERE id = ${workflowRunId}) TO '${wrPath}' (FORMAT PARQUET)`,
+    );
+
+    // Export test_results for this run
+    const [trCount] = await this.all(
+      `SELECT COUNT(*)::INTEGER AS cnt FROM test_results WHERE workflow_run_id = ?`,
+      [workflowRunId],
+    );
+    await this.run(
+      `COPY (SELECT * FROM test_results WHERE workflow_run_id = ${workflowRunId}) TO '${trPath}' (FORMAT PARQUET)`,
+    );
+
+    // Export commit_changes for this commit
+    const [ccCount] = await this.all(
+      `SELECT COUNT(*)::INTEGER AS cnt FROM commit_changes WHERE commit_sha = ?`,
+      [commitSha],
+    );
+    await this.run(
+      `COPY (SELECT * FROM commit_changes WHERE commit_sha = '${commitSha}') TO '${ccPath}' (FORMAT PARQUET)`,
+    );
+
+    return {
+      testResultsCount: trCount.cnt,
+      commitChangesCount: ccCount.cnt,
+      workflowRunPath: wrPath,
+      testResultsPath: trPath,
+      commitChangesPath: ccPath,
+    };
+  }
+
+  async importFromParquetDir(inputDir: string): Promise<ImportResult> {
+    const { readdirSync } = await import("node:fs");
+    const files = readdirSync(inputDir).filter((f) => f.endsWith(".parquet"));
+
+    // Sort: workflow_run_ first, then commit_changes_, then test_results_
+    // (test_results has FK to workflow_runs)
+    const priorityOrder = (name: string): number => {
+      if (name.startsWith("workflow_run_")) return 0;
+      if (name.startsWith("commit_changes_")) return 1;
+      if (name.startsWith("test_results_")) return 2;
+      return 3;
+    };
+    files.sort((a, b) => priorityOrder(a) - priorityOrder(b));
+
+    let workflowRunsImported = 0;
+    let testResultsImported = 0;
+    let commitChangesImported = 0;
+
+    for (const file of files) {
+      const filePath = join(inputDir, file);
+      if (file.startsWith("workflow_run_")) {
+        const [before] = await this.all("SELECT COUNT(*)::INTEGER AS cnt FROM workflow_runs");
+        await this.exec(
+          `INSERT OR IGNORE INTO workflow_runs SELECT * FROM read_parquet('${filePath}')`,
+        );
+        const [after] = await this.all("SELECT COUNT(*)::INTEGER AS cnt FROM workflow_runs");
+        workflowRunsImported += after.cnt - before.cnt;
+      } else if (file.startsWith("test_results_")) {
+        const [before] = await this.all("SELECT COUNT(*)::INTEGER AS cnt FROM test_results");
+        await this.exec(
+          `INSERT OR IGNORE INTO test_results SELECT * FROM read_parquet('${filePath}')`,
+        );
+        const [after] = await this.all("SELECT COUNT(*)::INTEGER AS cnt FROM test_results");
+        testResultsImported += after.cnt - before.cnt;
+      } else if (file.startsWith("commit_changes_")) {
+        const [before] = await this.all("SELECT COUNT(*)::INTEGER AS cnt FROM commit_changes");
+        await this.exec(
+          `INSERT OR IGNORE INTO commit_changes SELECT * FROM read_parquet('${filePath}')`,
+        );
+        const [after] = await this.all("SELECT COUNT(*)::INTEGER AS cnt FROM commit_changes");
+        commitChangesImported += after.cnt - before.cnt;
+      }
+    }
+
+    return { workflowRunsImported, testResultsImported, commitChangesImported };
   }
 
   // Private helpers

--- a/src/cli/storage/types.ts
+++ b/src/cli/storage/types.ts
@@ -155,6 +155,20 @@ export interface CoFailureQueryOpts {
   minCoRuns?: number;
 }
 
+export interface ExportResult {
+  testResultsCount: number;
+  commitChangesCount: number;
+  workflowRunPath: string;
+  testResultsPath: string;
+  commitChangesPath: string;
+}
+
+export interface ImportResult {
+  workflowRunsImported: number;
+  testResultsImported: number;
+  commitChangesImported: number;
+}
+
 export interface MetricStore {
   initialize(): Promise<void>;
   close(): Promise<void>;
@@ -178,4 +192,6 @@ export interface MetricStore {
   hasCommitChanges(commitSha: string): Promise<boolean>;
   queryCoFailures(opts: CoFailureQueryOpts): Promise<CoFailureResult[]>;
   getCoFailureBoosts(changedFiles: string[], opts?: CoFailureQueryOpts): Promise<Map<string, number>>;
+  exportRunToParquet(workflowRunId: number, outputDir: string): Promise<ExportResult>;
+  importFromParquetDir(inputDir: string): Promise<ImportResult>;
 }

--- a/src/parquet_export/moon.pkg
+++ b/src/parquet_export/moon.pkg
@@ -1,0 +1,3 @@
+import {
+  "mizchi/parquet" @parquet,
+}

--- a/src/parquet_export/parquet_export.mbt
+++ b/src/parquet_export/parquet_export.mbt
@@ -1,0 +1,111 @@
+///| Write test_results rows as Parquet bytes.
+///  Columns: workflow_run_id (Int64), test_id (String?), task_id (String?),
+///  suite (String), test_name (String), status (String), duration_ms (Int32),
+///  retry_count (Int32), commit_sha (String), created_at_ms (Int64)
+pub fn write_test_results_parquet(
+  rows : Array[TestResultRow],
+) -> Bytes!@parquet.ParquetError {
+  let columns = [
+    @parquet.new_column("workflow_run_id", Int64, Required),
+    @parquet.new_column("test_id", String, Optional),
+    @parquet.new_column("task_id", String, Optional),
+    @parquet.new_column("suite", String, Required),
+    @parquet.new_column("test_name", String, Required),
+    @parquet.new_column("status", String, Required),
+    @parquet.new_column("duration_ms", Int32, Required),
+    @parquet.new_column("retry_count", Int32, Required),
+    @parquet.new_column("commit_sha", String, Required),
+    @parquet.new_column("created_at_ms", Int64, Required),
+  ]
+  let pq_rows : Array[Array[@parquet.Value]] = []
+  for row in rows {
+    pq_rows.push([
+      @parquet.Value::Int64(row.workflow_run_id),
+      match row.test_id {
+        Some(v) => @parquet.Value::String(v)
+        None => @parquet.Value::Null
+      },
+      match row.task_id {
+        Some(v) => @parquet.Value::String(v)
+        None => @parquet.Value::Null
+      },
+      @parquet.Value::String(row.suite),
+      @parquet.Value::String(row.test_name),
+      @parquet.Value::String(row.status),
+      @parquet.Value::Int32(row.duration_ms),
+      @parquet.Value::Int32(row.retry_count),
+      @parquet.Value::String(row.commit_sha),
+      @parquet.Value::Int64(row.created_at_ms),
+    ])
+  }
+  let file = @parquet.new_parquet_file(columns, pq_rows, Some("flaker"))
+  @parquet.write_bytes!(file)
+}
+
+///| Write commit_changes rows as Parquet bytes.
+pub fn write_commit_changes_parquet(
+  rows : Array[CommitChangeRow],
+) -> Bytes!@parquet.ParquetError {
+  let columns = [
+    @parquet.new_column("commit_sha", String, Required),
+    @parquet.new_column("file_path", String, Required),
+    @parquet.new_column("change_type", String, Optional),
+    @parquet.new_column("additions", Int32, Required),
+    @parquet.new_column("deletions", Int32, Required),
+  ]
+  let pq_rows : Array[Array[@parquet.Value]] = []
+  for row in rows {
+    pq_rows.push([
+      @parquet.Value::String(row.commit_sha),
+      @parquet.Value::String(row.file_path),
+      match row.change_type {
+        Some(v) => @parquet.Value::String(v)
+        None => @parquet.Value::Null
+      },
+      @parquet.Value::Int32(row.additions),
+      @parquet.Value::Int32(row.deletions),
+    ])
+  }
+  let file = @parquet.new_parquet_file(columns, pq_rows, Some("flaker"))
+  @parquet.write_bytes!(file)
+}
+
+///| Write workflow_runs rows as Parquet bytes.
+pub fn write_workflow_runs_parquet(
+  rows : Array[WorkflowRunRow],
+) -> Bytes!@parquet.ParquetError {
+  let columns = [
+    @parquet.new_column("id", Int64, Required),
+    @parquet.new_column("repo", String, Required),
+    @parquet.new_column("branch", String, Optional),
+    @parquet.new_column("commit_sha", String, Required),
+    @parquet.new_column("event", String, Optional),
+    @parquet.new_column("status", String, Optional),
+    @parquet.new_column("created_at_ms", Int64, Required),
+    @parquet.new_column("duration_ms", Int32, Required),
+  ]
+  let pq_rows : Array[Array[@parquet.Value]] = []
+  for row in rows {
+    pq_rows.push([
+      @parquet.Value::Int64(row.id),
+      @parquet.Value::String(row.repo),
+      match row.branch {
+        Some(v) => @parquet.Value::String(v)
+        None => @parquet.Value::Null
+      },
+      @parquet.Value::String(row.commit_sha),
+      match row.event {
+        Some(v) => @parquet.Value::String(v)
+        None => @parquet.Value::Null
+      },
+      match row.status {
+        Some(v) => @parquet.Value::String(v)
+        None => @parquet.Value::Null
+      },
+      @parquet.Value::Int64(row.created_at_ms),
+      @parquet.Value::Int32(row.duration_ms),
+    ])
+  }
+  let file = @parquet.new_parquet_file(columns, pq_rows, Some("flaker"))
+  @parquet.write_bytes!(file)
+}

--- a/src/parquet_export/parquet_export_test.mbt
+++ b/src/parquet_export/parquet_export_test.mbt
@@ -1,0 +1,91 @@
+test "write_test_results_parquet produces valid bytes" {
+  let rows = [
+    TestResultRow::{
+      workflow_run_id: 1L,
+      test_id: Some("test-id-1"),
+      task_id: Some("task-1"),
+      suite: "tests/login.spec.ts",
+      test_name: "login works",
+      status: "passed",
+      duration_ms: 150,
+      retry_count: 0,
+      commit_sha: "abc123",
+      created_at_ms: 1712100000000L,
+    },
+    TestResultRow::{
+      workflow_run_id: 1L,
+      test_id: None,
+      task_id: None,
+      suite: "tests/signup.spec.ts",
+      test_name: "signup works",
+      status: "failed",
+      duration_ms: 200,
+      retry_count: 1,
+      commit_sha: "abc123",
+      created_at_ms: 1712100000000L,
+    },
+  ]
+  let bytes = write_test_results_parquet!(rows)
+  // Parquet files start with magic bytes "PAR1"
+  assert_true!(bytes.length() > 4)
+  assert_eq!(bytes[0], b'P')
+  assert_eq!(bytes[1], b'A')
+  assert_eq!(bytes[2], b'R')
+  assert_eq!(bytes[3], b'1')
+}
+
+test "write_commit_changes_parquet produces valid bytes" {
+  let rows = [
+    CommitChangeRow::{
+      commit_sha: "abc123",
+      file_path: "src/foo.ts",
+      change_type: Some("modified"),
+      additions: 10,
+      deletions: 5,
+    },
+  ]
+  let bytes = write_commit_changes_parquet!(rows)
+  assert_true!(bytes.length() > 4)
+  assert_eq!(bytes[0], b'P')
+}
+
+test "write_workflow_runs_parquet produces valid bytes" {
+  let rows = [
+    WorkflowRunRow::{
+      id: 42L,
+      repo: "test/repo",
+      branch: Some("main"),
+      commit_sha: "abc123",
+      event: Some("push"),
+      status: Some("completed"),
+      created_at_ms: 1712100000000L,
+      duration_ms: 60000,
+    },
+  ]
+  let bytes = write_workflow_runs_parquet!(rows)
+  assert_true!(bytes.length() > 4)
+  assert_eq!(bytes[0], b'P')
+}
+
+test "round-trip: write and read test_results" {
+  let rows = [
+    TestResultRow::{
+      workflow_run_id: 1L,
+      test_id: Some("tid"),
+      task_id: Some("task"),
+      suite: "tests/a.spec.ts",
+      test_name: "test a",
+      status: "passed",
+      duration_ms: 100,
+      retry_count: 0,
+      commit_sha: "sha1",
+      created_at_ms: 1712100000000L,
+    },
+  ]
+  let bytes = write_test_results_parquet!(rows)
+  let file = @parquet.read_bytes!(bytes)
+  assert_eq!(file.row_count(), 1)
+  let row = file.rows()[0]
+  assert_eq!(row[3], @parquet.Value::String("tests/a.spec.ts"))
+  assert_eq!(row[5], @parquet.Value::String("passed"))
+}

--- a/src/parquet_export/types.mbt
+++ b/src/parquet_export/types.mbt
@@ -1,0 +1,34 @@
+///|
+pub(all) struct TestResultRow {
+  workflow_run_id : Int64
+  test_id : String?
+  task_id : String?
+  suite : String
+  test_name : String
+  status : String
+  duration_ms : Int
+  retry_count : Int
+  commit_sha : String
+  created_at_ms : Int64
+} derive(Show, FromJson, ToJson)
+
+///|
+pub(all) struct CommitChangeRow {
+  commit_sha : String
+  file_path : String
+  change_type : String?
+  additions : Int
+  deletions : Int
+} derive(Show, FromJson, ToJson)
+
+///|
+pub(all) struct WorkflowRunRow {
+  id : Int64
+  repo : String
+  branch : String?
+  commit_sha : String
+  event : String?
+  status : String?
+  created_at_ms : Int64
+  duration_ms : Int
+} derive(Show, FromJson, ToJson)

--- a/src/parquet_export/write_fixture_test.mbt
+++ b/src/parquet_export/write_fixture_test.mbt
@@ -1,0 +1,67 @@
+test "write fixture parquet files for DuckDB interop test" {
+  // Write test_results.parquet
+  let tr_rows = [
+    TestResultRow::{
+      workflow_run_id: 1L,
+      test_id: Some("tid-1"),
+      task_id: Some("task-1"),
+      suite: "tests/login.spec.ts",
+      test_name: "login works",
+      status: "passed",
+      duration_ms: 150,
+      retry_count: 0,
+      commit_sha: "abc123",
+      created_at_ms: 1712100000000L,
+    },
+    TestResultRow::{
+      workflow_run_id: 1L,
+      test_id: None,
+      task_id: None,
+      suite: "tests/signup.spec.ts",
+      test_name: "signup works",
+      status: "failed",
+      duration_ms: 200,
+      retry_count: 1,
+      commit_sha: "abc123",
+      created_at_ms: 1712100000000L,
+    },
+  ]
+  let tr_bytes = write_test_results_parquet!(tr_rows)
+  @parquet.write_file!("/tmp/flaker-test-results.parquet", @parquet.read_bytes!(tr_bytes))
+
+  // Write commit_changes.parquet
+  let cc_rows = [
+    CommitChangeRow::{
+      commit_sha: "abc123",
+      file_path: "src/foo.ts",
+      change_type: Some("modified"),
+      additions: 10,
+      deletions: 5,
+    },
+    CommitChangeRow::{
+      commit_sha: "abc123",
+      file_path: "src/bar.ts",
+      change_type: Some("added"),
+      additions: 20,
+      deletions: 0,
+    },
+  ]
+  let cc_bytes = write_commit_changes_parquet!(cc_rows)
+  @parquet.write_file!("/tmp/flaker-commit-changes.parquet", @parquet.read_bytes!(cc_bytes))
+
+  // Write workflow_runs.parquet
+  let wr_rows = [
+    WorkflowRunRow::{
+      id: 42L,
+      repo: "test/repo",
+      branch: Some("main"),
+      commit_sha: "abc123",
+      event: Some("push"),
+      status: Some("completed"),
+      created_at_ms: 1712100000000L,
+      duration_ms: 60000,
+    },
+  ]
+  let wr_bytes = write_workflow_runs_parquet!(wr_rows)
+  @parquet.write_file!("/tmp/flaker-workflow-runs.parquet", @parquet.read_bytes!(wr_bytes))
+}

--- a/tests/commands/export-parquet.test.ts
+++ b/tests/commands/export-parquet.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync, existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { DuckDBStore } from "../../src/cli/storage/duckdb.js";
+import { exportRunParquet } from "../../src/cli/commands/export-parquet.js";
+
+describe("exportRunParquet", () => {
+  let store: DuckDBStore;
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    store = new DuckDBStore(":memory:");
+    await store.initialize();
+    tmpDir = join(tmpdir(), `flaker-export-${Date.now()}`);
+    mkdirSync(tmpDir, { recursive: true });
+
+    await store.insertWorkflowRun({
+      id: 1, repo: "test/repo", branch: "main", commitSha: "sha1",
+      event: "push", status: "completed",
+      createdAt: new Date("2026-04-01"), durationMs: 60000,
+    });
+    await store.insertTestResults([{
+      workflowRunId: 1, suite: "tests/a.spec.ts", testName: "test a",
+      status: "passed", durationMs: 100, retryCount: 0, errorMessage: null,
+      commitSha: "sha1", variant: null, createdAt: new Date("2026-04-01"),
+    }]);
+    await store.insertCommitChanges("sha1", [
+      { filePath: "src/a.ts", changeType: "modified", additions: 5, deletions: 2 },
+    ]);
+  });
+
+  afterEach(async () => {
+    await store.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("exports parquet files to artifacts directory", async () => {
+    const storagePath = join(tmpDir, "flaker.db");
+    await exportRunParquet(store, 1, storagePath);
+
+    const artifactsDir = join(tmpDir, "artifacts");
+    expect(existsSync(artifactsDir)).toBe(true);
+
+    const files = readdirSync(artifactsDir);
+    expect(files.some((f) => f.includes("workflow_run"))).toBe(true);
+    expect(files.some((f) => f.includes("test_results"))).toBe(true);
+    expect(files.some((f) => f.includes("commit_changes"))).toBe(true);
+  });
+
+  it("does not throw on missing run id", async () => {
+    const storagePath = join(tmpDir, "flaker.db");
+    // Should log warning, not throw
+    await exportRunParquet(store, 999, storagePath);
+  });
+});

--- a/tests/parquet/duckdb-interop.test.ts
+++ b/tests/parquet/duckdb-interop.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { DuckDBStore } from "../../src/cli/storage/duckdb.js";
+
+describe("mizchi/parquet → DuckDB read_parquet interop", () => {
+  let store: DuckDBStore;
+
+  beforeEach(async () => {
+    store = new DuckDBStore(":memory:");
+    await store.initialize();
+  });
+
+  afterEach(async () => {
+    await store.close();
+  });
+
+  it("DuckDB reads test_results.parquet", async () => {
+    const result = await store.raw<{
+      suite: string;
+      test_name: string;
+      status: string;
+      duration_ms: number;
+      commit_sha: string;
+      retry_count: number;
+    }>(`SELECT suite, test_name, status, duration_ms::INTEGER as duration_ms, commit_sha, retry_count::INTEGER as retry_count FROM read_parquet('/tmp/flaker-test-results.parquet') ORDER BY suite`);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].suite).toBe("tests/login.spec.ts");
+    expect(result[0].test_name).toBe("login works");
+    expect(result[0].status).toBe("passed");
+    expect(result[0].duration_ms).toBe(150);
+    expect(result[1].suite).toBe("tests/signup.spec.ts");
+    expect(result[1].status).toBe("failed");
+    expect(result[1].retry_count).toBe(1);
+  });
+
+  it("DuckDB reads commit_changes.parquet", async () => {
+    const result = await store.raw<{
+      commit_sha: string;
+      file_path: string;
+      change_type: string;
+      additions: number;
+    }>(`SELECT commit_sha, file_path, change_type, additions::INTEGER as additions FROM read_parquet('/tmp/flaker-commit-changes.parquet') ORDER BY file_path`);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].file_path).toBe("src/bar.ts");
+    expect(result[0].change_type).toBe("added");
+    expect(result[0].additions).toBe(20);
+    expect(result[1].file_path).toBe("src/foo.ts");
+    expect(result[1].additions).toBe(10);
+  });
+
+  it("DuckDB reads workflow_runs.parquet", async () => {
+    const result = await store.raw<{
+      id: number;
+      repo: string;
+      branch: string;
+      commit_sha: string;
+      event: string;
+      status: string;
+    }>(`SELECT id::INTEGER as id, repo, branch, commit_sha, event, status FROM read_parquet('/tmp/flaker-workflow-runs.parquet')`);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(42);
+    expect(result[0].repo).toBe("test/repo");
+    expect(result[0].branch).toBe("main");
+    expect(result[0].event).toBe("push");
+  });
+
+  it("DuckDB can query across parquet files with JOIN", async () => {
+    const result = await store.raw<{
+      file_path: string;
+      suite: string;
+      status: string;
+    }>(`
+      SELECT cc.file_path, tr.suite, tr.status
+      FROM read_parquet('/tmp/flaker-commit-changes.parquet') cc
+      JOIN read_parquet('/tmp/flaker-test-results.parquet') tr
+        ON cc.commit_sha = tr.commit_sha
+      ORDER BY cc.file_path, tr.suite
+    `);
+
+    expect(result.length).toBeGreaterThan(0);
+    expect(result[0]).toHaveProperty("file_path");
+    expect(result[0]).toHaveProperty("suite");
+  });
+});

--- a/tests/parquet/export-import.test.ts
+++ b/tests/parquet/export-import.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { DuckDBStore } from "../../src/cli/storage/duckdb.js";
+
+describe("Parquet export and import", () => {
+  let store: DuckDBStore;
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    store = new DuckDBStore(":memory:");
+    await store.initialize();
+    tmpDir = join(tmpdir(), `flaker-parquet-${Date.now()}`);
+    mkdirSync(tmpDir, { recursive: true });
+
+    // Seed data
+    await store.insertWorkflowRun({
+      id: 1, repo: "test/repo", branch: "main", commitSha: "sha1",
+      event: "push", status: "completed",
+      createdAt: new Date("2026-04-01"), durationMs: 60000,
+    });
+    await store.insertCommitChanges("sha1", [
+      { filePath: "src/foo.ts", changeType: "modified", additions: 10, deletions: 5 },
+      { filePath: "src/bar.ts", changeType: "added", additions: 20, deletions: 0 },
+    ]);
+    await store.insertTestResults([
+      {
+        workflowRunId: 1, suite: "tests/login.spec.ts", testName: "login works",
+        status: "passed", durationMs: 150, retryCount: 0, errorMessage: null,
+        commitSha: "sha1", variant: null, createdAt: new Date("2026-04-01"),
+      },
+      {
+        workflowRunId: 1, suite: "tests/signup.spec.ts", testName: "signup works",
+        status: "failed", durationMs: 200, retryCount: 1, errorMessage: "timeout",
+        commitSha: "sha1", variant: null, createdAt: new Date("2026-04-01"),
+      },
+    ]);
+  });
+
+  afterEach(async () => {
+    await store.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("exports a workflow run to Parquet files", async () => {
+    const result = await store.exportRunToParquet(1, tmpDir);
+
+    expect(result.testResultsCount).toBe(2);
+    expect(result.commitChangesCount).toBe(2);
+    expect(existsSync(result.workflowRunPath)).toBe(true);
+    expect(existsSync(result.testResultsPath)).toBe(true);
+    expect(existsSync(result.commitChangesPath)).toBe(true);
+  });
+
+  it("round-trips data through Parquet export/import", async () => {
+    // Export
+    await store.exportRunToParquet(1, tmpDir);
+
+    // Create a fresh store and import
+    const store2 = new DuckDBStore(":memory:");
+    await store2.initialize();
+
+    const importResult = await store2.importFromParquetDir(tmpDir);
+    expect(importResult.workflowRunsImported).toBe(1);
+    expect(importResult.testResultsImported).toBe(2);
+    expect(importResult.commitChangesImported).toBe(2);
+
+    // Verify data integrity
+    const runs = await store2.raw<{ cnt: number }>(
+      "SELECT COUNT(*)::INTEGER AS cnt FROM workflow_runs",
+    );
+    expect(runs[0].cnt).toBe(1);
+
+    const tests = await store2.raw<{ suite: string; status: string }>(
+      "SELECT suite, status FROM test_results ORDER BY suite",
+    );
+    expect(tests).toHaveLength(2);
+    expect(tests[0].suite).toBe("tests/login.spec.ts");
+    expect(tests[0].status).toBe("passed");
+    expect(tests[1].status).toBe("failed");
+
+    const changes = await store2.raw<{ file_path: string }>(
+      "SELECT file_path FROM commit_changes ORDER BY file_path",
+    );
+    expect(changes).toHaveLength(2);
+    expect(changes[0].file_path).toBe("src/bar.ts");
+
+    await store2.close();
+  });
+
+  it("import skips duplicate workflow runs", async () => {
+    await store.exportRunToParquet(1, tmpDir);
+    // Import into same store (already has the data)
+    const result = await store.importFromParquetDir(tmpDir);
+    // Should not duplicate - ON CONFLICT DO NOTHING
+    const runs = await store.raw<{ cnt: number }>(
+      "SELECT COUNT(*)::INTEGER AS cnt FROM workflow_runs",
+    );
+    expect(runs[0].cnt).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `mizchi/parquet` MoonBit dependency with typed Parquet writers for test_results, commit_changes, workflow_runs
- Verify MoonBit parquet ↔ DuckDB `read_parquet()` interoperability (4 tests including JOIN)
- Add `exportRunToParquet` / `importFromParquetDir` to DuckDB store using `COPY TO` / `read_parquet()`
- Auto-export Parquet files after `collect` and `collect-local` to `.flaker/artifacts/`
- Export is non-fatal: logs warning on failure, doesn't block collection

## Architecture

```
collect/collect-local
  → INSERT into DuckDB (existing)
  → COPY TO .flaker/artifacts/*.parquet (NEW)

import (future)
  → read_parquet('.flaker/artifacts/*.parquet') → INSERT into DuckDB
```

## File layout

```
.flaker/
  artifacts/
    workflow_run_1.parquet
    test_results_1.parquet
    commit_changes_1.parquet
```

## Test plan

- [x] MoonBit parquet writers: valid PAR1 bytes, round-trip (4 tests)
- [x] DuckDB interop: read all 3 table types + cross-file JOIN (4 tests)
- [x] Export/import: round-trip, duplicate skip (3 tests)
- [x] Export helper: artifact creation, error handling (2 tests)
- [x] Full test suite: 395 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)