### PR TITLE
feat: add flaker context command for LLM-assisted strategy selection

### DIFF
--- a/src/cli/commands/context.ts
+++ b/src/cli/commands/context.ts
@@ -1,0 +1,187 @@
+import { existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import type { MetricStore } from "../storage/types.js";
+
+export interface FlakerContext {
+  environment: {
+    testCount: number;
+    uniqueSuites: number;
+    commitHistory: number;
+    commitsWithChanges: number;
+    resolverConfigured: boolean;
+    coverageDataAvailable: boolean;
+    gbdtModelAvailable: boolean;
+    coFailureDataPoints: number;
+    tunedAlpha: number | null;
+    oldestDataDays: number | null;
+    newestDataDays: number | null;
+  };
+  strategies: {
+    [name: string]: {
+      requires: string[];
+      characteristics: string[];
+    };
+  };
+}
+
+export async function buildContext(
+  store: MetricStore,
+  opts: {
+    storagePath: string;
+    resolverConfigured: boolean;
+  },
+): Promise<FlakerContext> {
+  const modelsDir = resolve(dirname(opts.storagePath), "models");
+  const gbdtModelAvailable = existsSync(resolve(modelsDir, "gbdt.json"));
+  let tunedAlpha: number | null = null;
+  try {
+    const tuningPath = resolve(modelsDir, "tuning.json");
+    if (existsSync(tuningPath)) {
+      const { readFileSync } = await import("node:fs");
+      tunedAlpha = JSON.parse(readFileSync(tuningPath, "utf8")).alpha ?? null;
+    }
+  } catch {}
+
+  const [testCount] = await store.raw<{ cnt: number }>(
+    "SELECT COUNT(*)::INTEGER AS cnt FROM test_results",
+  );
+  const [suiteCount] = await store.raw<{ cnt: number }>(
+    "SELECT COUNT(DISTINCT suite)::INTEGER AS cnt FROM test_results",
+  );
+  const [commitCount] = await store.raw<{ cnt: number }>(
+    "SELECT COUNT(DISTINCT commit_sha)::INTEGER AS cnt FROM test_results",
+  );
+  const [changesCount] = await store.raw<{ cnt: number }>(
+    "SELECT COUNT(DISTINCT commit_sha)::INTEGER AS cnt FROM commit_changes",
+  );
+  const [coFailureCount] = await store.raw<{ cnt: number }>(
+    `SELECT COUNT(*)::INTEGER AS cnt FROM (
+       SELECT cc.file_path, tr.test_id
+       FROM commit_changes cc
+       JOIN test_results tr ON cc.commit_sha = tr.commit_sha
+       WHERE tr.status IN ('failed', 'flaky') OR (tr.retry_count > 0 AND tr.status = 'passed')
+       GROUP BY cc.file_path, tr.test_id
+       HAVING COUNT(*) >= 2
+     )`,
+  );
+
+  let oldestDays: number | null = null;
+  let newestDays: number | null = null;
+  try {
+    const [dateRange] = await store.raw<{ oldest: number; newest: number }>(
+      `SELECT
+        DATEDIFF('day', MIN(created_at), CURRENT_TIMESTAMP)::INTEGER AS oldest,
+        DATEDIFF('day', MAX(created_at), CURRENT_TIMESTAMP)::INTEGER AS newest
+       FROM test_results
+       WHERE created_at IS NOT NULL`,
+    );
+    if (dateRange) {
+      oldestDays = dateRange.oldest;
+      newestDays = dateRange.newest;
+    }
+  } catch {}
+
+  return {
+    environment: {
+      testCount: testCount.cnt,
+      uniqueSuites: suiteCount.cnt,
+      commitHistory: commitCount.cnt,
+      commitsWithChanges: changesCount.cnt,
+      resolverConfigured: opts.resolverConfigured,
+      coverageDataAvailable: false, // future: check for coverage data
+      gbdtModelAvailable,
+      coFailureDataPoints: coFailureCount.cnt,
+      tunedAlpha,
+      oldestDataDays: oldestDays,
+      newestDataDays: newestDays,
+    },
+    strategies: {
+      random: {
+        requires: [],
+        characteristics: [
+          "No dependencies, works immediately",
+          "Recall scales linearly with sample percentage",
+          "Baseline for comparison — efficiency always ~1.0",
+        ],
+      },
+      weighted: {
+        requires: [],
+        characteristics: [
+          "Prioritizes tests with higher flaky rates",
+          "Slightly better than random when flaky tests exist",
+          "No dependency on changed files",
+        ],
+      },
+      "weighted+co-failure": {
+        requires: ["commit_changes data (auto-collected)"],
+        characteristics: [
+          "Adds co-failure correlation to weighted scoring",
+          "Requires --changed flag with list of changed files",
+          "Improvement depends on co-failure data quality",
+        ],
+      },
+      hybrid: {
+        requires: ["resolver configuration in flaker.toml"],
+        characteristics: [
+          "Deterministic priority tiers: affected → co-failure → previously_failed → new → weighted",
+          "Highest recall in benchmarks (92-94% at 20% sample)",
+          "Requires dependency resolver (workspace/glob/bitflow)",
+          "Most effective with --changed flag",
+        ],
+      },
+      "coverage-guided": {
+        requires: ["coverage data collection (not yet implemented)"],
+        characteristics: [
+          "Greedy set cover maximizing changed-edge coverage",
+          "Very high precision (tests selected are always relevant)",
+          "Lower recall than hybrid (misses flaky failures)",
+          "Best used as component within hybrid, not standalone",
+        ],
+      },
+      gbdt: {
+        requires: ["trained model in .flaker/models/gbdt.json (not yet integrated)"],
+        characteristics: [
+          "ML-based: learns from historical test/file/failure patterns",
+          "No resolver needed — 71-90% recall depending on data volume",
+          "Outperforms hybrid when co-failure correlation is moderate",
+          "Degrades with insufficient training data (<50 commits)",
+        ],
+      },
+    },
+  };
+}
+
+export function formatContext(ctx: FlakerContext): string {
+  const env = ctx.environment;
+  const lines = [
+    "# Flaker Context",
+    "",
+    "## Environment",
+    `  Test results:          ${env.testCount}`,
+    `  Unique suites:         ${env.uniqueSuites}`,
+    `  Commit history:        ${env.commitHistory}`,
+    `  Commits with changes:  ${env.commitsWithChanges}`,
+    `  Co-failure data points: ${env.coFailureDataPoints}`,
+    `  Resolver configured:   ${env.resolverConfigured}`,
+    `  GBDT model available:  ${env.gbdtModelAvailable}`,
+    `  Coverage data:         ${env.coverageDataAvailable}`,
+    `  Tuned alpha:           ${env.tunedAlpha ?? "not tuned"}`,
+    `  Data range:            ${env.oldestDataDays != null ? `${env.oldestDataDays}d ago — ${env.newestDataDays}d ago` : "no data"}`,
+    "",
+    "## Available Strategies",
+  ];
+
+  for (const [name, info] of Object.entries(ctx.strategies)) {
+    const available = info.requires.length === 0 ||
+      info.requires.every((r) => !r.includes("not yet"));
+    lines.push(``, `### ${name} ${available ? "" : "(unavailable)"}`);
+    if (info.requires.length > 0) {
+      lines.push(`  Requires: ${info.requires.join(", ")}`);
+    }
+    for (const c of info.characteristics) {
+      lines.push(`  - ${c}`);
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1276,6 +1276,34 @@ program
     }
   });
 
+// --- context ---
+program
+  .command("context")
+  .description("Show environment data and strategy characteristics for decision-making")
+  .option("--json", "Output as JSON for programmatic consumption")
+  .action(async (opts) => {
+    const config = loadConfig(process.cwd());
+    const store = new DuckDBStore(resolve(config.storage.path));
+    await store.initialize();
+
+    try {
+      const hasResolver = !!(config as any).affected;
+      const { buildContext, formatContext } = await import("./commands/context.js");
+      const ctx = await buildContext(store, {
+        storagePath: config.storage.path,
+        resolverConfigured: hasResolver,
+      });
+
+      if (opts.json) {
+        console.log(JSON.stringify(ctx, null, 2));
+      } else {
+        console.log(formatContext(ctx));
+      }
+    } finally {
+      await store.close();
+    }
+  });
+
 // --- doctor ---
 program
   .command("doctor")
@@ -1369,6 +1397,10 @@ program
   ]);
   appendExamplesToCommand(program.commands.find((command) => command.name() === "doctor"), [
     "flaker doctor",
+  ]);
+  appendExamplesToCommand(program.commands.find((command) => command.name() === "context"), [
+    "flaker context",
+    "flaker context --json",
   ]);
   appendExamplesToCommand(program.commands.find((command) => command.name() === "eval-fixture"), [
     "flaker eval-fixture",

--- a/tests/commands/context.test.ts
+++ b/tests/commands/context.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { DuckDBStore } from "../../src/cli/storage/duckdb.js";
+import { buildContext, formatContext } from "../../src/cli/commands/context.js";
+
+describe("flaker context", () => {
+  let store: DuckDBStore;
+
+  beforeEach(async () => {
+    store = new DuckDBStore(":memory:");
+    await store.initialize();
+  });
+
+  afterEach(async () => {
+    await store.close();
+  });
+
+  it("returns empty context for fresh store", async () => {
+    const ctx = await buildContext(store, {
+      storagePath: "/tmp/nonexistent/flaker.db",
+      resolverConfigured: false,
+    });
+
+    expect(ctx.environment.testCount).toBe(0);
+    expect(ctx.environment.commitHistory).toBe(0);
+    expect(ctx.environment.coFailureDataPoints).toBe(0);
+    expect(ctx.environment.resolverConfigured).toBe(false);
+    expect(ctx.environment.gbdtModelAvailable).toBe(false);
+  });
+
+  it("reflects data after insertion", async () => {
+    await store.insertWorkflowRun({
+      id: 1, repo: "test/repo", branch: "main", commitSha: "sha1",
+      event: "push", status: "completed",
+      createdAt: new Date(), durationMs: 60000,
+    });
+    await store.insertTestResults([
+      {
+        workflowRunId: 1, suite: "tests/a.spec.ts", testName: "test a",
+        status: "failed", durationMs: 100, retryCount: 0, errorMessage: "err",
+        commitSha: "sha1", variant: null, createdAt: new Date(),
+      },
+      {
+        workflowRunId: 1, suite: "tests/b.spec.ts", testName: "test b",
+        status: "passed", durationMs: 100, retryCount: 0, errorMessage: null,
+        commitSha: "sha1", variant: null, createdAt: new Date(),
+      },
+    ]);
+    await store.insertCommitChanges("sha1", [
+      { filePath: "src/foo.ts", changeType: "modified", additions: 5, deletions: 2 },
+    ]);
+
+    const ctx = await buildContext(store, {
+      storagePath: "/tmp/nonexistent/flaker.db",
+      resolverConfigured: true,
+    });
+
+    expect(ctx.environment.testCount).toBe(2);
+    expect(ctx.environment.uniqueSuites).toBe(2);
+    expect(ctx.environment.commitHistory).toBe(1);
+    expect(ctx.environment.commitsWithChanges).toBe(1);
+    expect(ctx.environment.resolverConfigured).toBe(true);
+  });
+
+  it("lists all 6 strategies with characteristics", async () => {
+    const ctx = await buildContext(store, {
+      storagePath: "/tmp/nonexistent/flaker.db",
+      resolverConfigured: false,
+    });
+
+    expect(Object.keys(ctx.strategies)).toHaveLength(6);
+    expect(ctx.strategies.random).toBeDefined();
+    expect(ctx.strategies.hybrid).toBeDefined();
+    expect(ctx.strategies.gbdt).toBeDefined();
+
+    // Each strategy has characteristics
+    for (const [, info] of Object.entries(ctx.strategies)) {
+      expect(info.characteristics.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("formats readable text output", async () => {
+    const ctx = await buildContext(store, {
+      storagePath: "/tmp/nonexistent/flaker.db",
+      resolverConfigured: false,
+    });
+
+    const output = formatContext(ctx);
+    expect(output).toContain("Flaker Context");
+    expect(output).toContain("Environment");
+    expect(output).toContain("Available Strategies");
+    expect(output).toContain("random");
+    expect(output).toContain("hybrid");
+  });
+
+  it("JSON output is serializable", async () => {
+    const ctx = await buildContext(store, {
+      storagePath: "/tmp/nonexistent/flaker.db",
+      resolverConfigured: false,
+    });
+
+    const json = JSON.stringify(ctx);
+    const parsed = JSON.parse(json);
+    expect(parsed.environment.testCount).toBe(0);
+    expect(parsed.strategies.random.characteristics).toBeInstanceOf(Array);
+  });
+});


### PR DESCRIPTION
## Summary

Add `flaker context` command that outputs environment data and strategy characteristics for LLM-based decision making.

## Design

The command provides **facts and properties only, no recommendations**. This avoids biasing the LLM's judgment — it receives the data and decides the strategy itself.

### Text output
```
# Flaker Context

## Environment
  Test results:          2000
  Unique suites:         150
  Commit history:        200
  Commits with changes:  180
  Co-failure data points: 758
  Resolver configured:   true
  GBDT model available:  false
  ...

## Available Strategies

### random
  - No dependencies, works immediately
  - Recall scales linearly with sample percentage

### hybrid
  Requires: resolver configuration in flaker.toml
  - Deterministic priority tiers: affected → co-failure → ...
  - Highest recall in benchmarks (92-94% at 20% sample)
```

### JSON output (`--json`)
```json
{
  "environment": { "testCount": 2000, "resolverConfigured": true, ... },
  "strategies": {
    "random": { "requires": [], "characteristics": ["..."] },
    "hybrid": { "requires": ["resolver configuration"], "characteristics": ["..."] }
  }
}
```

## Test plan

- [x] Empty store context (5 tests)
- [x] Data-populated context
- [x] All 6 strategies listed with characteristics
- [x] Text formatting
- [x] JSON serialization
- [x] Full suite: 410 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)