### PR TITLE
feat: add alpha auto-tuning for co-failure boost

### DIFF
--- a/src/cli/commands/sample.ts
+++ b/src/cli/commands/sample.ts
@@ -28,6 +28,7 @@ export interface SampleOpts {
   quarantineManifestEntries?: QuarantineManifestEntry[];
   listedTests?: TestId[];
   coFailureDays?: number;
+  coFailureAlpha?: number;
 }
 
 export interface SamplingSummary {
@@ -162,7 +163,9 @@ export async function planSample(opts: SampleOpts): Promise<SamplePlan> {
           taskId: test.task_id,
           filter: test.filter,
         });
-        const boost = boosts.get(key) ?? 0;
+        const rawBoost = boosts.get(key) ?? 0;
+        const alpha = opts.coFailureAlpha ?? 1.0;
+        const boost = rawBoost * alpha;
         return boost > 0 ? { ...test, co_failure_boost: boost } : test;
       });
     }

--- a/src/cli/eval/alpha-tuner.ts
+++ b/src/cli/eval/alpha-tuner.ts
@@ -1,0 +1,122 @@
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import type { MetricStore } from "../storage/types.js";
+import { planSample } from "../commands/sample.js";
+import type { DependencyResolver } from "../resolvers/types.js";
+
+export interface TuningConfig {
+  alpha: number;
+}
+
+export interface TuningResult {
+  alpha: number;
+  recall: number;
+  precision: number;
+  f1: number;
+}
+
+const DEFAULT_TUNING: TuningConfig = { alpha: 1.0 };
+
+export function loadTuningConfig(storagePath: string): TuningConfig {
+  const tuningPath = resolve(dirname(storagePath), "models", "tuning.json");
+  if (!existsSync(tuningPath)) {
+    return DEFAULT_TUNING;
+  }
+  try {
+    return JSON.parse(readFileSync(tuningPath, "utf8"));
+  } catch {
+    return DEFAULT_TUNING;
+  }
+}
+
+export function saveTuningConfig(storagePath: string, config: TuningConfig): void {
+  const modelsDir = resolve(dirname(storagePath), "models");
+  mkdirSync(modelsDir, { recursive: true });
+  const tuningPath = join(modelsDir, "tuning.json");
+  writeFileSync(tuningPath, JSON.stringify(config, null, 2));
+}
+
+interface TuneAlphaOpts {
+  store: MetricStore;
+  changedFilesPerCommit: Map<string, string[]>;
+  groundTruth: Map<string, Set<string>>; // commit_sha -> set of failed suites
+  allTestSuites: string[];
+  sampleCount: number;
+  resolver?: DependencyResolver;
+  alphaValues?: number[];
+}
+
+export async function tuneAlpha(opts: TuneAlphaOpts): Promise<TuningResult[]> {
+  const alphas = opts.alphaValues ?? [0, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0];
+  const commits = [...opts.changedFilesPerCommit.entries()];
+  const results: TuningResult[] = [];
+
+  for (const alpha of alphas) {
+    let totalFailures = 0;
+    let detectedFailures = 0;
+    let totalSampled = 0;
+    let totalSampledFailures = 0;
+
+    for (const [commitSha, changedFiles] of commits) {
+      const failedSuites = opts.groundTruth.get(commitSha) ?? new Set();
+
+      const plan = await planSample({
+        store: opts.store,
+        count: opts.sampleCount,
+        mode: opts.resolver ? "hybrid" : "weighted",
+        seed: 42,
+        changedFiles,
+        resolver: opts.resolver,
+        coFailureAlpha: alpha,
+      });
+
+      const sampledSuites = new Set(plan.sampled.map((t) => t.suite));
+
+      totalFailures += failedSuites.size;
+      for (const suite of failedSuites) {
+        if (sampledSuites.has(suite)) detectedFailures++;
+      }
+      totalSampled += plan.sampled.length;
+      for (const t of plan.sampled) {
+        if (failedSuites.has(t.suite)) totalSampledFailures++;
+      }
+    }
+
+    const recall = totalFailures > 0 ? detectedFailures / totalFailures : 1;
+    const precision = totalSampled > 0 ? totalSampledFailures / totalSampled : 0;
+    const f1 = recall + precision > 0 ? (2 * recall * precision) / (recall + precision) : 0;
+
+    results.push({
+      alpha,
+      recall: Math.round(recall * 1000) / 1000,
+      precision: Math.round(precision * 1000) / 1000,
+      f1: Math.round(f1 * 1000) / 1000,
+    });
+  }
+
+  return results;
+}
+
+export function findBestAlpha(results: TuningResult[]): TuningResult {
+  return results.reduce((best, r) => (r.f1 > best.f1 ? r : best), results[0]);
+}
+
+export function formatTuningReport(results: TuningResult[]): string {
+  const best = findBestAlpha(results);
+  const lines = [
+    "# Alpha Tuning Results",
+    "",
+    "| Alpha  | Recall | Precision | F1     |",
+    "|--------|--------|-----------|--------|",
+  ];
+
+  for (const r of results) {
+    const marker = r.alpha === best.alpha ? " *" : "";
+    lines.push(
+      `| ${r.alpha.toFixed(2).padEnd(6)} | ${(r.recall * 100).toFixed(1).padStart(5)}% | ${(r.precision * 100).toFixed(1).padStart(8)}% | ${r.f1.toFixed(3).padStart(6)} |${marker}`,
+    );
+  }
+
+  lines.push("", `Best alpha: ${best.alpha} (F1=${best.f1.toFixed(3)})`);
+  return lines.join("\n");
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -28,6 +28,15 @@ import {
 import { ActrunRunner } from "./runners/actrun.js";
 import { runBisect } from "./commands/bisect.js";
 import { runImport } from "./commands/import.js";
+import { loadTuningConfig, type TuningConfig } from "./eval/alpha-tuner.js";
+
+function loadTuningConfigSafe(storagePath: string): TuningConfig {
+  try {
+    return loadTuningConfig(storagePath);
+  } catch {
+    return { alpha: 1.0 };
+  }
+}
 import { runCollectLocal } from "./commands/collect-local.js";
 import { runQuery, formatQueryResult } from "./commands/query.js";
 import {
@@ -413,6 +422,7 @@ program
           quarantineManifestEntries: manifest?.entries,
           listedTests,
           coFailureDays: opts.coFailureDays ? parseInt(opts.coFailureDays, 10) : undefined,
+          coFailureAlpha: loadTuningConfigSafe(config.storage.path).alpha,
         });
         await recordSamplingRunFromSummary(store, {
           commitSha: resolveCurrentCommitSha(process.cwd()),
@@ -1164,6 +1174,86 @@ program
       await loadFixtureIntoStore(store, fixture);
       const results = await evaluateFixture(store, fixture);
       console.log(formatEvalFixtureReport({ config: baseConfig, results }));
+      await store.close();
+    }
+  });
+
+// --- tune ---
+program
+  .command("tune")
+  .description("Auto-tune co-failure alpha parameter using historical data")
+  .option("--window <days>", "Analysis window in days", "90")
+  .option("--sample-percentage <n>", "Sample percentage for evaluation", "20")
+  .option("--dry-run", "Show results without saving")
+  .action(async (opts) => {
+    const config = loadConfig(process.cwd());
+    const store = new DuckDBStore(resolve(config.storage.path));
+    await store.initialize();
+
+    try {
+      const windowDays = parseInt(opts.window, 10);
+      const samplePercentage = parseInt(opts.samplePercentage, 10);
+
+      // Get recent commits with changed files and test results
+      const commits = await store.raw<{
+        commit_sha: string;
+      }>(`SELECT DISTINCT commit_sha FROM test_results
+          WHERE created_at > CURRENT_TIMESTAMP - INTERVAL '${windowDays} days'
+          ORDER BY commit_sha`);
+
+      if (commits.length < 5) {
+        console.log("Not enough data for tuning (need at least 5 commits with test results)");
+        return;
+      }
+
+      const changedFilesPerCommit = new Map<string, string[]>();
+      const groundTruth = new Map<string, Set<string>>();
+
+      for (const { commit_sha } of commits) {
+        const changes = await store.raw<{ file_path: string }>(
+          `SELECT file_path FROM commit_changes WHERE commit_sha = ?`,
+          [commit_sha],
+        );
+        if (changes.length === 0) continue;
+        changedFilesPerCommit.set(commit_sha, changes.map((c) => c.file_path));
+
+        const failures = await store.raw<{ suite: string }>(
+          `SELECT DISTINCT suite FROM test_results
+           WHERE commit_sha = ? AND status IN ('failed', 'flaky')`,
+          [commit_sha],
+        );
+        groundTruth.set(commit_sha, new Set(failures.map((f) => f.suite)));
+      }
+
+      if (changedFilesPerCommit.size < 3) {
+        console.log("Not enough commits with change data for tuning");
+        return;
+      }
+
+      const allSuites = await store.raw<{ suite: string }>(
+        `SELECT DISTINCT suite FROM test_results`,
+      );
+      const sampleCount = Math.round(allSuites.length * (samplePercentage / 100));
+
+      const { tuneAlpha, findBestAlpha, formatTuningReport, saveTuningConfig } =
+        await import("./eval/alpha-tuner.js");
+
+      const results = await tuneAlpha({
+        store,
+        changedFilesPerCommit,
+        groundTruth,
+        allTestSuites: allSuites.map((s) => s.suite),
+        sampleCount,
+      });
+
+      console.log(formatTuningReport(results));
+
+      if (!opts.dryRun) {
+        const best = findBestAlpha(results);
+        saveTuningConfig(config.storage.path, { alpha: best.alpha });
+        console.log(`\nSaved alpha=${best.alpha} to .flaker/models/tuning.json`);
+      }
+    } finally {
       await store.close();
     }
   });

--- a/tests/eval/alpha-tuner.test.ts
+++ b/tests/eval/alpha-tuner.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { DuckDBStore } from "../../src/cli/storage/duckdb.js";
+import { generateFixture } from "../../src/cli/eval/fixture-generator.js";
+import { loadFixtureIntoStore } from "../../src/cli/eval/fixture-loader.js";
+import {
+  tuneAlpha,
+  findBestAlpha,
+  formatTuningReport,
+  loadTuningConfig,
+  saveTuningConfig,
+} from "../../src/cli/eval/alpha-tuner.js";
+
+describe("alpha tuner", () => {
+  let store: DuckDBStore;
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    store = new DuckDBStore(":memory:");
+    await store.initialize();
+    tmpDir = join(tmpdir(), `flaker-tune-${Date.now()}`);
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await store.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("tunes alpha over grid of values", async () => {
+    const fixture = generateFixture({
+      testCount: 30,
+      commitCount: 20,
+      flakyRate: 0.1,
+      coFailureStrength: 0.8,
+      filesPerCommit: 2,
+      testsPerFile: 5,
+      samplePercentage: 30,
+      seed: 42,
+    });
+    await loadFixtureIntoStore(store, fixture);
+
+    // Build ground truth from last 25% of commits
+    const evalStart = Math.floor(fixture.commits.length * 0.75);
+    const evalCommits = fixture.commits.slice(evalStart);
+
+    const changedFilesPerCommit = new Map<string, string[]>();
+    const groundTruth = new Map<string, Set<string>>();
+    for (const commit of evalCommits) {
+      changedFilesPerCommit.set(commit.sha, commit.changedFiles.map((f) => f.filePath));
+      groundTruth.set(
+        commit.sha,
+        new Set(commit.testResults.filter((r) => r.status === "failed").map((r) => r.suite)),
+      );
+    }
+
+    const results = await tuneAlpha({
+      store,
+      changedFilesPerCommit,
+      groundTruth,
+      allTestSuites: fixture.tests.map((t) => t.suite),
+      sampleCount: Math.round(fixture.tests.length * 0.3),
+      alphaValues: [0, 0.5, 1.0, 2.0],
+    });
+
+    expect(results).toHaveLength(4);
+    for (const r of results) {
+      expect(r.recall).toBeGreaterThanOrEqual(0);
+      expect(r.recall).toBeLessThanOrEqual(1);
+      expect(r.f1).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("findBestAlpha picks highest F1", () => {
+    const results = [
+      { alpha: 0, recall: 0.2, precision: 0.1, f1: 0.13 },
+      { alpha: 1, recall: 0.5, precision: 0.3, f1: 0.375 },
+      { alpha: 2, recall: 0.4, precision: 0.2, f1: 0.267 },
+    ];
+    const best = findBestAlpha(results);
+    expect(best.alpha).toBe(1);
+  });
+
+  it("saves and loads tuning config", () => {
+    const storagePath = join(tmpDir, "flaker.db");
+    saveTuningConfig(storagePath, { alpha: 2.5 });
+
+    const modelsDir = join(tmpDir, "models");
+    expect(existsSync(join(modelsDir, "tuning.json"))).toBe(true);
+
+    const loaded = loadTuningConfig(storagePath);
+    expect(loaded.alpha).toBe(2.5);
+  });
+
+  it("loadTuningConfig returns default when file missing", () => {
+    const loaded = loadTuningConfig(join(tmpDir, "nonexistent.db"));
+    expect(loaded.alpha).toBe(1.0);
+  });
+
+  it("formatTuningReport marks best alpha", () => {
+    const results = [
+      { alpha: 0, recall: 0.2, precision: 0.1, f1: 0.13 },
+      { alpha: 1, recall: 0.5, precision: 0.3, f1: 0.375 },
+    ];
+    const report = formatTuningReport(results);
+    expect(report).toContain("Alpha Tuning Results");
+    expect(report).toContain("Best alpha: 1");
+    expect(report).toContain("*");
+  });
+});


### PR DESCRIPTION
## Summary

- Add `coFailureAlpha` parameter to `SampleOpts` — scales `co_failure_boost` by α before applying
- Add `flaker tune` CLI command — grid searches α values using historical data
- Auto-save best α to `.flaker/models/tuning.json`, auto-load during `flaker sample`
- Grid search: α ∈ {0, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0}, optimize for F1 score

## Usage

```bash
# Auto-tune from historical data
flaker tune --window 90 --sample-percentage 20

# Dry run (show results without saving)
flaker tune --dry-run

# Sample automatically uses tuned alpha
flaker sample --strategy weighted --changed src/foo.ts
```

## Test plan

- [x] Grid search over alpha values (5 tests)
- [x] findBestAlpha picks highest F1
- [x] Save/load tuning config
- [x] Default config when file missing
- [x] Report formatting
- [x] Full test suite: 400 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)