### PR TITLE
Add flaker management skill and quickstart docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "flaker",
-      "description": "Set up @mizchi/flaker on a new repository. Includes the flaker-setup skill which encodes the Day 0 → Week 4 onboarding flow.",
+      "description": "Introduce and operate @mizchi/flaker on OSS repositories. Includes flaker-setup for onboarding and flaker-management for advisory rollout, CI promotion, quarantine, and Playwright E2E/VRT operations.",
       "version": "0.3.0",
       "source": "./",
       "author": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flaker",
   "version": "0.3.0",
-  "description": "Claude Code skill for setting up @mizchi/flaker on a new repository — encodes the Day 0 → Week 4 onboarding flow with decision points, copy-paste commands, and pitfalls.",
+  "description": "Claude Code skills for introducing and operating @mizchi/flaker — onboarding, advisory rollout, CI promotion, quarantine, and staged Playwright E2E/VRT management.",
   "author": {
     "name": "mizchi",
     "url": "https://github.com/mizchi"

--- a/README.md
+++ b/README.md
@@ -41,7 +41,12 @@ Requirements:
 
 ## Install as a Claude Code plugin
 
-This repo also ships a Claude Code plugin (`flaker-setup` skill) that walks an LLM agent through introducing flaker on a fresh repository. Day 0 → Week 4 onboarding flow, decision points, copy-paste commands, and pitfalls — all encoded as a skill so the agent picks the right order automatically.
+This repo also ships a Claude Code plugin with two skills:
+
+- `flaker-setup`
+  Introduce flaker on a fresh repository. Day 0 → Week 4 onboarding flow, decision points, copy-paste commands, and pitfalls.
+- `flaker-management`
+  Operate flaker after setup. Advisory vs required gating, nightly triage, quarantine, flaky tag management, and staged Playwright E2E / VRT rollout.
 
 ```bash
 # In Claude Code
@@ -49,9 +54,14 @@ This repo also ships a Claude Code plugin (`flaker-setup` skill) that walks an L
 /plugin install flaker@flaker
 ```
 
-Then ask the agent something like "新しいプロジェクトに flaker をセットアップしたい" and it will invoke the `flaker-setup` skill.
+Then ask the agent something like:
 
-The full reference checklist (used by the skill) lives at [docs/new-project-checklist.ja.md](docs/new-project-checklist.ja.md).
+- "新しいプロジェクトに flaker をセットアップしたい"
+- "flaker の advisory を required に上げる条件を決めたい"
+- "E2E VRT の nightly triage を設計したい"
+
+The setup reference checklist lives at [docs/new-project-checklist.ja.md](docs/new-project-checklist.ja.md).
+The operations quick start lives at [docs/flaker-management-quickstart.ja.md](docs/flaker-management-quickstart.ja.md) and [docs/flaker-management-quickstart.md](docs/flaker-management-quickstart.md).
 
 ## Use as a MoonBit Library
 

--- a/docs/flaker-management-quickstart.ja.md
+++ b/docs/flaker-management-quickstart.ja.md
@@ -1,0 +1,185 @@
+# flaker Management Quick Start
+
+[English](flaker-management-quickstart.md)
+
+`flaker` を導入したあと、どう運用を始めるかの最短手順。
+このページは `flaker.toml` がすでにあり、`flaker run --profile ci` を advisory として回し始める段階を前提にする。
+
+まだ導入していない場合は先に [new-project-checklist.ja.md](new-project-checklist.ja.md) を使う。
+
+この quick start の目的は 3 つ。
+
+- 毎日何を回すかを固定する
+- 毎週何を見て昇格 / 降格を判断するかを固定する
+- Playwright E2E / VRT を安全に gate へ入れる最短ルートを示す
+
+## 0. 前提
+
+少なくとも次があること。
+
+- `flaker.toml`
+- `profile.scheduled`
+- `profile.ci`
+- `profile.local`
+- GitHub Actions の `pull_request` または `push` / `schedule`
+
+最低限の Playwright 向け設定例:
+
+```toml
+[runner]
+type = "playwright"
+command = "pnpm exec playwright test -c playwright.config.ts"
+flaky_tag_pattern = "@flaky"
+
+[quarantine]
+auto = true
+flaky_rate_threshold_percentage = 30
+min_runs = 10
+
+[profile.scheduled]
+strategy = "full"
+
+[profile.ci]
+strategy = "hybrid"
+sample_percentage = 30
+skip_flaky_tagged = true
+
+[profile.local]
+strategy = "affected"
+max_duration_seconds = 90
+fallback_strategy = "weighted"
+skip_flaky_tagged = true
+```
+
+## 1. まず 10 分でやること
+
+repo root で次を実行する。
+
+```bash
+mkdir -p .artifacts
+pnpm flaker analyze kpi
+pnpm flaker analyze eval --markdown --window 7 --output .artifacts/flaker-review.md
+pnpm flaker analyze flaky-tag --json > .artifacts/flaky-tag-triage.json
+```
+
+ここで見るもの:
+
+- `matched commits`
+- `false negative rate`
+- `pass correlation`
+- `sample ratio`
+- `saved test minutes`
+- `flaky` / `quarantined` test 数
+
+まだ `matched commits` が薄いなら、いきなり required にしない。advisory のまま observation を続ける。
+
+## 2. 毎日の loop
+
+nightly または 1 日 1 回、次を回す。
+
+```bash
+mkdir -p .artifacts
+export GITHUB_TOKEN=$(gh auth token)
+pnpm flaker collect ci --days 1
+pnpm flaker run --profile scheduled
+pnpm flaker analyze flaky-tag --json > .artifacts/flaky-tag-triage.json
+pnpm flaker analyze eval --markdown --window 7 --output .artifacts/flaker-review.md
+```
+
+必要なら quarantine も更新する。
+
+```bash
+pnpm flaker policy quarantine --auto --create-issues
+```
+
+この loop の役割:
+
+- full run で history を増やす
+- `@flaky` の add / remove 候補を出す
+- 週次レビュー用の markdown を残す
+
+## 3. 毎週のレビュー
+
+週 1 回、次の表を埋める。
+
+```md
+## Week YYYY-MM-DD
+
+- matched commits:
+- false negative rate:
+- pass correlation:
+- sample ratio:
+- saved test minutes:
+- fallback rate:
+- flaky tests:
+- quarantined tests:
+- promote:
+- keep:
+- demote:
+```
+
+詳しいテンプレートは [skills/flaker-management/assets/weekly-review-template.md](../skills/flaker-management/assets/weekly-review-template.md)。
+
+## 4. advisory から required へ上げる条件
+
+少なくとも次を満たしてから required にする。
+
+- `matched commits >= 20`
+- `false negative rate <= 5%`
+- `pass correlation >= 95%`
+- `data confidence` が `moderate` 以上
+
+Playwright E2E / VRT なら、さらに次が必要。
+
+- user-visible contract が説明できる
+- dynamic region と non-goal が決まっている
+- PR budget に収まる
+
+## 5. 降格する条件
+
+次のどれかなら、required から advisory または `@flaky` / quarantine に戻す。
+
+- unexplained false failure が継続する
+- rolling window で false failure rate が高い
+- owner が不在
+- 何を守る test か説明できない
+- runtime budget を圧迫している
+
+## 6. Playwright E2E / VRT の追加ルール
+
+VRT は新規追加した瞬間に gate に入れない。
+まず `Learning lane` で burn-in する。
+
+- `main` push または nightly で full に近く回す
+- 失敗理由を `intent-debt` / `environment-noise` / `test-design` などで分類する
+- `mask` / `stylePath` / animation disable でノイズを潰す
+- full-page snapshot より local contract を優先する
+
+test ごとの契約テンプレートは [skills/flaker-management/assets/test-contract-template.md](../skills/flaker-management/assets/test-contract-template.md) を使う。
+
+## 7. 事故ったとき
+
+CI failure の再確認:
+
+```bash
+pnpm flaker debug retry --run <workflow-run-id>
+```
+
+特定 test の confirm:
+
+```bash
+pnpm flaker debug confirm "path/to/spec.ts:test name" --runner local
+```
+
+mutation-based diagnose:
+
+```bash
+pnpm flaker debug diagnose --suite path/to/spec.ts --test "test name"
+```
+
+## 8. どの skill を使うか
+
+- 導入前: `flaker-setup`
+- 導入後の運用: `flaker-management`
+
+`flaker-management` skill の本体は [skills/flaker-management/SKILL.md](../skills/flaker-management/SKILL.md)。

--- a/docs/flaker-management-quickstart.md
+++ b/docs/flaker-management-quickstart.md
@@ -1,0 +1,185 @@
+# flaker Management Quick Start
+
+[日本語版](flaker-management-quickstart.ja.md)
+
+The shortest path to start operating `flaker` after setup.
+This page assumes you already have `flaker.toml` and have started running `flaker run --profile ci` in advisory mode.
+
+If you have not installed or initialized flaker yet, start with [new-project-checklist.ja.md](new-project-checklist.ja.md).
+
+This quick start has three goals:
+
+- fix what runs every day
+- fix what gets reviewed every week for promotion or demotion
+- give a safe path to gradually gate Playwright E2E / VRT
+
+## 0. Prerequisites
+
+At minimum, you should already have:
+
+- `flaker.toml`
+- `profile.scheduled`
+- `profile.ci`
+- `profile.local`
+- GitHub Actions for `pull_request` and/or `push` / `schedule`
+
+Minimal Playwright-oriented config:
+
+```toml
+[runner]
+type = "playwright"
+command = "pnpm exec playwright test -c playwright.config.ts"
+flaky_tag_pattern = "@flaky"
+
+[quarantine]
+auto = true
+flaky_rate_threshold_percentage = 30
+min_runs = 10
+
+[profile.scheduled]
+strategy = "full"
+
+[profile.ci]
+strategy = "hybrid"
+sample_percentage = 30
+skip_flaky_tagged = true
+
+[profile.local]
+strategy = "affected"
+max_duration_seconds = 90
+fallback_strategy = "weighted"
+skip_flaky_tagged = true
+```
+
+## 1. What to do in the first 10 minutes
+
+Run this at the repo root:
+
+```bash
+mkdir -p .artifacts
+pnpm flaker analyze kpi
+pnpm flaker analyze eval --markdown --window 7 --output .artifacts/flaker-review.md
+pnpm flaker analyze flaky-tag --json > .artifacts/flaky-tag-triage.json
+```
+
+Look at:
+
+- `matched commits`
+- `false negative rate`
+- `pass correlation`
+- `sample ratio`
+- `saved test minutes`
+- number of `flaky` / `quarantined` tests
+
+If `matched commits` is still thin, do not make the check required yet. Keep it advisory and continue observing.
+
+## 2. Daily loop
+
+Run this nightly or once per day:
+
+```bash
+mkdir -p .artifacts
+export GITHUB_TOKEN=$(gh auth token)
+pnpm flaker collect ci --days 1
+pnpm flaker run --profile scheduled
+pnpm flaker analyze flaky-tag --json > .artifacts/flaky-tag-triage.json
+pnpm flaker analyze eval --markdown --window 7 --output .artifacts/flaker-review.md
+```
+
+Update quarantine too when needed:
+
+```bash
+pnpm flaker policy quarantine --auto --create-issues
+```
+
+This loop does three things:
+
+- grows history via full execution
+- emits add / remove suggestions for `@flaky`
+- leaves markdown artifacts for weekly review
+
+## 3. Weekly review
+
+Fill this once a week:
+
+```md
+## Week YYYY-MM-DD
+
+- matched commits:
+- false negative rate:
+- pass correlation:
+- sample ratio:
+- saved test minutes:
+- fallback rate:
+- flaky tests:
+- quarantined tests:
+- promote:
+- keep:
+- demote:
+```
+
+For a fuller template, use [skills/flaker-management/assets/weekly-review-template.md](../skills/flaker-management/assets/weekly-review-template.md).
+
+## 4. When to promote advisory to required
+
+Do not promote until you have at least:
+
+- `matched commits >= 20`
+- `false negative rate <= 5%`
+- `pass correlation >= 95%`
+- `data confidence` at `moderate` or higher
+
+For Playwright E2E / VRT, also require:
+
+- a clear user-visible contract
+- dynamic regions and non-goals documented
+- the check fits inside the PR runtime budget
+
+## 5. When to demote
+
+Move a check back from required to advisory or `@flaky` / quarantine when any of these is true:
+
+- unexplained false failures continue
+- rolling-window false failure rate is high
+- nobody owns the check
+- the purpose of the check is unclear
+- it puts too much pressure on the runtime budget
+
+## 6. Additional rules for Playwright E2E / VRT
+
+Do not gate new VRT immediately.
+First let it burn in on a `Learning lane`.
+
+- run it on `main` push or nightly with near-full coverage
+- classify failures as `intent-debt`, `environment-noise`, `test-design`, and so on
+- remove noise with `mask`, `stylePath`, and animation disable
+- prefer local contracts over full-page snapshots
+
+For per-test contracts, use [skills/flaker-management/assets/test-contract-template.md](../skills/flaker-management/assets/test-contract-template.md).
+
+## 7. When something breaks
+
+Re-check a CI failure:
+
+```bash
+pnpm flaker debug retry --run <workflow-run-id>
+```
+
+Confirm a specific test:
+
+```bash
+pnpm flaker debug confirm "path/to/spec.ts:test name" --runner local
+```
+
+Run mutation-based diagnosis:
+
+```bash
+pnpm flaker debug diagnose --suite path/to/spec.ts --test "test name"
+```
+
+## 8. Which skill to use
+
+- before setup: `flaker-setup`
+- after setup, for operations: `flaker-management`
+
+The skill entrypoint is [skills/flaker-management/SKILL.md](../skills/flaker-management/SKILL.md).

--- a/skills/flaker-management/SKILL.md
+++ b/skills/flaker-management/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: flaker-management
+description: Operate @mizchi/flaker after setup. Use when the user asks how to run flaker day-to-day, review sampling and flaky metrics, design advisory vs required CI gates, promote or demote Playwright E2E or VRT checks, tune PR time budgets, run nightly triage, or manage quarantine and `@flaky` tags in an OSS repository.
+---
+
+# flaker management skill
+
+`flaker-management` is the operational companion to `flaker-setup`.
+
+- `flaker-setup`
+  Install, initialize, and wire the first advisory lane.
+- `flaker-management`
+  Run the lane over time, review health, promote or demote checks, and keep flaky tests from eroding trust.
+
+If the repository does not have `flaker.toml` and no CI lane yet, use `flaker-setup` first.
+
+## When this skill applies
+
+- "flaker の運用方法を決めたい"
+- "advisory から required にいつ上げるべき?"
+- "E2E VRT を段階的に gate に入れたい"
+- "nightly で flaky を triage したい"
+- "quarantine をどう回す?"
+- "週次レビューの playbook を作りたい"
+
+## Read order
+
+1. Read `../../docs/flaker-management-quickstart.ja.md` or `../../docs/flaker-management-quickstart.md` first, depending on the user's language.
+2. Read `references/management-guide.ja.md` for the full operating model.
+3. If the user wants theory or justification, read `references/theory.ja.md`.
+4. If the user wants copy-paste defaults, read `references/presets.ja.md`.
+5. Reuse templates from `assets/` instead of rewriting them.
+
+## What to inspect first
+
+- `flaker.toml`
+- current GitHub Actions topology: `pull_request`, `push`, `schedule`
+- latest `flaker analyze kpi`
+- latest `flaker analyze eval --markdown --window 7`
+- whether `@flaky` tagging or quarantine manifest is already in use
+- current PR runtime budget
+- whether the focus is generic CI health, or specifically Playwright E2E / VRT
+
+## Required output shape
+
+When applying this skill, return:
+
+1. lane design: `learning` / `verdict` / `rebalance`
+2. promotion criteria
+3. demotion criteria
+4. review cadence: per-PR / daily / weekly
+5. exact `flaker` commands, config, and workflow snippets
+
+## Guardrails
+
+- Do not move new E2E / VRT checks straight into required CI.
+- Do not treat retries as proof of stability.
+- Do not let quarantine become a graveyard; attach an owner and an exit rule.
+- Keep a full scheduled lane even after PR gating starts.
+- For AI-generated code, require a short per-test contract so visual checks encode intent, not just pixels.
+
+## flaker commands to prefer
+
+```bash
+flaker run --profile scheduled
+flaker run --profile ci
+flaker run --profile local
+flaker analyze kpi
+flaker analyze eval --markdown --window 7
+flaker analyze flaky-tag --json
+flaker policy quarantine --auto --create-issues
+```

--- a/skills/flaker-management/assets/flaker.playwright-vrt-bootstrap.toml
+++ b/skills/flaker-management/assets/flaker.playwright-vrt-bootstrap.toml
@@ -1,0 +1,23 @@
+[runner]
+type = "playwright"
+command = "pnpm exec playwright test -c playwright.config.ts"
+flaky_tag_pattern = "@flaky"
+
+[quarantine]
+auto = true
+flaky_rate_threshold_percentage = 30
+min_runs = 10
+
+[profile.scheduled]
+strategy = "full"
+
+[profile.ci]
+strategy = "hybrid"
+sample_percentage = 50
+skip_flaky_tagged = true
+
+[profile.local]
+strategy = "affected"
+max_duration_seconds = 120
+fallback_strategy = "weighted"
+skip_flaky_tagged = true

--- a/skills/flaker-management/assets/flaker.playwright-vrt-standard.toml
+++ b/skills/flaker-management/assets/flaker.playwright-vrt-standard.toml
@@ -1,0 +1,24 @@
+[runner]
+type = "playwright"
+command = "pnpm exec playwright test -c playwright.config.ts"
+flaky_tag_pattern = "@flaky"
+
+[quarantine]
+auto = true
+flaky_rate_threshold_percentage = 30
+min_runs = 10
+
+[profile.scheduled]
+strategy = "full"
+
+[profile.ci]
+strategy = "hybrid"
+sample_percentage = 30
+adaptive = true        # enable after enough matched commits / FNR history
+skip_flaky_tagged = true
+
+[profile.local]
+strategy = "affected"
+max_duration_seconds = 90
+fallback_strategy = "weighted"
+skip_flaky_tagged = true

--- a/skills/flaker-management/assets/flaker.playwright-vrt-strict.toml
+++ b/skills/flaker-management/assets/flaker.playwright-vrt-strict.toml
@@ -1,0 +1,24 @@
+[runner]
+type = "playwright"
+command = "pnpm exec playwright test -c playwright.config.ts"
+flaky_tag_pattern = "@flaky"
+
+[quarantine]
+auto = true
+flaky_rate_threshold_percentage = 20
+min_runs = 20
+
+[profile.scheduled]
+strategy = "full"
+
+[profile.ci]
+strategy = "hybrid"
+sample_percentage = 20
+adaptive = true
+skip_flaky_tagged = true
+
+[profile.local]
+strategy = "affected"
+max_duration_seconds = 120
+fallback_strategy = "weighted"
+skip_flaky_tagged = true

--- a/skills/flaker-management/assets/test-contract-template.md
+++ b/skills/flaker-management/assets/test-contract-template.md
@@ -1,0 +1,35 @@
+# Test Contract
+
+- test id:
+- suite / scenario:
+- owner:
+- current lane:
+
+## User-visible contract
+
+- この test が守る見た目 / 振る舞い:
+
+## Why this check exists
+
+- unit / DOM / API test ではなく、この check で守る理由:
+
+## Non-goals
+
+- この test で守らないもの:
+
+## Dynamic regions
+
+- mask 対象:
+- stylePath で消す対象:
+- animation / clock / network 固定:
+
+## Promotion evidence
+
+- 観測 window:
+- unexplained false failures:
+- last promoted at:
+
+## Demotion trigger
+
+- flaky とみなす条件:
+- advisory に戻す条件:

--- a/skills/flaker-management/assets/weekly-review-template.md
+++ b/skills/flaker-management/assets/weekly-review-template.md
@@ -1,0 +1,35 @@
+# flaker Weekly Review
+
+## Week YYYY-MM-DD
+
+### KPI
+
+- matched commits:
+- false negative rate:
+- pass correlation:
+- sample ratio:
+- saved test minutes:
+- fallback rate:
+
+### Flaky / Quarantine
+
+- flaky tests:
+- quarantined tests:
+- new add suggestions:
+- new remove suggestions:
+
+### Lane Decisions
+
+- promote:
+- keep:
+- demote:
+
+### Incidents
+
+- test:
+- classification:
+- action:
+
+### Notes
+
+- 

--- a/skills/flaker-management/assets/workflow-nightly-learning.yml
+++ b/skills/flaker-management/assets/workflow-nightly-learning.yml
@@ -1,0 +1,36 @@
+name: flaker-nightly-learning
+
+on:
+  schedule:
+    - cron: "0 18 * * *"
+  workflow_dispatch:
+
+jobs:
+  flaker-nightly:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+      - run: mkdir -p .artifacts
+      - run: pnpm flaker collect ci --days 1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: pnpm flaker run --profile scheduled
+      - run: pnpm flaker analyze flaky-tag --json > .artifacts/flaky-tag-triage.json
+      - run: pnpm flaker analyze eval --markdown --window 7 --output .artifacts/flaker-review.md
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: flaker-nightly-review
+          path: .artifacts/

--- a/skills/flaker-management/assets/workflow-pr-advisory.yml
+++ b/skills/flaker-management/assets/workflow-pr-advisory.yml
@@ -1,0 +1,33 @@
+name: flaker-pr-advisory
+
+on:
+  pull_request:
+
+jobs:
+  flaker-advisory:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+      - run: mkdir -p .artifacts
+      - run: pnpm flaker run --profile ci
+        continue-on-error: true
+
+      - run: pnpm flaker analyze kpi > .artifacts/kpi.md
+      - run: pnpm flaker analyze eval --json > .artifacts/flaker-eval.json
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: flaker-pr-advisory
+          path: .artifacts/

--- a/skills/flaker-management/references/management-guide.ja.md
+++ b/skills/flaker-management/references/management-guide.ja.md
@@ -1,0 +1,156 @@
+# flaker Management Guide
+
+最短の導入手順だけ欲しい場合は先に `../../docs/flaker-management-quickstart.ja.md` を読む。
+
+この guide は `flaker` を導入した後の運用を扱う。
+対象は次のような repo。
+
+- advisory の `flaker run --profile ci` はあるが、まだ required にしていない
+- nightly / scheduled で full run を回している
+- Playwright E2E / VRT を徐々に gate に入れたい
+- flaky tag や quarantine を使って suite の信頼を保ちたい
+
+## 1. レーン設計
+
+運用は 3 レーンで考える。
+
+- `Learning lane`
+  `main` push または nightly schedule で広く回す。目的は gate ではなく観測、学習、安定化。
+- `Verdict lane`
+  pull request の CI で回す。ここに入るのは、十分に観測され、速く、意図が明確な check だけ。
+- `Rebalance lane`
+  1 日 1 回または nightly で回す。昇格候補と降格候補を見つけ、`@flaky` と quarantine を更新する。
+
+`Learning lane` を消さないこと。`Verdict lane` はそこから選抜された subset にする。
+
+## 2. 毎日の loop
+
+最低限の daily or nightly loop:
+
+```bash
+mkdir -p .artifacts
+flaker collect ci --days 1
+flaker run --profile scheduled
+flaker analyze flaky-tag --json > .artifacts/flaky-tag-triage.json
+flaker analyze eval --markdown --window 7 --output .artifacts/flaker-review.md
+```
+
+必要なら:
+
+```bash
+flaker policy quarantine --auto --create-issues
+```
+
+この loop の役割:
+
+- full 実行で history を蓄積する
+- unstable test を `Verdict lane` から外す候補を出す
+- stable に戻った test を復帰候補として出す
+- 週次レビューの材料を Markdown に残す
+
+## 3. 週次レビュー
+
+毎週レビューする項目:
+
+- `matched commits`
+- `false negative rate`
+- `pass correlation`
+- `sample ratio`
+- `saved test minutes`
+- `flaky` / `quarantined` test 数
+- fallback rate
+- 新規に追加された unstable test
+
+テンプレートは `../assets/weekly-review-template.md` を使う。
+
+### 昇格の判断
+
+`Verdict lane` を advisory から required に上げる条件は、次を基本線にする。
+
+- `matched commits >= 20`
+- `false negative rate <= 5%`
+- `pass correlation >= 95%`
+- `data confidence` が `moderate` 以上
+
+Playwright E2E / VRT では、これに加えて:
+
+- その test の `user-visible contract` が説明できる
+- dynamic region と non-goal が定義されている
+- PR budget に収まる
+
+### 降格の判断
+
+次のどれかに当たるなら、一度 advisory または `@flaky` / quarantine に戻す。
+
+- unexplained false failure が継続する
+- rolling window で false failure rate が高い
+- owner が不在
+- 何を守る test か説明できない
+- runtime budget を圧迫している
+
+## 4. Playwright E2E / VRT の扱い
+
+Playwright VRT は特に環境依存性が高い。昇格前に先に潰すべきは threshold ではなく環境ノイズ。
+
+- OS / browser / viewport / locale / timezone を固定する
+- font を固定する
+- clock / random / network を固定する
+- animation を止める
+- `mask` / `stylePath` で dynamic region を消す
+- full-page snapshot より local contract を優先する
+
+新規 test は最初から gate に入れない。`Learning lane` で burn-in し、意図と揺れ方を把握してから昇格させる。
+
+## 5. AI-generated code に対する追加原則
+
+AI 生成コードでは `理解の負債` と `意図の負債` が増えやすい。
+だから VRT 失敗時に snapshot 更新だけで閉じない。
+
+最低でも、失敗理由を次から 1 つ選んで記録する。
+
+- `intent-debt`
+- `comprehension-debt`
+- `environment-noise`
+- `test-design`
+- `real-regression`
+
+これは `Verdict` だけではなく `Learning` を残すための操作である。
+
+## 6. flaker への落とし込み
+
+基本の config 役割:
+
+- `profile.scheduled`
+  full execution。history の母集団。
+- `profile.ci`
+  PR selective execution。`skip_flaky_tagged = true` を有効にして Verdict lane を守る。
+- `profile.local`
+  開発者向けの短い feedback loop。`affected` と `max_duration_seconds` を使う。
+
+基本コマンド:
+
+```bash
+flaker analyze kpi
+flaker analyze eval --markdown --window 7
+flaker analyze flaky-tag --json
+flaker policy quarantine --auto --create-issues
+```
+
+incident 時:
+
+```bash
+flaker debug retry --run <workflow-run-id>
+flaker debug confirm "path/to/spec.ts:test name" --runner local
+flaker debug diagnose --suite path/to/spec.ts --test "test name"
+```
+
+## 7. 推奨 cadence
+
+- per PR
+  `flaker run --profile ci`
+- daily or nightly
+  `collect ci --days 1` + `run --profile scheduled` + `flaky-tag` + `eval`
+- weekly
+  KPI review, promote / keep / demote の判断
+- monthly
+  budget 見直し、preset 見直し、quarantine の stale cleanup

--- a/skills/flaker-management/references/presets.ja.md
+++ b/skills/flaker-management/references/presets.ja.md
@@ -1,0 +1,92 @@
+# flaker Management Presets
+
+この skill では 3 つの運用 preset を持つ。
+
+## 1. bootstrap
+
+使いどころ:
+
+- 導入直後
+- advisory only で始めたい
+- E2E / VRT の history がまだ薄い
+
+既定:
+
+- PR budget: `10分`
+- local budget: `120秒`
+- `profile.ci.sample_percentage = 50`
+- promotion: `20 matched commits` と `false negative rate <= 5%`
+- demotion: rolling `14日` で incident `2件` 以上
+
+assets:
+
+- `../assets/flaker.playwright-vrt-bootstrap.toml`
+- `../assets/workflow-pr-advisory.yml`
+- `../assets/workflow-nightly-learning.yml`
+
+## 2. standard
+
+使いどころ:
+
+- OSS の標準運用
+- advisory から required へ段階的に上げたい
+- Playwright E2E / VRT を managed gate にしたい
+
+既定:
+
+- PR budget: `5分`
+- local budget: `90秒`
+- `profile.ci.sample_percentage = 30`
+- promotion: `matched commits >= 20`, `FNR <= 5%`, `pass correlation >= 95%`
+- demotion: rolling `30日` で false failure rate `> 2%` または incident `2件`
+
+assets:
+
+- `../assets/flaker.playwright-vrt-standard.toml`
+- `../assets/workflow-pr-advisory.yml`
+- `../assets/workflow-nightly-learning.yml`
+
+注意:
+
+- `adaptive = true` は matched commits や FNR history が十分に溜まってから有効にする
+- 導入直後なら `bootstrap` を使い、`adaptive` はまだ入れない
+
+## 3. strict
+
+使いどころ:
+
+- release quality に直結する UI contract を守る
+- dedicated shard を切る価値がある
+- quarantine を強めに運用する
+
+既定:
+
+- PR budget: `10分`
+- local budget: `120秒`
+- `profile.ci.sample_percentage = 20`
+- promotion: 直近 `100 run` で unexplained false failure `0`
+- demotion: unexplained false failure `1件` で advisory へ戻す
+
+assets:
+
+- `../assets/flaker.playwright-vrt-strict.toml`
+- `../assets/workflow-pr-advisory.yml`
+- `../assets/workflow-nightly-learning.yml`
+
+## 4. 統計メモ
+
+`0失敗 / n回` を独立ベルヌーイ近似で見ると、95% 片側上限は:
+
+```text
+upper_bound = 1 - 0.05^(1 / n)
+```
+
+目安:
+
+- `10 run clean` -> 約 `25.9%`
+- `20 run clean` -> 約 `13.9%`
+- `60 run clean` -> 約 `4.9%`
+- `300 run clean` -> 約 `1.0%`
+
+つまり `10回通った` は burn-in にはよいが、gate 昇格の根拠としては弱い。
+OSS の標準 preset では `60 run` をより強い目安とする。

--- a/skills/flaker-management/references/theory.ja.md
+++ b/skills/flaker-management/references/theory.ja.md
@@ -1,0 +1,69 @@
+# flaker Management Theory
+
+この skill が前提にしている理論は 4 つある。
+
+- staged build / fast feedback
+- flaky test quarantine
+- deterministic visual testing
+- AI 時代の proactive QA
+
+## 1. staged build / fast feedback
+
+PR の commit build は速くあるべきで、重い検査は後段に逃がす。
+だから flaker 運用では:
+
+- PR gate を小さく保つ
+- full execution は nightly / schedule に置く
+
+を基本にする。
+
+参考:
+
+- Martin Fowler, Continuous Integration  
+  <https://martinfowler.com/articles/continuousIntegration.html>
+
+## 2. flaky test quarantine
+
+non-deterministic test を healthy な gate suite と混ぜると、CI への信頼が壊れる。
+したがって:
+
+- quarantine する
+- stable なら戻す
+- quarantine を放置しない
+
+が必要になる。
+
+参考:
+
+- Martin Fowler, Eradicating Non-Determinism in Tests  
+  <https://martinfowler.com/articles/nonDeterminism.html>
+- Google Testing Blog, Flaky Tests at Google and How We Mitigate Them  
+  <https://testing.googleblog.com/2016/05/flaky-tests-at-google-and-how-we.html?m=1>
+- Google Testing Blog, Where do our flaky tests come from?  
+  <https://testing.googleblog.com/2017/04/where-do-our-flaky-tests-come-from.html>
+
+## 3. deterministic visual testing
+
+VRT は threshold 以前に環境固定が本体。
+Playwright の visual comparison でも baseline と比較対象は同一環境が前提で、`mask` `stylePath` `animation disable` などを使ってノイズを消す。
+
+参考:
+
+- Playwright Best Practices  
+  <https://playwright.dev/docs/best-practices>
+- Playwright Visual comparisons  
+  <https://playwright.dev/docs/next/test-snapshots>
+- Playwright Page Assertions  
+  <https://playwright.dev/docs/api/class-pageassertions>
+
+## 4. proactive QA in AI-accelerated development
+
+AI 生成コードでは `理解の負債` と `意図の負債` が増えやすい。
+だからテストは `Verdict` だけでなく `Learning` の役割を持たせるべきで、QA は後追い検出だけでなく、先に意図・契約・リスクを作る方向に寄る。
+
+参考:
+
+- 翻訳記事: <https://nihonbuson.hatenadiary.jp/entry/QA-activities-in-response-to-generated-code>
+- 元記事と discussion は翻訳記事のリンク先を辿ること
+
+この skill が `Learning lane`、per-test contract、failure reason の記録を強く勧める理由はここにある。


### PR DESCRIPTION
## Summary
Add a new `flaker-management` skill for post-setup operations and add bilingual quick start docs.

## What changed
- add `skills/flaker-management` with references, presets, and reusable assets
- add `docs/flaker-management-quickstart.ja.md` and `docs/flaker-management-quickstart.md`
- update README and plugin metadata to advertise the new operations-focused skill
- fix workflow templates to create `.artifacts` before writing review outputs

## Why
The repo already had a setup-oriented skill, but it did not have an operations-oriented skill for day-to-day flaker management, advisory-to-required promotion, quarantine, and staged Playwright E2E/VRT rollout.

## Validation
- documentation-only change
- no tests run