### PR TITLE
fix: CLI UX improvements from subagent evaluation (3 rounds)

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -94,8 +94,20 @@ export async function runDoctor(cwd: string, deps?: Partial<DoctorDeps>): Promis
   };
 }
 
+const REMEDIATION: Record<string, string> = {
+  config: "Run 'flaker init --owner <org> --name <repo>' to create one",
+  duckdb: "Run 'pnpm rebuild duckdb' or 'npm rebuild duckdb'",
+  moonbit: "Install MoonBit from https://moonbitlang.com (optional, fallback available)",
+};
+
 export function formatDoctorReport(report: DoctorReport): string {
-  const lines = report.checks.map((c) => `${c.ok ? "OK" : "NG"} ${c.name}: ${c.detail}`);
+  const lines: string[] = [];
+  for (const c of report.checks) {
+    lines.push(`${c.ok ? "OK" : "NG"}  ${c.name.padEnd(10)}${c.detail}`);
+    if (!c.ok && REMEDIATION[c.name]) {
+      lines.push(`              → ${REMEDIATION[c.name]}`);
+    }
+  }
   lines.push("");
   lines.push(report.ok ? "Doctor checks passed." : "Doctor checks failed.");
   return lines.join("\n");

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -58,7 +58,7 @@ export function loadConfig(dir: string): FlakerConfig {
   try {
     content = readFileSync(filePath, "utf-8");
   } catch {
-    throw new Error(`Config file not found: ${filePath}`);
+    throw new Error(`Config file not found: ${filePath}. Run 'flaker init' to create one.`);
   }
   const parsed = parse(content) as unknown as Record<string, unknown>;
   return deepMerge(DEFAULT_CONFIG, parsed);

--- a/src/cli/eval/fixture-report.ts
+++ b/src/cli/eval/fixture-report.ts
@@ -56,5 +56,6 @@ export function formatSweepReport(reports: EvalFixtureReport[]): string {
     );
   }
 
+  lines.push("", `Gain = recall improvement of best strategy over Random.`);
   return lines.join("\n");
 }

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -658,7 +658,10 @@ program
 // --- report ---
 const reportCommand = program
   .command("report")
-  .description("Summarize and diff normalized test reports");
+  .description("Summarize and diff normalized test reports")
+  .action(() => {
+    reportCommand.outputHelp();
+  });
 
 reportCommand
   .command("summarize")
@@ -1132,16 +1135,31 @@ program
   .option("--seed <n>", "Random seed", "42")
   .option("--sweep", "Sweep co-failure strength 0.0-1.0")
   .action(async (opts) => {
-    const baseConfig = {
-      testCount: parseInt(opts.tests, 10),
-      commitCount: parseInt(opts.commits, 10),
-      flakyRate: parseFloat(opts.flakyRate),
-      coFailureStrength: parseFloat(opts.coFailureStrength),
-      filesPerCommit: parseInt(opts.filesPerCommit, 10),
-      testsPerFile: parseInt(opts.testsPerFile, 10),
-      samplePercentage: parseInt(opts.samplePercentage, 10),
-      seed: parseInt(opts.seed, 10),
-    };
+    // Validate inputs
+    const testCount = parseInt(opts.tests, 10);
+    const commitCount = parseInt(opts.commits, 10);
+    const flakyRate = parseFloat(opts.flakyRate);
+    const coFailureStrength = parseFloat(opts.coFailureStrength);
+    const filesPerCommit = parseInt(opts.filesPerCommit, 10);
+    const testsPerFile = parseInt(opts.testsPerFile, 10);
+    const samplePercentage = parseInt(opts.samplePercentage, 10);
+    const seed = parseInt(opts.seed, 10);
+
+    const errors: string[] = [];
+    if (!Number.isFinite(testCount) || testCount < 1) errors.push("--tests must be a positive integer");
+    if (!Number.isFinite(commitCount) || commitCount < 1) errors.push("--commits must be a positive integer");
+    if (!Number.isFinite(flakyRate) || flakyRate < 0 || flakyRate > 1) errors.push("--flaky-rate must be between 0 and 1");
+    if (!Number.isFinite(coFailureStrength) || coFailureStrength < 0 || coFailureStrength > 1) errors.push("--co-failure-strength must be between 0 and 1");
+    if (!Number.isFinite(filesPerCommit) || filesPerCommit < 1) errors.push("--files-per-commit must be a positive integer");
+    if (!Number.isFinite(testsPerFile) || testsPerFile < 1) errors.push("--tests-per-file must be a positive integer");
+    if (!Number.isFinite(samplePercentage) || samplePercentage < 1 || samplePercentage > 100) errors.push("--sample-percentage must be between 1 and 100");
+    if (!Number.isFinite(seed)) errors.push("--seed must be an integer");
+    if (errors.length > 0) {
+      console.error(errors.join("\n"));
+      process.exit(1);
+    }
+
+    const baseConfig = { testCount, commitCount, flakyRate, coFailureStrength, filesPerCommit, testsPerFile, samplePercentage, seed };
 
     if (opts.sweep) {
       const strengths = [0.0, 0.25, 0.5, 0.75, 1.0];

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1195,11 +1195,29 @@ program
     "flaker sample --strategy affected --changed src/foo.ts",
     "flaker sample --strategy weighted --percentage 20 --skip-quarantined",
   ]);
+  appendHelpText(
+    program.commands.find((command) => command.name() === "sample") as Command,
+    formatHelpExamples("Strategies", [
+      "random    Select tests uniformly at random",
+      "weighted  Prioritize tests with high flaky rates and co-failure correlation",
+      "affected  Select only tests related to changed files (requires --changed)",
+      "hybrid    Combine affected + co-failure + previously-failed + weighted fill (recommended)",
+    ]),
+  );
   appendExamplesToCommand(program.commands.find((command) => command.name() === "run"), [
     "flaker run --strategy hybrid --count 25",
     "flaker run --strategy affected --changed src/foo.ts",
     "flaker run --runner actrun --strategy hybrid --count 50",
   ]);
+  appendHelpText(
+    program.commands.find((command) => command.name() === "run") as Command,
+    formatHelpExamples("Strategies", [
+      "random    Select tests uniformly at random",
+      "weighted  Prioritize tests with high flaky rates and co-failure correlation",
+      "affected  Select only tests related to changed files (requires --changed)",
+      "hybrid    Combine affected + co-failure + previously-failed + weighted fill (recommended)",
+    ]),
+  );
   appendExamplesToCommand(program.commands.find((command) => command.name() === "affected"), [
     "flaker affected src/foo.ts src/bar.ts",
     "flaker affected --changed src/foo.ts,src/bar.ts",
@@ -1244,6 +1262,14 @@ program
   appendExamplesToCommand(program.commands.find((command) => command.name() === "doctor"), [
     "flaker doctor",
   ]);
+  appendExamplesToCommand(program.commands.find((command) => command.name() === "eval-fixture"), [
+    "flaker eval-fixture",
+    "flaker eval-fixture --sweep",
+  ]);
+  appendHelpText(
+    program.commands.find((command) => command.name() === "eval-fixture") as Command,
+    `\nRuns synthetic benchmarks comparing sampling strategies. No config needed.\nOutput: a comparison table showing recall, precision, F1, and efficiency.\nUse --sweep to compare across different co-failure correlation strengths.\n`,
+  );
 
   return program;
 }
@@ -1251,5 +1277,26 @@ program
 const program = createProgram();
 
 if (isDirectCliExecution()) {
-  program.parse();
+  if (process.argv.length <= 2) {
+    program.outputHelp();
+    process.exit(0);
+  }
+
+  program.parseAsync(process.argv).catch((err) => {
+    if (err instanceof Error) {
+      if (err.message.includes("Config file not found") || err.message.includes("flaker.toml")) {
+        console.error(`Error: ${err.message}`);
+        console.error(`Run 'flaker init --owner <org> --name <repo>' to create one.`);
+        process.exit(1);
+      }
+      if (err.message.includes("DuckDB") || err.message.includes("duckdb")) {
+        console.error(`Error: ${err.message}`);
+        console.error(`Run 'flaker doctor' to check your setup.`);
+        process.exit(1);
+      }
+    }
+    // Unknown error - show message without full stack
+    console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  });
 }


### PR DESCRIPTION
## Summary

Three rounds of subagent UX evaluation identified and fixed 8 issues.

### Round 1 (Critical)
- Config errors now show friendly messages instead of stack traces
- Sampling strategy descriptions added to `sample --help` and `run --help`
- `doctor` command now shows remediation hints for NG checks

### Round 2 (High/Medium)
- `eval-fixture` validates all numeric inputs (NaN, negative, out of range)
- `report` with no subcommand exits 0 (was 1)
- Sweep table "Gain" column explained in footer

### Round 3 (Verification)
- All fixes verified. Score improved from ~5/10 to **8.5/10**
- Remaining: minor `report summarize` inconsistencies (not blocking)

## Test plan

- [x] Full test suite: 395 tests passing, no regressions
- [x] Manual verification of all error paths by subagent evaluator

🤖 Generated with [Claude Code](https://claude.com/claude-code)