### PR TITLE
Add 0.5 migration guide and changelog summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 ## [0.5.0](https://github.com/mizchi/flaker/compare/flaker-v0.4.0...flaker-v0.5.0) (2026-04-18)
 
+### Migration guide
+
+Upgrading from `0.4.x` does **not** require a `flaker.toml` rename.
+The main change is the recommended user-facing CLI surface:
+
+- prefer `flaker run --gate iteration|merge|release` over profile-oriented examples
+- prefer `flaker doctor` over `flaker debug doctor`
+- prefer `flaker status` over `flaker analyze kpi` for the default dashboard
+
+Existing profile-based configs and commands remain supported:
+
+- `profile.local`, `profile.ci`, `profile.scheduled` still work
+- `flaker run --profile ...` is still supported for advanced and custom setups
+- existing category commands under `analyze`, `debug`, `policy`, and `dev` are unchanged
+
+For a practical migration checklist, see:
+
+- [docs/migration-0.4-to-0.5.ja.md](docs/migration-0.4-to-0.5.ja.md)
+- [docs/migration-0.4-to-0.5.md](docs/migration-0.4-to-0.5.md)
+
+### Highlights
+
+- gate-oriented daily workflow: `flaker run --gate iteration`, `flaker doctor`, `flaker status`
+- docs are split by audience: usage vs operations
+- management guidance is now explicit for advisory/required gates, quarantine, and staged E2E/VRT rollout
+
+### Compatibility notes
+
+- no config-key migration is required from `0.4.x`
+- this is a conceptual UX migration, not a hard CLI break like `0.2.0`
+- if you already use custom profiles in CI, you can keep them and adopt gates gradually in docs and scripts
 
 ### Features
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ It is designed for repositories where:
 - How well does local sampled execution predict CI outcomes?
 
 > **Upgrading from 0.0.x / 0.1.x?** See [docs/how-to-use.md#config-migration](docs/how-to-use.md#config-migration) for the full key rename map. Starting with `0.2.0`, the CLI refuses to start on legacy configs and points to the migration guide.
+>
+> **Upgrading from 0.4.x?** See [docs/migration-0.4-to-0.5.md](docs/migration-0.4-to-0.5.md) or [docs/migration-0.4-to-0.5.ja.md](docs/migration-0.4-to-0.5.ja.md). `0.5.x` keeps existing profiles working, but the recommended user-facing commands are now gate-oriented.
 
 ## Install as a CLI
 
@@ -61,6 +63,7 @@ Then ask the agent something like:
 - "E2E VRT の nightly triage を設計したい"
 
 The setup reference checklist lives at [docs/new-project-checklist.ja.md](docs/new-project-checklist.ja.md) and [docs/new-project-checklist.md](docs/new-project-checklist.md).
+The `0.4.x -> 0.5.x` migration guide lives at [docs/migration-0.4-to-0.5.ja.md](docs/migration-0.4-to-0.5.ja.md) and [docs/migration-0.4-to-0.5.md](docs/migration-0.4-to-0.5.md).
 The user guide lives at [docs/usage-guide.ja.md](docs/usage-guide.ja.md) and [docs/usage-guide.md](docs/usage-guide.md).
 The operations guide lives at [docs/operations-guide.ja.md](docs/operations-guide.ja.md) and [docs/operations-guide.md](docs/operations-guide.md).
 The operations quick start lives at [docs/flaker-management-quickstart.ja.md](docs/flaker-management-quickstart.ja.md) and [docs/flaker-management-quickstart.md](docs/flaker-management-quickstart.md).

--- a/docs/migration-0.4-to-0.5.ja.md
+++ b/docs/migration-0.4-to-0.5.ja.md
@@ -1,0 +1,123 @@
+# flaker 0.4 → 0.5 Migration Guide
+
+[English](migration-0.4-to-0.5.md)
+
+`0.5.x` は `0.2.0` のような hard breaking release ではない。
+`0.4.x` の `flaker.toml` や profile ベースの運用は、そのまま継続できる。
+
+今回の移行は主に:
+
+- 利用者向けの表現を `profile` 中心から `gate` 中心へ寄せる
+- 日常利用と運用管理のドキュメントを分離する
+
+という UX 整理である。
+
+## まず結論
+
+必須の config rename はない。
+
+ただし、利用者向けの案内や script は次の形へ寄せるのを推奨する。
+
+| 0.4 までの案内 | 0.5 での推奨 |
+|---|---|
+| `flaker run --profile local` | `flaker run --gate iteration` |
+| `flaker run --profile ci` | `flaker run --gate merge` |
+| `flaker run --profile scheduled` | `flaker run --gate release` |
+| `flaker debug doctor` | `flaker doctor` |
+| `flaker analyze kpi` | `flaker status` |
+
+## 変えなくてよいもの
+
+- `flaker.toml` の `[profile.local]`, `[profile.ci]`, `[profile.scheduled]`
+- custom profile を使う CI script
+- `analyze`, `debug`, `policy`, `dev` 配下の詳細コマンド
+- sampling strategy 名 (`affected`, `hybrid`, `weighted`, `full` など)
+
+つまり `0.4.x` の運用は壊さず、`0.5.x` では入口だけを薄くするイメージ。
+
+## Gate と profile の対応
+
+`gate` は新しい内部概念ではなく、既存 profile を利用者向けに言い換えた薄い surface。
+
+| Gate | 実体 |
+|---|---|
+| `iteration` | `profile.local` |
+| `merge` | `profile.ci` |
+| `release` | `profile.scheduled` |
+
+advanced / custom profile を使う場合は引き続き `--profile` を使ってよい。
+
+## 利用者向け script の移行例
+
+### ローカル実行
+
+```bash
+# before
+pnpm flaker run --profile local
+
+# after
+pnpm flaker run --gate iteration
+```
+
+### dry-run と explain
+
+```bash
+# before
+pnpm flaker run --profile local --dry-run --explain
+
+# after
+pnpm flaker run --gate iteration --dry-run --explain
+```
+
+### ヘルス確認
+
+```bash
+# before
+pnpm flaker analyze kpi
+pnpm flaker debug doctor
+
+# after
+pnpm flaker status
+pnpm flaker doctor
+```
+
+## CI 側の扱い
+
+`0.4.x` で `--profile ci` や custom profile を使っているなら、すぐに置き換える必要はない。
+
+次の方針を推奨する。
+
+1. 利用者向け README や package script は `--gate` へ寄せる
+2. CI は当面 `--profile` のままでもよい
+3. gate 名で十分表現できる job だけ順次 `--gate merge` / `--gate release` に寄せる
+
+## ドキュメント導線の変更
+
+`0.5.x` では docs を役割別に分離している。
+
+- 日常利用: [usage-guide.ja.md](usage-guide.ja.md)
+- 運用設計: [operations-guide.ja.md](operations-guide.ja.md)
+- 詳細リファレンス: [how-to-use.ja.md](how-to-use.ja.md)
+
+`0.4.x` で README や `how-to-use` を直接見ていた利用者は、まず `usage-guide` から入るのがよい。
+
+## 推奨確認手順
+
+upgrade 後は次を確認する。
+
+```bash
+pnpm flaker doctor
+pnpm flaker run --gate iteration --dry-run --explain
+pnpm flaker status
+```
+
+CI で gate を使う場合は:
+
+```bash
+pnpm flaker run --gate merge
+```
+
+## 既知の注意点
+
+- `0.5.x` は gate-oriented UX を追加した release で、profile API を削除した release ではない
+- `0.2.0` 以前から上げる場合は、このページではなく [how-to-use.md#config-migration](how-to-use.md#config-migration) を先に見る

--- a/docs/migration-0.4-to-0.5.md
+++ b/docs/migration-0.4-to-0.5.md
@@ -1,0 +1,121 @@
+# flaker 0.4 -> 0.5 Migration Guide
+
+[日本語版](migration-0.4-to-0.5.ja.md)
+
+`0.5.x` is not a hard breaking release like `0.2.0`.
+Your `0.4.x` `flaker.toml` and profile-based setup can continue to work as-is.
+
+This migration is mainly about:
+
+- shifting the user-facing language from `profile` to `gate`
+- separating day-to-day usage docs from operations docs
+
+## Short version
+
+There is no required config rename from `0.4.x`.
+
+But user-facing scripts and examples should move toward:
+
+| 0.4-style guidance | 0.5 recommendation |
+|---|---|
+| `flaker run --profile local` | `flaker run --gate iteration` |
+| `flaker run --profile ci` | `flaker run --gate merge` |
+| `flaker run --profile scheduled` | `flaker run --gate release` |
+| `flaker debug doctor` | `flaker doctor` |
+| `flaker analyze kpi` | `flaker status` |
+
+## What does not need to change
+
+- `[profile.local]`, `[profile.ci]`, `[profile.scheduled]` in `flaker.toml`
+- CI scripts that already use custom profiles
+- detailed commands under `analyze`, `debug`, `policy`, and `dev`
+- sampling strategy names such as `affected`, `hybrid`, `weighted`, or `full`
+
+So the goal is to keep `0.4.x` behavior working while making the entrypoint thinner in `0.5.x`.
+
+## Gate to profile mapping
+
+`gate` is not a replacement backend. It is a thinner user-facing surface over the existing profiles.
+
+| Gate | Underlying profile |
+|---|---|
+| `iteration` | `profile.local` |
+| `merge` | `profile.ci` |
+| `release` | `profile.scheduled` |
+
+If you rely on advanced or custom profiles, keep using `--profile`.
+
+## Script migration examples
+
+### Local run
+
+```bash
+# before
+pnpm flaker run --profile local
+
+# after
+pnpm flaker run --gate iteration
+```
+
+### Dry-run with explanation
+
+```bash
+# before
+pnpm flaker run --profile local --dry-run --explain
+
+# after
+pnpm flaker run --gate iteration --dry-run --explain
+```
+
+### Health checks
+
+```bash
+# before
+pnpm flaker analyze kpi
+pnpm flaker debug doctor
+
+# after
+pnpm flaker status
+pnpm flaker doctor
+```
+
+## CI guidance
+
+If your `0.4.x` CI already uses `--profile ci` or custom profiles, you do not need to switch immediately.
+
+Recommended path:
+
+1. move user-facing README examples and package scripts to `--gate`
+2. leave CI on `--profile` for now if it is already stable
+3. migrate only the jobs that are naturally expressible as `--gate merge` or `--gate release`
+
+## Documentation entrypoints
+
+`0.5.x` splits docs by audience:
+
+- day-to-day usage: [usage-guide.md](usage-guide.md)
+- operations and rollout: [operations-guide.md](operations-guide.md)
+- detailed reference: [how-to-use.md](how-to-use.md)
+
+If you used to jump directly from the README into `how-to-use`, start with `usage-guide` first.
+
+## Recommended verification
+
+After upgrading:
+
+```bash
+pnpm flaker doctor
+pnpm flaker run --gate iteration --dry-run --explain
+pnpm flaker status
+```
+
+If you want to validate the CI-facing gate:
+
+```bash
+pnpm flaker run --gate merge
+```
+
+## Notes
+
+- `0.5.x` adds a gate-oriented UX; it does not remove the profile-based API
+- if you are upgrading from `0.2.0` or earlier, see [how-to-use.md#config-migration](how-to-use.md#config-migration) first

--- a/docs/usage-guide.ja.md
+++ b/docs/usage-guide.ja.md
@@ -15,6 +15,7 @@
 それらは [operations-guide.ja.md](operations-guide.ja.md) を参照。
 
 まだ導入していない場合は [new-project-checklist.ja.md](new-project-checklist.ja.md) から始める。
+`0.4.x` から上げる場合は [migration-0.4-to-0.5.ja.md](migration-0.4-to-0.5.ja.md) を先に見る。
 
 ## 対象読者
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -15,6 +15,7 @@ It does not cover:
 For those, see [operations-guide.md](operations-guide.md).
 
 If flaker is not installed or initialized yet, start with [new-project-checklist.md](new-project-checklist.md).
+If you are upgrading from `0.4.x`, read [migration-0.4-to-0.5.md](migration-0.4-to-0.5.md) first.
 
 ## Audience
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -32,7 +32,7 @@ export function createProgram(): Command {
   program
     .name("flaker")
     .description("Intelligent test selection — run fewer tests, catch more failures")
-    .version("0.4.0")
+    .version("0.5.0")
     .showHelpAfterError()
     .showSuggestionAfterError();
 

--- a/tests/cli/version.test.ts
+++ b/tests/cli/version.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { createProgram } from "../../src/cli/main.js";
+
+describe("CLI version", () => {
+  it("matches the current package release line", () => {
+    const program = createProgram();
+
+    expect(program.version()).toBe("0.5.0");
+  });
+});

--- a/tests/cli/version.test.ts
+++ b/tests/cli/version.test.ts
@@ -1,10 +1,15 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { createProgram } from "../../src/cli/main.js";
+
+const packageVersion = JSON.parse(
+  readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
+) as { version: string };
 
 describe("CLI version", () => {
   it("matches the current package release line", () => {
     const program = createProgram();
 
-    expect(program.version()).toBe("0.5.0");
+    expect(program.version()).toBe(packageVersion.version);
   });
 });


### PR DESCRIPTION
## Summary
- add dedicated 0.4 -> 0.5 migration guides in Japanese and English
- add a human-facing migration summary to the 0.5.0 changelog and link it from the README and usage guides
- fix the top-level CLI version string to report 0.5.0 and cover it with a test

## Verification
- pnpm exec vitest run tests/cli/version.test.ts tests/cli/help.test.ts
- pnpm run typecheck
- pnpm run build
- pnpm exec node dist/cli/main.js --version