### PR TITLE
chore: switch release-please to GitHub App token and manual dispatch

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,18 +1,25 @@
 name: release-please
 
+# Manual trigger only. Release timing is an explicit maintainer decision.
+# Run via Actions UI or: gh workflow run release-please.yml
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: 3420845
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v4
         with:
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary

- Authenticate via dedicated GitHub App (app-id `3420845`) instead of default `GITHUB_TOKEN` + 'Allow Actions to create PRs' setting
- Run only on `workflow_dispatch` — release timing is an explicit maintainer action
- CHANGELOG generation remains automated

## After merge

- Toggle off 'Allow GitHub Actions to create and approve pull requests' in Settings → Actions → General (no longer needed)
- To cut a release: `gh workflow run release-please.yml --repo mizchi/flaker`

## Prerequisites (already done)

- [x] `RELEASE_PLEASE_APP_PRIVATE_KEY` secret set
- [x] App installed via All repositories scope