### PR TITLE
fix(ci): use Nix + moonbit-overlay in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,10 +25,14 @@ jobs:
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
-      - uses: hustcer/setup-moonbit@v1
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
 
       - name: MoonBit deps
-        run: moon update
+        run: nix develop --command moon update
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -40,7 +44,7 @@ jobs:
         run: |
           pnpm run typecheck
           pnpm vitest run
-          moon test --target js
+          nix develop --command moon test --target js
 
       - name: CLI smoke
         run: node dist/cli/main.js --help >/dev/null


### PR DESCRIPTION
Replace `hustcer/setup-moonbit@v1` with `cachix/install-nix-action@v31` and run `moon` via `nix develop --command`. flaker already ships `flake.nix` backed by `moonbit-community/moonbit-overlay`, so this makes the publish workflow reproducible and drops one third-party action.