### PR TITLE
feat(cli): reduce primary surface 53 → 11 (0.7.0 phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Changelog
 
+## 0.7.0-next.0 (prerelease)
+
+### Deprecated (removed in 0.8.0)
+
+All listed below still work; they now emit a stderr warning pointing at
+the 0.7.0 canonical replacement.
+
+| Deprecated | Canonical replacement |
+|---|---|
+| `flaker setup init` | `flaker init` |
+| `flaker exec run` / `flaker exec affected` | `flaker run` / `flaker run --gate iteration --changed <paths>` |
+| `flaker ops daily` | `flaker apply` |
+| `flaker collect ci / local / coverage / commit-changes / calibrate` | `flaker apply` |
+| `flaker quarantine suggest / apply` | `flaker apply` |
+| `flaker policy quarantine / check / report` | `flaker apply` |
+| `flaker gate review / history / explain` | `flaker status --gate <name> [--detail]` |
+| `flaker analyze kpi` | `flaker status` |
+| `flaker analyze eval` | `flaker status --markdown` |
+| `flaker analyze flaky` | `flaker status --list flaky` |
+| `flaker analyze flaky-tag` | `flaker apply` |
+| `flaker analyze reason / insights / cluster / bundle / context` | `flaker explain <topic>` |
+| `flaker analyze query` | `flaker query <sql>` |
+| `flaker import report / parquet` | `flaker import <file>` (auto-detect) |
+| `flaker report summary / diff / aggregate` | `flaker report <file> --summary \| --diff <base> \| --aggregate <dir>` |
+| `flaker debug doctor` | `flaker doctor` |
+
+### New
+
+- `flaker plan` / `flaker apply` (declarative reconciler; shipped in 0.6.0)
+- `flaker status` gained `--markdown`, `--list flaky|quarantined`, `--detail`, `--gate <name>`
+- `flaker query <sql>` top-level
+- `flaker explain <topic>` umbrella for AI-assisted analysis
+- `flaker import <file>` auto-detects adapter from extension
+- `flaker report <file>` uses `--summary` / `--diff` / `--aggregate` flags
+- `[promotion]` config section with documented defaults
+- `[promotion].data_confidence_min` validated against the `low|moderate|high` enum
+
+### Changed
+
+- `flaker --help` reorganized into three tiers: Primary (11), Advanced, Deprecated
+- Primary command surface reduced from 53 to 11 user-facing entries (hidden `dev *` subtree retained)
+
+### Fixed
+
+- `flaker apply` now aborts cleanly when `GITHUB_TOKEN` is missing (previously `process.exit(1)` bypassed the executor's abort handler)
+- `probeRepo.hasLocalHistory` now queries `workflow_runs` instead of being hardcoded `false`
+
 ## [0.5.0](https://github.com/mizchi/flaker/compare/flaker-v0.4.0...flaker-v0.5.0) (2026-04-18)
 
 ### Migration guide

--- a/docs/superpowers/plans/2026-04-19-cli-surface-reduction.md
+++ b/docs/superpowers/plans/2026-04-19-cli-surface-reduction.md
@@ -1,0 +1,256 @@
+# 0.7.0 CLI Surface Reduction Plan
+
+> **For agentic workers:** Use superpowers:subagent-driven-development to execute phases task-by-task.
+
+**Goal:** Reduce user-facing CLI surface from 53 leaf commands to 10 primary commands by absorbing secondary commands into `apply` / `status` / `explain` / flag-based `import` and `report`, while keeping all deprecated forms functional until 0.8.0.
+
+**Architecture:** Three-phase rollout. Phase 1 adds the consolidated verbs + flags and wires deprecation aliases. Phase 2 ships docs + skill migrations. Phase 3 (shipped as 0.8.0) removes the deprecated aliases. This plan covers Phase 1 only; Phase 2/3 are separate plans.
+
+**Tech Stack:** Node.js 24+, TypeScript, Commander, Vitest, DuckDB.
+
+---
+
+## Target surface (0.7.0 primary, 10 commands)
+
+| Command | Absorbs |
+|---|---|
+| `flaker init` | `setup init` |
+| `flaker plan` / `flaker apply` | — (0.6.0) |
+| `flaker status` | `analyze kpi`, `analyze eval`, `analyze flaky`, `gate review`, `gate history`, `gate explain` (via flags: `--detail`, `--markdown`, `--list flaky\|quarantined`, `--gate <name>`) |
+| `flaker run --gate <name>` | `exec run`, `exec affected` |
+| `flaker doctor` | `debug doctor` |
+| `flaker debug <retry\|confirm\|bisect\|diagnose>` | `ops incident` |
+| `flaker query <sql>` | `analyze query` |
+| `flaker explain <topic>` | `analyze reason\|insights\|cluster\|bundle\|context` |
+| `flaker import <file>` | `import report`, `import parquet` (adapter auto-detect) |
+| `flaker report <file>` | `report summary\|diff\|aggregate` (via flags) |
+
+Fully absorbed into `apply` (no direct replacement; use `apply` or keep as hidden alias):
+- `collect ci / local / coverage / commit-changes / calibrate`
+- `quarantine suggest / quarantine apply`
+- `policy quarantine / policy check / policy report`
+- `ops daily` (apply now emits the daily artifact via `--output`)
+
+Remains hidden (developer-only, not in user help):
+- `flaker dev *`
+
+---
+
+## Scope & non-goals
+
+**In scope (Phase 1 = 0.7.0):**
+- Extend `status` with `--detail`, `--markdown`, `--list <flaky|quarantined>`, `--gate <name>`
+- Add top-level `flaker query <sql>` (alias `analyze query`)
+- Add top-level `flaker explain <topic>` (new umbrella for 5 analyze subcommands)
+- Make `flaker import <file>` auto-detect adapter from file extension, keep `--adapter` as override
+- Make `flaker report <file>` accept `--summary / --diff <base> / --aggregate <dir>` instead of subcommands
+- Generalize `warnDeprecated` to support a list of aliases
+- Mark all absorbed commands as DEPRECATED with stderr warnings
+- Reorganize `flaker --help` to show only the 10 primary commands; everything else under `Advanced:` footer or hidden
+- Bump version to 0.7.0 in package.json + CHANGELOG entry
+
+**Out of scope (separate plans):**
+- Actual removal of deprecated commands (0.8.0)
+- `docs/migration-0.6-to-0.7.md` (Phase 2)
+- Rewriting `flaker-setup` / `flaker-management` skills (Phase 2)
+- Hiding `dev` subtree from root `--help` (Phase 2; needs coordination with contributors)
+- `apply --output` artifact emission to subsume `ops daily` (Phase 2)
+- `apply --emit weekly` / `--emit incident` (Phase 2)
+
+---
+
+## File structure
+
+**Create:**
+- `src/cli/categories/explain.ts` — umbrella for AI analysis
+- `src/cli/deprecation.ts` — generalized deprecation-warning infrastructure
+- `tests/cli/surface-reduction.test.ts` — shape test asserting the 10 primary commands
+
+**Modify (per task):**
+- `src/cli/main.ts` — add `query` top-level, `explain` top-level, reorganize help, wire deprecations for `exec`, `setup`, `ops daily`, `collect *`, `quarantine`, `policy`, `analyze kpi|eval|flaky|flaky-tag|reason|insights|cluster|bundle|context|query`, `gate review|history|explain`, `import parquet`, `report summary|diff|aggregate`, `debug doctor`
+- `src/cli/commands/status/summary.ts` — add `--detail`, `--markdown`, `--list`, `--gate` rendering
+- `src/cli/categories/analyze.ts` — flag `analyze *` (except `query`) as deprecated
+- `src/cli/categories/import.ts` — add file-extension auto-detect
+- `src/cli/categories/report.ts` — add flag-based API
+- `package.json` — bump to 0.7.0
+- `CHANGELOG.md` — record breaking deprecations
+
+---
+
+## Task breakdown
+
+### Task 1: Generalize `warnDeprecated` infrastructure
+
+**Files:**
+- Create: `src/cli/deprecation.ts`
+- Modify: `src/cli/main.ts` (replace inline helper)
+- Test: `tests/cli/deprecation-infra.test.ts`
+
+- [ ] Write failing test: `deprecate(cmd, { since, remove, canonical })` attaches both an action-wrap warning (stderr) and an `outputHelp` override warning, and updates the command description.
+- [ ] Implement `deprecate()` in `src/cli/deprecation.ts`. Signature:
+   ```ts
+   export function deprecate(
+     cmd: Command,
+     opts: { since: string; remove: string; canonical: string }
+   ): Command;
+   ```
+   It wraps `cmd._action`, overrides `outputHelp`, and rewrites the description to prepend `DEPRECATED (removed in <remove>) — use \`<canonical>\` instead.`
+- [ ] Replace the inline `warnDeprecated` / `attachDeprecationWarning` in main.ts with calls to `deprecate()`.
+- [ ] Run existing deprecation-warning test; it should still pass (message text unchanged).
+- [ ] Commit `refactor(cli): generalize deprecation helper`.
+
+### Task 2: `flaker status` gains `--markdown`
+
+**Files:**
+- Modify: `src/cli/commands/status/summary.ts`
+- Modify: `src/cli/main.ts` (register new option)
+- Test: `tests/cli/status-markdown.test.ts`
+
+- [ ] Failing test: `runStatusSummary` + `formatStatusSummary` accept a `format: "text" | "markdown" | "json"` argument, and `"markdown"` output contains `# flaker Status` plus section headings matching the existing text mode but with proper Markdown tables.
+- [ ] Implement a `formatStatusMarkdown(summary)` function beside `formatStatusSummary` that renders the same fields as a Markdown document.
+- [ ] Add `--markdown` flag to `flaker status` in `main.ts` mutually exclusive with `--json`.
+- [ ] Commit `feat(status): add --markdown output for weekly review artifacts`.
+
+### Task 3: `flaker status --list <flaky|quarantined>`
+
+**Files:**
+- Modify: `src/cli/commands/status/summary.ts` and/or add `src/cli/commands/status/list.ts`
+- Test: `tests/cli/status-list.test.ts`
+
+- [ ] Failing test: `flaker status --list flaky` prints a table of top N flaky tests (reuse `analyze flaky` logic).
+- [ ] Failing test: `flaker status --list quarantined` prints the current quarantine manifest.
+- [ ] Implement a `listFlaky()` and `listQuarantined()` function that reuses existing analyze/quarantine primitives, and branch in `statusAction`.
+- [ ] Commit `feat(status): add --list flaky and --list quarantined`.
+
+### Task 4: `flaker status --gate <name>` and `--detail`
+
+**Files:**
+- Modify: `src/cli/commands/status/summary.ts`
+- Test: `tests/cli/status-detail.test.ts`
+
+- [ ] Failing test: `--detail` renders promotion-threshold actuals next to each `unmet` drift row (matched_commits: 18/20 style), plus `sampleRatio`, `recall`, `falsePositiveRate`, `skippedMinutes`.
+- [ ] Failing test: `--gate merge --detail --json` returns a narrowed view focusing on the merge gate only.
+- [ ] Implement.
+- [ ] Commit `feat(status): add --detail and --gate for operator-grade reporting`.
+
+### Task 5: Deprecate `analyze kpi`, `analyze eval`, `analyze flaky`, `analyze flaky-tag`
+
+**Files:**
+- Modify: `src/cli/categories/analyze.ts` (wrap registrations with `deprecate()`)
+- Test: extend `tests/cli/deprecation-warning.test.ts`
+
+- [ ] Failing test: each of the 4 commands emits the deprecation warning with a canonical pointer (`status` for kpi/eval/flaky, `apply` for flaky-tag).
+- [ ] Apply `deprecate(cmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker status" })` (etc.) to each registration.
+- [ ] Commit `feat(cli): deprecate analyze kpi/eval/flaky/flaky-tag in favor of status/apply`.
+
+### Task 6: Top-level `flaker query <sql>`
+
+**Files:**
+- Modify: `src/cli/main.ts` (register top-level `query`)
+- Modify: `src/cli/categories/analyze.ts` (mark `analyze query` deprecated, canonical: `flaker query`)
+- Test: `tests/cli/query-top-level.test.ts`
+
+- [ ] Failing test: `flaker query --help` works; `flaker analyze query --help` emits the deprecation warning.
+- [ ] Move action to top-level `query` and deprecate the analyze form.
+- [ ] Commit `feat(cli): promote analyze query to top-level flaker query`.
+
+### Task 7: New `flaker explain <topic>` umbrella
+
+**Files:**
+- Create: `src/cli/categories/explain.ts`
+- Modify: `src/cli/main.ts` (register category)
+- Modify: `src/cli/categories/analyze.ts` (deprecate `reason`, `insights`, `cluster`, `bundle`, `context`)
+- Test: `tests/cli/explain.test.ts`
+
+- [ ] Failing test: `flaker explain reason --help` (and the 4 others) show the expected help.
+- [ ] `flaker explain <topic>` routes to existing actions for `reason | insights | cluster | bundle | context`. Implementation: import the existing action functions and dispatch by topic.
+- [ ] Deprecate the 5 `analyze *` commands pointing at the new `explain <topic>` canonical form.
+- [ ] Commit `feat(cli): add flaker explain umbrella and deprecate analyze reason/insights/cluster/bundle/context`.
+
+### Task 8: `flaker import` adapter auto-detect
+
+**Files:**
+- Modify: `src/cli/categories/import.ts`
+- Test: `tests/cli/import-autodetect.test.ts`
+
+- [ ] Failing test: `flaker import report.xml` auto-picks `junit`; `flaker import report.json` needs disambiguation (default to `playwright`, override via `--adapter vitest` etc.); `flaker import report.parquet` uses the parquet branch.
+- [ ] Implement extension inference: `.xml` → junit, `.parquet` → parquet, `.json` → playwright (default) with CLI flag override. Keep existing `import report <file>` subcommand working but deprecate it.
+- [ ] Commit `feat(import): auto-detect adapter from file extension`.
+
+### Task 9: `flaker report` flag-based API
+
+**Files:**
+- Modify: `src/cli/categories/report.ts`
+- Test: `tests/cli/report-flags.test.ts`
+
+- [ ] Failing test: `flaker report path --summary`, `--diff <base>`, `--aggregate <dir>` all dispatch to the existing logic; old `flaker report summary|diff|aggregate` subcommands still work but emit deprecation warning.
+- [ ] Implement a top-level action that dispatches based on which flag is set (mutually exclusive). Deprecate the subcommands.
+- [ ] Commit `feat(report): unify summary/diff/aggregate under flag-based API`.
+
+### Task 10: Deprecate `setup`, `exec`, `ops daily`, `collect *`, `quarantine`, `policy`, `gate review/history/explain`, `debug doctor`, `import parquet`, `import report`
+
+**Files:**
+- Modify: every `categories/*.ts` touched
+- Test: extend `tests/cli/deprecation-warning.test.ts`
+
+- [ ] Apply `deprecate(cmd, { ... })` to each command per the mapping table at the top of this plan. Canonical pointers:
+   - `setup init` → `flaker init`
+   - `setup` (category) → `flaker init` (hidden; category becomes empty)
+   - `exec run` → `flaker run`
+   - `exec affected` → `flaker run --gate iteration --changed <paths>`
+   - `ops daily` → `flaker apply` (artifact path via `--output` once Phase 2 lands; keep warning pointing to `apply`)
+   - `collect ci / local / coverage / commit-changes / calibrate` → `flaker apply`
+   - `quarantine suggest / apply` → `flaker apply`
+   - `policy quarantine / check / report` → `flaker apply`
+   - `gate review / history / explain` → `flaker status --gate <name> --detail`
+   - `debug doctor` → `flaker doctor`
+   - `import parquet` → `flaker import <file>` (auto-detect)
+   - `import report` → `flaker import <file>` (auto-detect)
+- [ ] Commit `feat(cli): deprecate 14 commands now absorbed into apply/status/import/run`.
+
+### Task 11: Reorganize `flaker --help`
+
+**Files:**
+- Modify: `src/cli/main.ts` (`helpInformation` override)
+- Test: `tests/cli/help-shape.test.ts`
+
+- [ ] Failing test: top-level help lists only the 10 primary commands under "Primary commands" and groups the rest under "Advanced" and "Deprecated (removed in 0.8.0)" sections.
+- [ ] Update the `helpInformation` override to match. Keep category help (`flaker <category> --help`) intact.
+- [ ] Commit `docs(cli): reorganize help around the 10 primary commands`.
+
+### Task 12: Surface-reduction shape test
+
+**Files:**
+- Create: `tests/cli/surface-reduction.test.ts`
+
+- [ ] Write a test that runs `node dist/cli/main.js --help`, extracts the "Primary commands" block, and asserts exactly the 10 expected entries. Regression net against accidental re-expansion.
+- [ ] Commit `test(cli): lock primary command surface to 10 entries`.
+
+### Task 13: Version + changelog
+
+**Files:**
+- Modify: `package.json`, `CHANGELOG.md`
+- Commit last.
+
+- [ ] Bump `version` in `package.json` to `0.7.0-next.0` (so 0.7.0 proper ships after skill/docs migration in Phase 2).
+- [ ] Add a CHANGELOG section listing the deprecations and the migration target for each.
+- [ ] Commit `chore(release): 0.7.0-next.0 — surface reduction phase 1`.
+
+---
+
+## Self-review
+
+### Spec coverage
+Every command in the current 53-leaf surface has an entry in the mapping table at the top of this plan and at least one task that handles its migration. Tasks 2–4 absorb behavior into `status`; Tasks 6–7 introduce new umbrellas; Tasks 8–9 consolidate IO verbs via flags; Task 10 blanket-deprecates the rest; Task 11 reorganizes help; Task 12 locks the invariant.
+
+### Placeholders
+None — each task has concrete file paths, code shape, test names, and commit messages. The only intentional deferral is the actual removal of deprecated commands (0.8.0, separate plan) and the artifact-emission side of `apply --output` (Phase 2).
+
+### Type consistency
+- `status` flag names: `--detail` / `--markdown` / `--json` / `--list` / `--gate` are documented consistently across Tasks 2–4 and Task 11.
+- Deprecation canonical pointers in Task 5 / Task 10 all point to commands that exist after Tasks 2–9 land. Task ordering matters: execute Tasks 1–9 in order, then Task 10 can safely refer to the new commands.
+
+### Risk notes
+- `status --list flaky` duplicates `analyze flaky` output shape. Resist rewriting the flaky detection logic; call it from status.
+- `explain <topic>` is an umbrella; keeping the underlying actions unchanged and only dispatching from the new entry minimizes regression surface.
+- `import` auto-detect is a behavior change: `.json` currently requires `--adapter`. Default to `playwright` when extension-only inference is ambiguous, and log the chosen adapter on stderr so users can see what was inferred.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mizchi/flaker",
-  "version": "0.5.0",
+  "version": "0.7.0-next.0",
   "description": "Flaky test detection, sampling, and test runner orchestration",
   "type": "module",
   "bin": {

--- a/src/cli/categories/analyze.ts
+++ b/src/cli/categories/analyze.ts
@@ -37,6 +37,7 @@ import {
   runStatusListQuarantined,
 } from "../commands/status/summary.js";
 import type { GateName } from "../gate.js";
+import { deprecate } from "../deprecation.js";
 
 export async function analyzeKpiAction(opts: { windowDays: string; json?: boolean }): Promise<void> {
   const config = loadConfig(process.cwd());
@@ -153,7 +154,7 @@ export function registerAnalyzeCommands(program: Command): void {
       }
     });
 
-  analyze
+  const flakyTagCmd = analyze
     .command("flaky-tag")
     .description("Suggest which Playwright tests should gain or lose the flaky tag")
     .option("--window-days <days>", "Analysis window in days")
@@ -198,15 +199,17 @@ export function registerAnalyzeCommands(program: Command): void {
         await store.close();
       }
     });
+  deprecate(flakyTagCmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker apply" });
 
-  analyze
+  const kpiCmd = analyze
     .command("kpi")
     .description("Show KPI dashboard — sampling effectiveness, flaky tracking, data quality")
     .option("--window-days <days>", "Analysis window in days", "30")
     .option("--json", "Output as JSON")
     .action(analyzeKpiAction);
+  deprecate(kpiCmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker status" });
 
-  analyze
+  const flakyCmd = analyze
     .command("flaky")
     .description("Inspect flaky tests and failure-rate trends")
     .option("--top <n>", "Number of top flaky tests to show")
@@ -242,6 +245,7 @@ export function registerAnalyzeCommands(program: Command): void {
         await store.close();
       }
     });
+  deprecate(flakyCmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker status --list flaky" });
 
   analyze
     .command("cluster")
@@ -316,7 +320,7 @@ export function registerAnalyzeCommands(program: Command): void {
       }
     });
 
-  analyze
+  const evalCmd = analyze
     .command("eval")
     .description("Measure whether local sampled runs predict CI")
     .option("--window <days>", "Analysis window in days")
@@ -347,6 +351,7 @@ export function registerAnalyzeCommands(program: Command): void {
         await store.close();
       }
     });
+  deprecate(evalCmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker status --markdown" });
 
   analyze
     .command("context")

--- a/src/cli/categories/analyze.ts
+++ b/src/cli/categories/analyze.ts
@@ -122,37 +122,146 @@ export async function statusAction(opts: {
   }
 }
 
+export async function analyzeBundleAction(opts: { windowDays: string; output?: string }): Promise<void> {
+  const { writeFileSync } = await import("node:fs");
+  const config = loadConfig(process.cwd());
+  const store = new DuckDBStore(resolve(config.storage.path));
+  await store.initialize();
+  try {
+    const bundle = await runAnalysisBundle({
+      store,
+      storagePath: config.storage.path,
+      resolverConfigured: !!(config as any).affected,
+      windowDays: parseInt(opts.windowDays, 10),
+    });
+    const rendered = formatAnalysisBundle(bundle);
+    console.log(rendered);
+    if (opts.output) {
+      writeFileSync(resolve(process.cwd(), opts.output), rendered, "utf8");
+    }
+  } finally {
+    await store.close();
+  }
+}
+
+export async function analyzeClusterAction(opts: {
+  windowDays: string;
+  minCoFailures: string;
+  minCoRate: string;
+  top: string;
+}): Promise<void> {
+  const config = loadConfig(process.cwd());
+  const store = new DuckDBStore(resolve(config.storage.path));
+  await store.initialize();
+  try {
+    const clusters = await runFailureClusters({
+      store,
+      windowDays: parseInt(opts.windowDays, 10),
+      minCoFailures: parseInt(opts.minCoFailures, 10),
+      minCoRate: Number(opts.minCoRate),
+      top: parseInt(opts.top, 10),
+    });
+    console.log(formatFailureClusters(clusters));
+  } finally {
+    await store.close();
+  }
+}
+
+export async function analyzeReasonAction(opts: { window: string; json?: boolean }): Promise<void> {
+  const config = loadConfig(process.cwd());
+  const store = new DuckDBStore(resolve(config.storage.path));
+  await store.initialize();
+  try {
+    const report = await runReason({ store, windowDays: Number(opts.window) });
+    if (opts.json) {
+      console.log(JSON.stringify(report, null, 2));
+    } else {
+      console.log(formatReasoningReport(report));
+    }
+  } finally {
+    await store.close();
+  }
+}
+
+export async function analyzeInsightsAction(opts: { windowDays: string; top: string }): Promise<void> {
+  const config = loadConfig(process.cwd());
+  const store = new DuckDBStore(resolve(config.storage.path));
+  await store.initialize();
+  try {
+    const { runInsights: _runInsights, formatInsights } = await import("../commands/analyze/insights.js");
+    const result = await _runInsights({
+      store,
+      windowDays: parseInt(opts.windowDays, 10),
+      top: parseInt(opts.top, 10),
+    });
+    console.log(formatInsights(result));
+  } finally {
+    await store.close();
+  }
+}
+
+export async function analyzeContextAction(opts: { json?: boolean }): Promise<void> {
+  const config = loadConfig(process.cwd());
+  const store = new DuckDBStore(resolve(config.storage.path));
+  await store.initialize();
+
+  try {
+    const hasResolver = !!(config as any).affected;
+    const { buildContext, formatContext } = await import("../commands/analyze/context.js");
+    const ctx = await buildContext(store, {
+      storagePath: config.storage.path,
+      resolverConfigured: hasResolver,
+    });
+
+    if (opts.json) {
+      console.log(JSON.stringify(ctx, null, 2));
+    } else {
+      console.log(formatContext(ctx));
+    }
+  } finally {
+    await store.close();
+  }
+}
+
+export async function analyzeQueryAction(sql: string): Promise<void> {
+  // Reject write operations and dangerous DuckDB functions
+  const stripped = sql.replace(/--[^\n]*/g, "").replace(/\/\*[\s\S]*?\*\//g, "").trim();
+  const normalized = stripped.toUpperCase();
+  const writePatterns = /^(INSERT|UPDATE|DELETE|DROP|ALTER|CREATE|TRUNCATE|COPY\s|ATTACH|LOAD|INSTALL)/;
+  if (writePatterns.test(normalized)) {
+    console.error("Error: query command only supports read-only (SELECT/WITH) queries.");
+    process.exit(1);
+  }
+  // Block DuckDB filesystem functions
+  const dangerousFns = /\b(READ_CSV_AUTO|READ_CSV|READ_PARQUET|READ_JSON_AUTO|READ_JSON|READ_BLOB|READ_TEXT|WRITE_CSV|HTTPFS)\s*\(/i;
+  if (dangerousFns.test(stripped)) {
+    console.error("Error: filesystem/network functions are not allowed in query command.");
+    process.exit(1);
+  }
+  const config = loadConfig(process.cwd());
+  const store = new DuckDBStore(resolve(config.storage.path));
+  await store.initialize();
+
+  try {
+    const rows = await runQuery(store, sql);
+    console.log(formatQueryResult(rows as Record<string, unknown>[]));
+  } finally {
+    await store.close();
+  }
+}
+
 export function registerAnalyzeCommands(program: Command): void {
   const analyze = program
     .command("analyze")
     .description("Read-only inspection of flaker data");
 
-  analyze
+  const bundleCmd = analyze
     .command("bundle")
     .description("Export a machine-readable analysis bundle for AI consumers")
     .option("--window-days <days>", "Analysis window in days", "30")
     .option("--output <file>", "Write bundle JSON to a file")
-    .action(async (opts: { windowDays: string; output?: string }) => {
-      const { writeFileSync } = await import("node:fs");
-      const config = loadConfig(process.cwd());
-      const store = new DuckDBStore(resolve(config.storage.path));
-      await store.initialize();
-      try {
-        const bundle = await runAnalysisBundle({
-          store,
-          storagePath: config.storage.path,
-          resolverConfigured: !!(config as any).affected,
-          windowDays: parseInt(opts.windowDays, 10),
-        });
-        const rendered = formatAnalysisBundle(bundle);
-        console.log(rendered);
-        if (opts.output) {
-          writeFileSync(resolve(process.cwd(), opts.output), rendered, "utf8");
-        }
-      } finally {
-        await store.close();
-      }
-    });
+    .action(analyzeBundleAction);
+  deprecate(bundleCmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker explain bundle" });
 
   const flakyTagCmd = analyze
     .command("flaky-tag")
@@ -247,78 +356,31 @@ export function registerAnalyzeCommands(program: Command): void {
     });
   deprecate(flakyCmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker status --list flaky" });
 
-  analyze
+  const clusterCmd = analyze
     .command("cluster")
     .description("Inspect clusters of tests that frequently fail together")
     .option("--window-days <days>", "Analysis window in days", "90")
     .option("--min-co-failures <n>", "Minimum shared failing runs", "2")
     .option("--min-co-rate <ratio>", "Minimum co-failure rate as ratio (0.0-1.0)", "0.8")
     .option("--top <n>", "Number of clusters to show", "20")
-    .action(async (opts: {
-      windowDays: string;
-      minCoFailures: string;
-      minCoRate: string;
-      top: string;
-    }) => {
-      const config = loadConfig(process.cwd());
-      const store = new DuckDBStore(resolve(config.storage.path));
-      await store.initialize();
-      try {
-        const clusters = await runFailureClusters({
-          store,
-          windowDays: parseInt(opts.windowDays, 10),
-          minCoFailures: parseInt(opts.minCoFailures, 10),
-          minCoRate: Number(opts.minCoRate),
-          top: parseInt(opts.top, 10),
-        });
-        console.log(formatFailureClusters(clusters));
-      } finally {
-        await store.close();
-      }
-    });
+    .action(analyzeClusterAction);
+  deprecate(clusterCmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker explain cluster" });
 
-  analyze
+  const reasonCmd = analyze
     .command("reason")
     .description("Analyze flaky tests and produce actionable recommendations")
     .option("--window <days>", "Analysis window in days", "30")
     .option("--json", "Output raw JSON report")
-    .action(async (opts: { window: string; json?: boolean }) => {
-      const config = loadConfig(process.cwd());
-      const store = new DuckDBStore(resolve(config.storage.path));
-      await store.initialize();
-      try {
-        const report = await runReason({ store, windowDays: Number(opts.window) });
-        if (opts.json) {
-          console.log(JSON.stringify(report, null, 2));
-        } else {
-          console.log(formatReasoningReport(report));
-        }
-      } finally {
-        await store.close();
-      }
-    });
+    .action(analyzeReasonAction);
+  deprecate(reasonCmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker explain reason" });
 
-  analyze
+  const insightsCmd = analyze
     .command("insights")
     .description("Compare CI vs local failure patterns to identify environment-specific issues")
     .option("--window-days <days>", "Analysis window in days", "90")
     .option("--top <n>", "Number of tests to show per category", "20")
-    .action(async (opts: { windowDays: string; top: string }) => {
-      const config = loadConfig(process.cwd());
-      const store = new DuckDBStore(resolve(config.storage.path));
-      await store.initialize();
-      try {
-        const { runInsights: _runInsights, formatInsights } = await import("../commands/analyze/insights.js");
-        const result = await _runInsights({
-          store,
-          windowDays: parseInt(opts.windowDays, 10),
-          top: parseInt(opts.top, 10),
-        });
-        console.log(formatInsights(result));
-      } finally {
-        await store.close();
-      }
-    });
+    .action(analyzeInsightsAction);
+  deprecate(insightsCmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker explain insights" });
 
   const evalCmd = analyze
     .command("eval")
@@ -353,32 +415,12 @@ export function registerAnalyzeCommands(program: Command): void {
     });
   deprecate(evalCmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker status --markdown" });
 
-  analyze
+  const contextCmd = analyze
     .command("context")
     .description("Show environment data and strategy characteristics for decision-making")
     .option("--json", "Output as JSON for programmatic consumption")
-    .action(async (opts) => {
-      const config = loadConfig(process.cwd());
-      const store = new DuckDBStore(resolve(config.storage.path));
-      await store.initialize();
-
-      try {
-        const hasResolver = !!(config as any).affected;
-        const { buildContext, formatContext } = await import("../commands/analyze/context.js");
-        const ctx = await buildContext(store, {
-          storagePath: config.storage.path,
-          resolverConfigured: hasResolver,
-        });
-
-        if (opts.json) {
-          console.log(JSON.stringify(ctx, null, 2));
-        } else {
-          console.log(formatContext(ctx));
-        }
-      } finally {
-        await store.close();
-      }
-    });
+    .action(analyzeContextAction);
+  deprecate(contextCmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker explain context" });
 
   const queryCmd = analyze
     .command("query <sql>")
@@ -391,30 +433,6 @@ Examples:
   flaker analyze query "SELECT * FROM test_results ORDER BY created_at DESC LIMIT 20"
 `);
 
-  queryCmd.action(async (sql: string) => {
-      // Reject write operations and dangerous DuckDB functions
-      const stripped = sql.replace(/--[^\n]*/g, "").replace(/\/\*[\s\S]*?\*\//g, "").trim();
-      const normalized = stripped.toUpperCase();
-      const writePatterns = /^(INSERT|UPDATE|DELETE|DROP|ALTER|CREATE|TRUNCATE|COPY\s|ATTACH|LOAD|INSTALL)/;
-      if (writePatterns.test(normalized)) {
-        console.error("Error: query command only supports read-only (SELECT/WITH) queries.");
-        process.exit(1);
-      }
-      // Block DuckDB filesystem functions
-      const dangerousFns = /\b(READ_CSV_AUTO|READ_CSV|READ_PARQUET|READ_JSON_AUTO|READ_JSON|READ_BLOB|READ_TEXT|WRITE_CSV|HTTPFS)\s*\(/i;
-      if (dangerousFns.test(stripped)) {
-        console.error("Error: filesystem/network functions are not allowed in query command.");
-        process.exit(1);
-      }
-      const config = loadConfig(process.cwd());
-      const store = new DuckDBStore(resolve(config.storage.path));
-      await store.initialize();
-
-      try {
-        const rows = await runQuery(store, sql);
-        console.log(formatQueryResult(rows as Record<string, unknown>[]));
-      } finally {
-        await store.close();
-      }
-    });
+  queryCmd.action(analyzeQueryAction);
+  deprecate(queryCmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker query" });
 }

--- a/src/cli/categories/analyze.ts
+++ b/src/cli/categories/analyze.ts
@@ -26,7 +26,17 @@ import {
   runFlakyTagTriage,
 } from "../commands/analyze/flaky-tag-triage.js";
 import { createRunner } from "../runners/index.js";
-import { formatStatusSummary, runStatusSummary } from "../commands/status/summary.js";
+import {
+  formatStatusSummary,
+  formatStatusMarkdown,
+  renderDetail,
+  renderListFlaky,
+  renderListQuarantined,
+  runStatusSummary,
+  runStatusListFlaky,
+  runStatusListQuarantined,
+} from "../commands/status/summary.js";
+import type { GateName } from "../gate.js";
 
 export async function analyzeKpiAction(opts: { windowDays: string; json?: boolean }): Promise<void> {
   const config = loadConfig(process.cwd());
@@ -45,21 +55,67 @@ export async function analyzeKpiAction(opts: { windowDays: string; json?: boolea
   }
 }
 
-export async function statusAction(opts: { windowDays: string; json?: boolean }): Promise<void> {
+export async function statusAction(opts: {
+  windowDays: string;
+  json?: boolean;
+  markdown?: boolean;
+  list?: string;
+  detail?: boolean;
+  gate?: string;
+}): Promise<void> {
+  // Mutual exclusion checks
+  if (opts.markdown && opts.json) {
+    console.error("Error: --markdown and --json are mutually exclusive");
+    process.exit(2);
+  }
+  if (opts.list && (opts.markdown || opts.detail)) {
+    console.error("Error: --list is a standalone mode and cannot be combined with --markdown or --detail");
+    process.exit(2);
+  }
+
   const config = loadConfig(process.cwd());
   const store = new DuckDBStore(resolve(config.storage.path));
   await store.initialize();
   try {
+    // --list modes: standalone, skip normal summary
+    if (opts.list === "flaky") {
+      const rows = await runStatusListFlaky({ store, windowDays: parseInt(opts.windowDays, 10) });
+      console.log(renderListFlaky(rows));
+      return;
+    }
+    if (opts.list === "quarantined") {
+      const rows = await runStatusListQuarantined({ store });
+      console.log(renderListQuarantined(rows));
+      return;
+    }
+    if (opts.list) {
+      console.error(`Error: unknown --list value '${opts.list}'. Use 'flaky' or 'quarantined'.`);
+      process.exit(2);
+    }
+
+    const gate = opts.gate as GateName | undefined;
     const summary = await runStatusSummary({
       store,
       config,
       windowDays: parseInt(opts.windowDays, 10),
+      gate,
     });
+
+    let output: string;
     if (opts.json) {
       console.log(JSON.stringify(summary, null, 2));
+      return;
+    } else if (opts.markdown) {
+      output = formatStatusMarkdown(summary);
     } else {
-      console.log(formatStatusSummary(summary));
+      output = formatStatusSummary(summary);
     }
+
+    if (opts.detail) {
+      output += "\n\n" + renderDetail(summary.drift, config.promotion);
+    }
+
+    console.log(output);
   } finally {
     await store.close();
   }

--- a/src/cli/categories/analyze.ts
+++ b/src/cli/categories/analyze.ts
@@ -36,7 +36,7 @@ import {
   runStatusListFlaky,
   runStatusListQuarantined,
 } from "../commands/status/summary.js";
-import type { GateName } from "../gate.js";
+import { type GateName, VALID_GATE_NAMES } from "../gate.js";
 import { deprecate } from "../deprecation.js";
 
 export async function analyzeKpiAction(opts: { windowDays: string; json?: boolean }): Promise<void> {
@@ -91,6 +91,13 @@ export async function statusAction(opts: {
     }
     if (opts.list) {
       console.error(`Error: unknown --list value '${opts.list}'. Use 'flaky' or 'quarantined'.`);
+      process.exit(2);
+    }
+
+    if (opts.gate && !(VALID_GATE_NAMES as readonly string[]).includes(opts.gate)) {
+      console.error(
+        `Error: unknown --gate value '${opts.gate}'. Valid gates: ${VALID_GATE_NAMES.join(" | ")}.`,
+      );
       process.exit(2);
     }
 

--- a/src/cli/categories/collect.ts
+++ b/src/cli/categories/collect.ts
@@ -1,5 +1,6 @@
 import { resolve } from "node:path";
 import type { Command } from "commander";
+import { deprecate } from "../deprecation.js";
 import { Octokit } from "@octokit/rest";
 import { loadConfig, writeSamplingConfig, type FlakerConfig } from "../config.js";
 import {
@@ -155,9 +156,10 @@ export function registerCollectCommands(program: Command): void {
     .option("--output <file>", "Write collect summary to a file")
     .option("--fail-on-errors", "Exit with status 1 when any workflow run fails to collect")
     .action(collectCiAction);
+  deprecate(collectCmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker apply" });
 
   // --- collect ci ---
-  collectCmd
+  const collectCiCmd = collectCmd
     .command("ci")
     .description("Collect workflow runs from GitHub")
     .option("--days <n>", "Number of days to look back", "30")
@@ -166,9 +168,10 @@ export function registerCollectCommands(program: Command): void {
     .option("--output <file>", "Write collect summary to a file")
     .option("--fail-on-errors", "Exit with status 1 when any workflow run fails to collect")
     .action(collectCiAction);
+  deprecate(collectCiCmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker apply" });
 
   // --- collect local ---
-  collectCmd
+  const collectLocalCmd = collectCmd
     .command("local")
     .description("Import actrun local run history into flaker")
     .option("--last <n>", "Import only last N runs")
@@ -192,9 +195,10 @@ export function registerCollectCommands(program: Command): void {
         await store.close();
       }
     });
+  deprecate(collectLocalCmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker apply" });
 
   // --- collect coverage ---
-  collectCmd
+  const collectCoverageCmd = collectCmd
     .command("coverage")
     .description("Collect test coverage data and store edges in DuckDB")
     .requiredOption("--format <type>", "Coverage format: istanbul, v8, playwright")
@@ -220,9 +224,10 @@ export function registerCollectCommands(program: Command): void {
         await store.close();
       }
     });
+  deprecate(collectCoverageCmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker apply" });
 
   // --- collect commit-changes ---
-  collectCmd
+  const collectCommitChangesCmd = collectCmd
     .command("commit-changes")
     .description("Collect commit change data")
     .action(async () => {
@@ -232,9 +237,10 @@ export function registerCollectCommands(program: Command): void {
       console.error("Error: collect commit-changes requires --commit <sha> option");
       process.exit(1);
     });
+  deprecate(collectCommitChangesCmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker apply" });
 
   // --- collect calibrate ---
-  collectCmd
+  const collectCalibrateCmd = collectCmd
     .command("calibrate")
     .description("Analyze project history and write optimal [sampling] config to flaker.toml")
     .option("--window-days <days>", "Analysis window in days", "90")
@@ -279,4 +285,5 @@ export function registerCollectCommands(program: Command): void {
         await store.close();
       }
     });
+  deprecate(collectCalibrateCmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker apply" });
 }

--- a/src/cli/categories/debug.ts
+++ b/src/cli/categories/debug.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import { deprecate } from "../deprecation.js";
 import { runDoctor, formatDoctorReport } from "../commands/debug/doctor.js";
 import { runBisect } from "../commands/debug/bisect.js";
 import { runRetry, formatRetryReport } from "../commands/debug/retry.js";
@@ -205,8 +206,9 @@ With --json, prints: {"verdict": "BROKEN|FLAKY|TRANSIENT", "runs": {...}}
       },
     );
 
-  debug
+  const debugDoctorCmd = debug
     .command("doctor")
     .description("Check local flaker runtime requirements")
     .action(debugDoctorAction);
+  deprecate(debugDoctorCmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker doctor" });
 }

--- a/src/cli/categories/exec.ts
+++ b/src/cli/categories/exec.ts
@@ -1,5 +1,6 @@
 import { resolve } from "node:path";
 import type { Command } from "commander";
+import { deprecate } from "../deprecation.js";
 import {
   loadConfig,
   resolveActrunWorkflowPath,
@@ -161,7 +162,7 @@ export function registerExecCommands(program: Command): void {
     .command("exec")
     .description("Test selection and execution");
 
-  addSamplingOptions(
+  const execRunCmd = addSamplingOptions(
     exec
       .command("run")
       .description("Run the selected gate or profile (auto-detects changed files and strategy from config)")
@@ -172,8 +173,9 @@ export function registerExecCommands(program: Command): void {
   )
     .addHelpText("after", RUN_COMMAND_HELP)
     .action(execRunAction);
+  deprecate(execRunCmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker run" });
 
-  exec
+  const execAffectedCmd = exec
     .command("affected [paths...]")
     .description("Explain affected test selection for changed files")
     .option("--changed <files>", "Comma-separated list of changed files")
@@ -220,4 +222,5 @@ export function registerExecCommands(program: Command): void {
         );
       },
     );
+  deprecate(execAffectedCmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker run --gate iteration --changed <paths>" });
 }

--- a/src/cli/categories/explain.ts
+++ b/src/cli/categories/explain.ts
@@ -1,0 +1,50 @@
+import type { Command } from "commander";
+import {
+  analyzeReasonAction,
+  analyzeInsightsAction,
+  analyzeClusterAction,
+  analyzeBundleAction,
+  analyzeContextAction,
+} from "./analyze.js";
+
+export function registerExplainCommands(program: Command): void {
+  const explain = program
+    .command("explain")
+    .description("Explain flaker findings (reason | insights | cluster | bundle | context)");
+
+  explain
+    .command("reason")
+    .description("Analyze flaky tests and produce actionable recommendations")
+    .option("--window <days>", "Analysis window in days", "30")
+    .option("--json", "Output raw JSON report")
+    .action(analyzeReasonAction);
+
+  explain
+    .command("insights")
+    .description("Compare CI vs local failure patterns to identify environment-specific issues")
+    .option("--window-days <days>", "Analysis window in days", "90")
+    .option("--top <n>", "Number of tests to show per category", "20")
+    .action(analyzeInsightsAction);
+
+  explain
+    .command("cluster")
+    .description("Inspect clusters of tests that frequently fail together")
+    .option("--window-days <days>", "Analysis window in days", "90")
+    .option("--min-co-failures <n>", "Minimum shared failing runs", "2")
+    .option("--min-co-rate <ratio>", "Minimum co-failure rate as ratio (0.0-1.0)", "0.8")
+    .option("--top <n>", "Number of clusters to show", "20")
+    .action(analyzeClusterAction);
+
+  explain
+    .command("bundle")
+    .description("Export a machine-readable analysis bundle for AI consumers")
+    .option("--window-days <days>", "Analysis window in days", "30")
+    .option("--output <file>", "Write bundle JSON to a file")
+    .action(analyzeBundleAction);
+
+  explain
+    .command("context")
+    .description("Show environment data and strategy characteristics for decision-making")
+    .option("--json", "Output as JSON for programmatic consumption")
+    .action(analyzeContextAction);
+}

--- a/src/cli/categories/gate.ts
+++ b/src/cli/categories/gate.ts
@@ -1,5 +1,6 @@
 import { resolve } from "node:path";
 import type { Command } from "commander";
+import { deprecate } from "../deprecation.js";
 import { loadConfig } from "../config.js";
 import { DuckDBStore } from "../storage/duckdb.js";
 import { normalizeGateName, profileNameFromGateName } from "../gate.js";
@@ -81,23 +82,26 @@ export function registerGateCommands(program: Command): void {
     .command("gate")
     .description("Gate review and readiness inspection");
 
-  gate
+  const gateReviewCmd = gate
     .command("review <gate>")
     .description("Review gate readiness and recommended action")
     .option("--window-days <days>", "Analysis window in days", "30")
     .option("--json", "Output as JSON")
     .action(gateReviewAction);
+  deprecate(gateReviewCmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker status --gate <name> --detail" });
 
-  gate
+  const gateExplainCmd = gate
     .command("explain <gate>")
     .description("Explain resolved gate settings and their config sources")
     .option("--json", "Output as JSON")
     .action(gateExplainAction);
+  deprecate(gateExplainCmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker status --gate <name> --detail" });
 
-  gate
+  const gateHistoryCmd = gate
     .command("history <gate>")
     .description("Show recent gate outcomes and sample ratio trend")
     .option("--window-days <days>", "Analysis window in days", "14")
     .option("--json", "Output as JSON")
     .action(gateHistoryAction);
+  deprecate(gateHistoryCmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker status --gate <name>" });
 }

--- a/src/cli/categories/import.ts
+++ b/src/cli/categories/import.ts
@@ -5,21 +5,42 @@ import { loadConfig } from "../config.js";
 import { runImport } from "../commands/import/report.js";
 import { runImportParquet } from "../commands/import/parquet.js";
 import { parseWorkflowRunSource } from "../run-source.js";
+import { deprecate } from "../deprecation.js";
+
+export function detectAdapter(filePath: string): string | undefined {
+  const lower = filePath.toLowerCase();
+  if (lower.endsWith(".xml")) return "junit";
+  if (lower.endsWith(".parquet")) return "parquet";
+  if (lower.endsWith(".json")) return "playwright";
+  return undefined;
+}
 
 export function registerImportCommands(program: Command): void {
   const importCmd = program
     .command("import")
-    .description("Ingest external reports");
-
-  importCmd
-    .command("report <file>")
-    .description("Import a local test report file")
-    .option("--adapter <type>", "Adapter type (vitest, playwright, junit, vrt-migration, vrt-bench, custom)", "playwright")
+    .description("Ingest external reports")
+    .argument("[file]", "File to import (extension auto-detects adapter: .xml→junit, .parquet→parquet, .json→playwright)")
+    .option("--adapter <type>", "Adapter type override (vitest, playwright, junit, parquet, vrt-migration, vrt-bench, custom)")
     .option("--custom-command <cmd>", "Custom adapter command (required with --adapter custom)")
     .option("--commit <sha>", "Commit SHA")
     .option("--branch <branch>", "Branch name")
     .option("--source <source>", "Workflow run source: ci or local", "local")
-    .action(async (file: string, opts: { adapter: string; customCommand?: string; commit?: string; branch?: string; source?: string }) => {
+    .action(async (file: string | undefined, opts: { adapter?: string; customCommand?: string; commit?: string; branch?: string; source?: string }) => {
+      if (!file) {
+        importCmd.help();
+        return;
+      }
+      const inferredAdapter = opts.adapter ?? detectAdapter(file);
+      if (!inferredAdapter) {
+        process.stderr.write(
+          `error: cannot infer adapter from extension of "${file}". Use --adapter <type>.\n`,
+        );
+        process.exit(2);
+      }
+      if (inferredAdapter === "parquet") {
+        await runImportParquet(file);
+        return;
+      }
       const config = loadConfig(process.cwd());
       const store = new DuckDBStore(resolve(config.storage.path));
       await store.initialize();
@@ -27,7 +48,7 @@ export function registerImportCommands(program: Command): void {
         const result = await runImport({
           store,
           filePath: resolve(file),
-          adapterType: opts.adapter,
+          adapterType: inferredAdapter,
           customCommand: opts.customCommand,
           commitSha: opts.commit,
           branch: opts.branch,
@@ -40,10 +61,45 @@ export function registerImportCommands(program: Command): void {
       }
     });
 
-  importCmd
-    .command("parquet <dir>")
-    .description("Import flaker parquet artifacts from a directory")
-    .action(async (dir: string) => {
-      await runImportParquet(dir);
-    });
+  deprecate(
+    importCmd
+      .command("report <file>")
+      .description("Import a local test report file")
+      .option("--adapter <type>", "Adapter type (vitest, playwright, junit, vrt-migration, vrt-bench, custom)", "playwright")
+      .option("--custom-command <cmd>", "Custom adapter command (required with --adapter custom)")
+      .option("--commit <sha>", "Commit SHA")
+      .option("--branch <branch>", "Branch name")
+      .option("--source <source>", "Workflow run source: ci or local", "local")
+      .action(async (file: string, opts: { adapter: string; customCommand?: string; commit?: string; branch?: string; source?: string }) => {
+        const config = loadConfig(process.cwd());
+        const store = new DuckDBStore(resolve(config.storage.path));
+        await store.initialize();
+        try {
+          const result = await runImport({
+            store,
+            filePath: resolve(file),
+            adapterType: opts.adapter,
+            customCommand: opts.customCommand,
+            commitSha: opts.commit,
+            branch: opts.branch,
+            repo: `${config.repo.owner}/${config.repo.name}`,
+            source: parseWorkflowRunSource(opts.source),
+          });
+          console.log(`Imported ${result.testsImported} test results`);
+        } finally {
+          await store.close();
+        }
+      }),
+    { since: "0.7.0", remove: "0.8.0", canonical: "flaker import" },
+  );
+
+  deprecate(
+    importCmd
+      .command("parquet <dir>")
+      .description("Import flaker parquet artifacts from a directory")
+      .action(async (dir: string) => {
+        await runImportParquet(dir);
+      }),
+    { since: "0.7.0", remove: "0.8.0", canonical: "flaker import" },
+  );
 }

--- a/src/cli/categories/ops.ts
+++ b/src/cli/categories/ops.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import type { Command } from "commander";
+import { deprecate } from "../deprecation.js";
 import { loadConfig } from "../config.js";
 import { DuckDBStore } from "../storage/duckdb.js";
 import { prepareRunRequest } from "../commands/exec/prepare-run-request.js";
@@ -193,13 +194,14 @@ export function registerOpsCommands(program: Command): void {
     .command("ops")
     .description("Operator cadence commands");
 
-  ops
+  const dailyCmd = ops
     .command("daily")
     .description("Run the daily observation loop and render an artifact")
     .option("--window-days <days>", "Analysis window in days", "1")
     .option("--json", "Output as JSON")
     .option("--output <file>", "Write the rendered artifact to a file")
     .action(opsDailyAction);
+  deprecate(dailyCmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker apply" });
 
   ops
     .command("weekly")

--- a/src/cli/categories/policy.ts
+++ b/src/cli/categories/policy.ts
@@ -1,5 +1,6 @@
 import { resolve } from "node:path";
 import type { Command } from "commander";
+import { deprecate } from "../deprecation.js";
 import {
   runQuarantine,
   formatQuarantineTable,
@@ -190,8 +191,9 @@ export function registerPolicyCommands(program: Command): void {
         }
       },
     );
+  deprecate(quarantineCmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker apply" });
 
-  quarantineCmd
+  const quarantineCheckCmd = quarantineCmd
     .command("check")
     .description("Validate the repo-tracked quarantine manifest")
     .option("--manifest <path>", "Override manifest path")
@@ -236,8 +238,9 @@ export function registerPolicyCommands(program: Command): void {
         await store.close();
       }
     });
+  deprecate(quarantineCheckCmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker apply" });
 
-  quarantineCmd
+  const quarantineReportCmd = quarantineCmd
     .command("report")
     .description("Render a quarantine manifest report")
     .option("--manifest <path>", "Override manifest path")
@@ -289,8 +292,9 @@ export function registerPolicyCommands(program: Command): void {
         await store.close();
       }
     });
+  deprecate(quarantineReportCmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker apply" });
 
-  policy
+  const policyCheckCmd = policy
     .command("check")
     .description("Validate test spec ownership and config drift")
     .option("--json", "Output JSON report")
@@ -325,4 +329,5 @@ export function registerPolicyCommands(program: Command): void {
       );
       process.exit(report.errors.length > 0 ? 1 : 0);
     });
+  deprecate(policyCheckCmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker apply" });
 }

--- a/src/cli/categories/quarantine.ts
+++ b/src/cli/categories/quarantine.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import type { Command } from "commander";
+import { deprecate } from "../deprecation.js";
 import { loadConfig } from "../config.js";
 import { DuckDBStore } from "../storage/duckdb.js";
 import {
@@ -98,18 +99,20 @@ export function registerQuarantineCommands(program: Command): void {
     .command("quarantine")
     .description("Quarantine planning and plan-based mutation");
 
-  quarantine
+  const suggestCmd = quarantine
     .command("suggest")
     .description("Suggest quarantine add/remove actions without mutating state")
     .option("--window-days <days>", "Analysis window in days", "30")
     .option("--json", "Output as JSON")
     .option("--output <file>", "Write the rendered plan to a file")
     .action(quarantineSuggestAction);
+  deprecate(suggestCmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker apply" });
 
-  quarantine
+  const applyCmd = quarantine
     .command("apply")
     .description("Apply a reviewed quarantine plan")
     .requiredOption("--from <file>", "Read plan JSON from a file")
     .option("--create-issues", "Create GitHub issues for newly quarantined tests")
     .action(quarantineApplyAction);
+  deprecate(applyCmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker apply" });
 }

--- a/src/cli/categories/report.ts
+++ b/src/cli/categories/report.ts
@@ -13,6 +13,7 @@ import {
   createReportSummaryArtifact,
   loadReportSummaryArtifactsFromDir,
 } from "../commands/report/index.js";
+import { deprecate } from "../deprecation.js";
 
 function parseKeyValuePairs(input?: string): Record<string, string> | undefined {
   if (!input) return undefined;
@@ -31,16 +32,121 @@ function parseKeyValuePairs(input?: string): Record<string, string> | undefined 
   return Object.fromEntries(entries);
 }
 
+type SummaryOpts = {
+  adapter: string;
+  input: string;
+  bundle?: boolean;
+  shard?: string;
+  module?: string;
+  offset?: string;
+  limit?: string;
+  matrix?: string;
+  variant?: string;
+  meta?: string;
+  json?: boolean;
+  markdown?: boolean;
+  prComment?: boolean;
+};
+
+function runSummaryAction(opts: SummaryOpts): void {
+  const formatCount = [opts.json, opts.markdown, opts.prComment].filter(Boolean).length;
+  if (formatCount > 1) {
+    console.error("Error: choose one of --json, --markdown, or --pr-comment");
+    process.exit(1);
+  }
+  if (opts.bundle && opts.markdown) {
+    console.error("Error: --bundle cannot be combined with --markdown");
+    process.exit(1);
+  }
+
+  const summary = runReportSummarize({
+    adapter: opts.adapter,
+    input: readFileSync(resolve(opts.input), "utf-8"),
+  });
+  if (opts.bundle) {
+    console.log(
+      JSON.stringify(
+        createReportSummaryArtifact(summary, {
+          shard: opts.shard,
+          module: opts.module,
+          offset: opts.offset ? Number(opts.offset) : undefined,
+          limit: opts.limit ? Number(opts.limit) : undefined,
+          matrix: parseKeyValuePairs(opts.matrix),
+          variant: parseKeyValuePairs(opts.variant),
+          extra: parseKeyValuePairs(opts.meta),
+        }),
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+  if (opts.prComment) {
+    console.log(formatPrComment(summary));
+    return;
+  }
+  console.log(
+    formatReportSummary(summary, opts.json ? "json" : "markdown"),
+  );
+}
+
+type DiffOpts = {
+  base: string;
+  head: string;
+  adapter?: string;
+  json?: boolean;
+  markdown?: boolean;
+};
+
+function runDiffAction(opts: DiffOpts): void {
+  if (opts.json && opts.markdown) {
+    console.error("Error: choose either --json or --markdown");
+    process.exit(1);
+  }
+
+  const baseInput = readFileSync(resolve(opts.base), "utf-8");
+  const headInput = readFileSync(resolve(opts.head), "utf-8");
+  const base = opts.adapter
+    ? runReportSummarize({ adapter: opts.adapter, input: baseInput })
+    : parseReportSummary(baseInput);
+  const head = opts.adapter
+    ? runReportSummarize({ adapter: opts.adapter, input: headInput })
+    : parseReportSummary(headInput);
+  const diff = runReportDiff({ base, head });
+
+  console.log(formatReportDiff(diff, opts.json ? "json" : "markdown"));
+}
+
+type AggregateOpts = {
+  json?: boolean;
+  markdown?: boolean;
+};
+
+function runAggregateAction(dir: string, opts: AggregateOpts): void {
+  if (opts.json && opts.markdown) {
+    console.error("Error: choose either --json or --markdown");
+    process.exit(1);
+  }
+
+  const aggregate = runReportAggregate({
+    summaries: loadReportSummaryArtifactsFromDir(resolve(dir)),
+  });
+  console.log(
+    formatReportAggregate(aggregate, opts.json ? "json" : "markdown"),
+  );
+}
+
 export function registerReportCommands(program: Command): void {
   const reportCmd = program
     .command("report")
-    .description("Normalize and diff reports");
-
-  reportCmd
-    .command("summary")
-    .description("Summarize a raw adapter report")
-    .requiredOption("--adapter <type>", "Adapter type (playwright, junit, vrt-migration, vrt-bench)")
-    .requiredOption("--input <file>", "Raw adapter report file")
+    .description("Normalize and diff reports")
+    .argument("[file]", "Input file (or directory for --aggregate)")
+    .option("--summary", "Summarize a raw adapter report")
+    .option("--diff <base>", "Diff against a base report file")
+    .option("--aggregate <dir>", "Aggregate shard-aware summary artifacts from a directory")
+    // summary flags
+    .option("--adapter <type>", "Adapter type (playwright, junit, vrt-migration, vrt-bench)")
+    .option("--input <file>", "Raw adapter report file (alias for positional [file])")
     .option("--bundle", "Wrap summary with shard metadata for aggregation")
     .option("--shard <name>", "Shard name")
     .option("--module <name>", "Module name")
@@ -52,115 +158,143 @@ export function registerReportCommands(program: Command): void {
     .option("--json", "Output JSON report")
     .option("--markdown", "Output Markdown report")
     .option("--pr-comment", "Output compact Markdown for PR comments")
+    // diff flags
+    .option("--head <file>", "Head summary or raw report file (for --diff)")
     .action(
-      (opts: {
-        adapter: string;
-        input: string;
-        bundle?: boolean;
-        shard?: string;
-        module?: string;
-        offset?: string;
-        limit?: string;
-        matrix?: string;
-        variant?: string;
-        meta?: string;
-        json?: boolean;
-        markdown?: boolean;
-        prComment?: boolean;
-      }) => {
-        const formatCount = [opts.json, opts.markdown, opts.prComment].filter(Boolean).length;
-        if (formatCount > 1) {
-          console.error("Error: choose one of --json, --markdown, or --pr-comment");
-          process.exit(1);
+      (
+        file: string | undefined,
+        opts: {
+          summary?: boolean;
+          diff?: string;
+          aggregate?: string;
+          // summary opts
+          adapter?: string;
+          input?: string;
+          bundle?: boolean;
+          shard?: string;
+          module?: string;
+          offset?: string;
+          limit?: string;
+          matrix?: string;
+          variant?: string;
+          meta?: string;
+          json?: boolean;
+          markdown?: boolean;
+          prComment?: boolean;
+          // diff opts
+          head?: string;
+        },
+      ) => {
+        const flagCount = [opts.summary, opts.diff !== undefined, opts.aggregate !== undefined].filter(Boolean).length;
+        if (flagCount === 0) {
+          reportCmd.help();
+          return;
         }
-        if (opts.bundle && opts.markdown) {
-          console.error("Error: --bundle cannot be combined with --markdown");
-          process.exit(1);
+        if (flagCount > 1) {
+          console.error("Error: --summary, --diff, and --aggregate are mutually exclusive");
+          process.exit(2);
         }
 
-        const summary = runReportSummarize({
-          adapter: opts.adapter,
-          input: readFileSync(resolve(opts.input), "utf-8"),
-        });
-        if (opts.bundle) {
-          console.log(
-            JSON.stringify(
-              createReportSummaryArtifact(summary, {
-                shard: opts.shard,
-                module: opts.module,
-                offset: opts.offset ? Number(opts.offset) : undefined,
-                limit: opts.limit ? Number(opts.limit) : undefined,
-                matrix: parseKeyValuePairs(opts.matrix),
-                variant: parseKeyValuePairs(opts.variant),
-                extra: parseKeyValuePairs(opts.meta),
-              }),
-              null,
-              2,
-            ),
-          );
+        if (opts.summary) {
+          const inputFile = file ?? opts.input;
+          if (!inputFile) {
+            console.error("Error: --summary requires a file argument or --input <file>");
+            process.exit(2);
+          }
+          if (!opts.adapter) {
+            console.error("Error: --summary requires --adapter <type>");
+            process.exit(2);
+          }
+          runSummaryAction({
+            adapter: opts.adapter,
+            input: inputFile,
+            bundle: opts.bundle,
+            shard: opts.shard,
+            module: opts.module,
+            offset: opts.offset,
+            limit: opts.limit,
+            matrix: opts.matrix,
+            variant: opts.variant,
+            meta: opts.meta,
+            json: opts.json,
+            markdown: opts.markdown,
+            prComment: opts.prComment,
+          });
           return;
         }
-        if (opts.prComment) {
-          console.log(formatPrComment(summary));
+
+        if (opts.diff !== undefined) {
+          const headFile = file ?? opts.head;
+          if (!headFile) {
+            console.error("Error: --diff requires a head file argument or --head <file>");
+            process.exit(2);
+          }
+          runDiffAction({
+            base: opts.diff,
+            head: headFile,
+            adapter: opts.adapter,
+            json: opts.json,
+            markdown: opts.markdown,
+          });
           return;
         }
-        console.log(
-          formatReportSummary(summary, opts.json ? "json" : "markdown"),
-        );
+
+        if (opts.aggregate !== undefined) {
+          runAggregateAction(opts.aggregate, {
+            json: opts.json,
+            markdown: opts.markdown,
+          });
+        }
       },
     );
 
-  reportCmd
-    .command("diff")
-    .description("Diff two normalized summaries or raw adapter reports")
-    .requiredOption("--base <file>", "Base summary or raw report file")
-    .requiredOption("--head <file>", "Head summary or raw report file")
-    .option("--adapter <type>", "Adapter type when diffing raw reports")
-    .option("--json", "Output JSON report")
-    .option("--markdown", "Output Markdown report")
-    .action(
-      (opts: {
-        base: string;
-        head: string;
-        adapter?: string;
-        json?: boolean;
-        markdown?: boolean;
-      }) => {
-        if (opts.json && opts.markdown) {
-          console.error("Error: choose either --json or --markdown");
-          process.exit(1);
-        }
+  deprecate(
+    reportCmd
+      .command("summary")
+      .description("Summarize a raw adapter report")
+      .requiredOption("--adapter <type>", "Adapter type (playwright, junit, vrt-migration, vrt-bench)")
+      .requiredOption("--input <file>", "Raw adapter report file")
+      .option("--bundle", "Wrap summary with shard metadata for aggregation")
+      .option("--shard <name>", "Shard name")
+      .option("--module <name>", "Module name")
+      .option("--offset <n>", "Shard offset")
+      .option("--limit <n>", "Shard limit")
+      .option("--matrix <pairs>", "Comma-separated matrix metadata (key=value)")
+      .option("--variant <pairs>", "Comma-separated variant metadata (key=value)")
+      .option("--meta <pairs>", "Comma-separated extra metadata (key=value)")
+      .option("--json", "Output JSON report")
+      .option("--markdown", "Output Markdown report")
+      .option("--pr-comment", "Output compact Markdown for PR comments")
+      .action((opts: SummaryOpts) => {
+        runSummaryAction(opts);
+      }),
+    { since: "0.7.0", remove: "0.8.0", canonical: "flaker report --summary" },
+  );
 
-        const baseInput = readFileSync(resolve(opts.base), "utf-8");
-        const headInput = readFileSync(resolve(opts.head), "utf-8");
-        const base = opts.adapter
-          ? runReportSummarize({ adapter: opts.adapter, input: baseInput })
-          : parseReportSummary(baseInput);
-        const head = opts.adapter
-          ? runReportSummarize({ adapter: opts.adapter, input: headInput })
-          : parseReportSummary(headInput);
-        const diff = runReportDiff({ base, head });
+  deprecate(
+    reportCmd
+      .command("diff")
+      .description("Diff two normalized summaries or raw adapter reports")
+      .requiredOption("--base <file>", "Base summary or raw report file")
+      .requiredOption("--head <file>", "Head summary or raw report file")
+      .option("--adapter <type>", "Adapter type when diffing raw reports")
+      .option("--json", "Output JSON report")
+      .option("--markdown", "Output Markdown report")
+      .action((opts: DiffOpts) => {
+        runDiffAction(opts);
+      }),
+    { since: "0.7.0", remove: "0.8.0", canonical: "flaker report --diff <base>" },
+  );
 
-        console.log(formatReportDiff(diff, opts.json ? "json" : "markdown"));
-      },
-    );
-
-  reportCmd
-    .command("aggregate <dir>")
-    .description("Aggregate shard-aware summary artifacts")
-    .option("--json", "Output JSON report")
-    .option("--markdown", "Output Markdown report")
-    .action((dir: string, opts: { json?: boolean; markdown?: boolean }) => {
-      if (opts.json && opts.markdown) {
-        console.error("Error: choose either --json or --markdown");
-        process.exit(1);
-      }
-
-      const aggregate = runReportAggregate({
-        summaries: loadReportSummaryArtifactsFromDir(resolve(dir)),
-      });
-      console.log(
-        formatReportAggregate(aggregate, opts.json ? "json" : "markdown"),
-      );
-    });
+  deprecate(
+    reportCmd
+      .command("aggregate <dir>")
+      .description("Aggregate shard-aware summary artifacts")
+      .option("--json", "Output JSON report")
+      .option("--markdown", "Output Markdown report")
+      .action((dir: string, opts: AggregateOpts) => {
+        runAggregateAction(dir, opts);
+      }),
+    { since: "0.7.0", remove: "0.8.0", canonical: "flaker report --aggregate <dir>" },
+  );
 }

--- a/src/cli/categories/setup.ts
+++ b/src/cli/categories/setup.ts
@@ -2,6 +2,7 @@ import { basename } from "node:path";
 import type { Command } from "commander";
 import { runInit } from "../commands/setup/init.js";
 import { detectRepoInfo } from "../core/git.js";
+import { deprecate } from "../deprecation.js";
 
 const VALID_ADAPTERS = ["playwright", "vitest", "jest", "junit"] as const;
 const VALID_RUNNERS = ["vitest", "playwright", "jest", "actrun"] as const;
@@ -32,7 +33,7 @@ export function registerSetupCommands(program: Command): void {
     .command("setup")
     .description("Project scaffolding");
 
-  setup
+  const initCmd = setup
     .command("init")
     .description("Create flaker.toml (auto-detects owner/name from git remote)")
     .option("--owner <owner>", "Repository owner (auto-detected from git remote)")
@@ -40,4 +41,5 @@ export function registerSetupCommands(program: Command): void {
     .option("--adapter <type>", `Test result adapter: ${VALID_ADAPTERS.join("|")}`)
     .option("--runner <type>", `Test runner: ${VALID_RUNNERS.join("|")}`)
     .action(setupInitAction);
+  deprecate(initCmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker init" });
 }

--- a/src/cli/commands/status/summary.ts
+++ b/src/cli/commands/status/summary.ts
@@ -2,9 +2,10 @@ import type { FlakerConfig, PromotionThresholds } from "../../config.js";
 import { type GateName, profileNameFromGateName } from "../../gate.js";
 import { resolveProfile } from "../../profile-compat.js";
 import { workflowRunSourceSql } from "../../run-source.js";
-import type { MetricStore } from "../../storage/types.js";
+import type { MetricStore, FlakyScore, QuarantinedTest } from "../../storage/types.js";
 import { computeKpi, type FlakerKpi } from "../analyze/kpi.js";
 import { runQuarantineSuggest } from "../quarantine/suggest.js";
+import { runFlaky } from "../analyze/flaky.js";
 
 export interface DriftInput {
   matchedCommits: number;
@@ -118,6 +119,7 @@ export async function runStatusSummary(input: {
   config: FlakerConfig;
   now?: Date;
   windowDays?: number;
+  gate?: GateName;
 }): Promise<StatusSummary> {
   const now = input.now ?? new Date();
   const windowDays = input.windowDays ?? 30;
@@ -181,6 +183,18 @@ export async function runStatusSummary(input: {
     input.config.promotion,
   );
 
+  const allGates: Record<GateName, StatusGateSummary> = {
+    iteration: buildGateSummary(input.config, "iteration"),
+    merge: buildGateSummary(input.config, "merge"),
+    release: buildGateSummary(input.config, "release"),
+  };
+
+  // --gate narrows the gates block to a single gate entry for focused inspection.
+  // The drift report is promotion-wide and unaffected by --gate.
+  const gates: Record<GateName, StatusGateSummary> = input.gate
+    ? ({ [input.gate]: allGates[input.gate] } as Record<GateName, StatusGateSummary>)
+    : allGates;
+
   return {
     generatedAt: now.toISOString(),
     windowDays,
@@ -199,11 +213,7 @@ export async function runStatusSummary(input: {
       intermittentFlaky: kpi.flaky.intermittentFlaky,
       flakyTrend: kpi.flaky.flakyTrend,
     },
-    gates: {
-      iteration: buildGateSummary(input.config, "iteration"),
-      merge: buildGateSummary(input.config, "merge"),
-      release: buildGateSummary(input.config, "release"),
-    },
+    gates,
     quarantine: {
       currentCount: currentQuarantine.length,
       pendingAddCount: quarantinePlan.add.length,
@@ -278,4 +288,196 @@ export function formatStatusSummary(summary: StatusSummary): string {
   }
 
   return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Markdown renderer for --markdown flag
+// ---------------------------------------------------------------------------
+
+export function formatStatusMarkdown(summary: StatusSummary): string {
+  const lines: string[] = [
+    "# flaker Status",
+    "",
+    `_Generated: ${summary.generatedAt} — window: ${summary.windowDays} days_`,
+    "",
+    "## Activity",
+    "",
+    "| Metric | Value |",
+    "| --- | --- |",
+    `| Total runs | ${summary.activity.totalRuns} |`,
+    `| CI runs | ${summary.activity.ciRuns} |`,
+    `| Local runs | ${summary.activity.localRuns} |`,
+    `| Passed results | ${summary.activity.passedResults} |`,
+    `| Failed results | ${summary.activity.failedResults} |`,
+    "",
+    "## Health",
+    "",
+    "| Metric | Value |",
+    "| --- | --- |",
+    `| Data confidence | ${summary.health.dataConfidence} |`,
+    `| Matched commits | ${summary.health.matchedCommits} |`,
+    `| Sample ratio | ${summary.health.sampleRatio != null ? `${summary.health.sampleRatio}%` : "N/A"} |`,
+    `| Broken tests | ${summary.health.brokenTests} |`,
+    `| Intermittent flaky | ${summary.health.intermittentFlaky} |`,
+    `| Flaky trend | ${summary.health.flakyTrend > 0 ? `+${summary.health.flakyTrend}` : summary.health.flakyTrend} |`,
+    "",
+    "## Gates",
+    "",
+    "| Gate | Profile | Strategy | Sample | Budget (s) | Adaptive |",
+    "| --- | --- | --- | --- | --- | --- |",
+  ];
+
+  for (const gate of Object.keys(summary.gates) as GateName[]) {
+    const info = summary.gates[gate];
+    lines.push(
+      `| ${gate} | ${info.profile} | ${info.strategy} | ${info.samplePercentage != null ? `${info.samplePercentage}%` : "N/A"} | ${info.maxDurationSeconds ?? "N/A"} | ${info.adaptive ? "on" : "off"} |`,
+    );
+  }
+
+  lines.push(
+    "",
+    "## Quarantine",
+    "",
+    "| Metric | Value |",
+    "| --- | --- |",
+    `| Current quarantined | ${summary.quarantine.currentCount} |`,
+    `| Pending add | +${summary.quarantine.pendingAddCount} |`,
+    `| Pending remove | -${summary.quarantine.pendingRemoveCount} |`,
+    "",
+    "## Promotion Drift",
+    "",
+  );
+
+  if (summary.drift.ok) {
+    lines.push("**Status: ready** — all 5 thresholds met.");
+  } else {
+    lines.push(`**Status: not ready** — ${summary.drift.unmet.length}/5 thresholds unmet.`, "");
+    lines.push("| Field | Actual | Threshold |", "| --- | --- | --- |");
+    for (const item of summary.drift.unmet) {
+      const actual = item.actual == null ? "N/A" : String(item.actual);
+      const threshold = String(item.threshold);
+      lines.push(`| ${item.field} | ${actual} | ${threshold} |`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// renderDetail for --detail flag
+// ---------------------------------------------------------------------------
+
+export function renderDetail(drift: DriftReport, _thresholds: PromotionThresholds): string {
+  const lines: string[] = ["## Drift Detail", ""];
+  if (drift.ok) {
+    lines.push("All promotion thresholds met.");
+    return lines.join("\n");
+  }
+  for (const item of drift.unmet) {
+    if (item.field === "matched_commits") {
+      // numeric: show actual / threshold
+      const actual = item.actual == null ? "n/a" : String(item.actual);
+      lines.push(`- ${item.field}: ${actual} / ${item.threshold}`);
+    } else if (typeof item.actual === "string" || item.actual == null) {
+      // string (data_confidence) or null: show arrow
+      const actual = item.actual == null ? "n/a" : item.actual;
+      lines.push(`- ${item.field}: ${actual} → ${item.threshold}`);
+    } else {
+      // other numeric fields (rates as percentages)
+      const actual = item.actual == null ? "n/a" : `${item.actual}%`;
+      const threshold = typeof item.threshold === "number" ? `${item.threshold}%` : String(item.threshold);
+      lines.push(`- ${item.field}: ${actual} / ${threshold}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// renderListFlaky / renderListQuarantined for --list flag
+// ---------------------------------------------------------------------------
+
+export interface FlakyListRow {
+  suite: string;
+  test_name: string;
+  flaky_rate: number;
+  runs: number;
+}
+
+export interface QuarantinedListRow {
+  suite: string;
+  test_name: string;
+  added_at: string;
+}
+
+const DEFAULT_LIST_TOP = 20;
+
+export function renderListFlaky(rows: FlakyListRow[], top = DEFAULT_LIST_TOP): string {
+  const limited = rows.slice(0, top);
+  if (limited.length === 0) {
+    return "No flaky tests found.";
+  }
+  const header = ["Suite", "Test Name", "Flaky Rate", "Runs"];
+  const tableRows = limited.map((r) => [
+    r.suite,
+    r.test_name,
+    `${Math.round(r.flaky_rate * 100)}%`,
+    String(r.runs),
+  ]);
+  return formatSimpleTable(header, tableRows);
+}
+
+export function renderListQuarantined(rows: QuarantinedListRow[], top = DEFAULT_LIST_TOP): string {
+  const limited = rows.slice(0, top);
+  if (limited.length === 0) {
+    return "No quarantined tests.";
+  }
+  const header = ["Suite", "Test Name", "Added At"];
+  const tableRows = limited.map((r) => [r.suite, r.test_name, r.added_at]);
+  return formatSimpleTable(header, tableRows);
+}
+
+function formatSimpleTable(headers: string[], rows: string[][]): string {
+  const allRows = [headers, ...rows];
+  const colWidths = headers.map((_, i) =>
+    Math.max(...allRows.map((row) => (row[i] ?? "").length)),
+  );
+  const sep = colWidths.map((w) => "-".repeat(w)).join(" | ");
+  const formatRow = (row: string[]) =>
+    row.map((cell, i) => (cell ?? "").padEnd(colWidths[i])).join(" | ");
+  return [formatRow(headers), sep, ...rows.map(formatRow)].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// runStatusListFlaky / runStatusListQuarantined
+// ---------------------------------------------------------------------------
+
+export async function runStatusListFlaky(input: {
+  store: MetricStore;
+  windowDays?: number;
+  top?: number;
+}): Promise<FlakyListRow[]> {
+  // Reuse runFlaky from analyze/flaky.ts (src/cli/commands/analyze/flaky.ts:11)
+  const results = await runFlaky({
+    store: input.store,
+    windowDays: input.windowDays ?? 30,
+    top: input.top ?? DEFAULT_LIST_TOP,
+  });
+  return results.map((r) => ({
+    suite: r.suite,
+    test_name: r.testName,
+    flaky_rate: r.flakyRate / 100,
+    runs: r.totalRuns,
+  }));
+}
+
+export async function runStatusListQuarantined(input: {
+  store: MetricStore;
+}): Promise<QuarantinedListRow[]> {
+  // Reuse store.queryQuarantined() — same primitive used by runStatusSummary
+  const rows: QuarantinedTest[] = await input.store.queryQuarantined();
+  return rows.map((r) => ({
+    suite: r.suite,
+    test_name: r.testName,
+    added_at: r.createdAt instanceof Date ? r.createdAt.toISOString().slice(0, 10) : String(r.createdAt),
+  }));
 }

--- a/src/cli/commands/status/summary.ts
+++ b/src/cli/commands/status/summary.ts
@@ -245,7 +245,7 @@ export function formatStatusSummary(summary: StatusSummary): string {
     "## Gates",
   ];
 
-  for (const gate of ["iteration", "merge", "release"] as const) {
+  for (const gate of Object.keys(summary.gates) as GateName[]) {
     const info = summary.gates[gate];
     lines.push(
       `  ${gate}: ${info.strategy} via ${info.profile}`

--- a/src/cli/deprecation.ts
+++ b/src/cli/deprecation.ts
@@ -9,15 +9,28 @@ export interface DeprecationOpts {
   canonical: string;
 }
 
+function fullPath(cmd: Command): string {
+  const parts: string[] = [];
+  let current: Command | null = cmd;
+  while (current) {
+    const n = current.name();
+    if (n) parts.unshift(n);
+    current = (current.parent as Command | null) ?? null;
+  }
+  return parts.join(" "); // e.g. "flaker analyze query"
+}
+
 export function deprecate(cmd: Command, opts: DeprecationOpts): Command {
-  const name = cmd.name();
   const prefix = `DEPRECATED in ${opts.since} (removed in ${opts.remove})`;
   const description = cmd.description();
   cmd.description(`${prefix} — use \`${opts.canonical}\` instead. ${description}`);
 
+  // Lazily compute the full path so that commands registered before .name()
+  // is set on the root program still resolve to the correct "flaker ..." path.
   const warn = () => {
+    const name = fullPath(cmd);
     process.stderr.write(
-      `warning: \`flaker ${name}\` is deprecated and will be removed in ${opts.remove}. `
+      `warning: \`${name}\` is deprecated and will be removed in ${opts.remove}. `
       + `Use \`${opts.canonical}\` instead.\n`,
     );
   };

--- a/src/cli/deprecation.ts
+++ b/src/cli/deprecation.ts
@@ -1,0 +1,65 @@
+import type { Command } from "commander";
+
+export interface DeprecationOpts {
+  /** Version in which the command became deprecated. */
+  since: string;
+  /** Version in which the command will be removed. */
+  remove: string;
+  /** The canonical replacement, e.g. "flaker status". */
+  canonical: string;
+}
+
+export function deprecate(cmd: Command, opts: DeprecationOpts): Command {
+  const name = cmd.name();
+  const prefix = `DEPRECATED in ${opts.since} (removed in ${opts.remove})`;
+  const description = cmd.description();
+  cmd.description(`${prefix} — use \`${opts.canonical}\` instead. ${description}`);
+
+  const warn = () => {
+    process.stderr.write(
+      `warning: \`flaker ${name}\` is deprecated and will be removed in ${opts.remove}. `
+      + `Use \`${opts.canonical}\` instead.\n`,
+    );
+  };
+
+  // Intercept future .action() calls on this command so the warning is
+  // automatically prepended to whatever handler is registered.
+  const originalAction = cmd.action.bind(cmd);
+  cmd.action = (fn: (...fnArgs: unknown[]) => unknown): Command => {
+    return originalAction(async (...fnArgs: unknown[]) => {
+      warn();
+      await fn(...fnArgs);
+    });
+  };
+
+  // Re-register the already-set action (if any) through the interceptor so
+  // the warning fires even when .action() was called before deprecate().
+  // We reach into Commander internals to grab the stored user fn and
+  // re-register it, rather than trying to call _actionHandler directly.
+  type CmdInternal = { _actionHandler: ((...a: unknown[]) => unknown) | null };
+  const internal = cmd as unknown as CmdInternal;
+  if (internal._actionHandler !== null) {
+    // Temporarily remove the current _actionHandler so that cmd.action()
+    // (now our interceptor) installs a fresh one.
+    const savedHandler = internal._actionHandler;
+    internal._actionHandler = null;
+    // Install a new action that calls the original _actionHandler with the
+    // processedArgs array, exactly as Commander would.
+    originalAction(async (...fnArgs: unknown[]) => {
+      warn();
+      // fnArgs = (opts, command) — reconstruct processedArgs by dropping the
+      // trailing Command instance that Commander appends.
+      const processedArgs = fnArgs.slice(0, -1);
+      await savedHandler(processedArgs as unknown[]);
+    });
+  }
+
+  // Override outputHelp so --help also warns.
+  const origOutputHelp = cmd.outputHelp.bind(cmd);
+  cmd.outputHelp = ((contextOrFn?: unknown) => {
+    warn();
+    return origOutputHelp(contextOrFn as Parameters<typeof origOutputHelp>[0]);
+  }) as typeof cmd.outputHelp;
+
+  return cmd;
+}

--- a/src/cli/gate.ts
+++ b/src/cli/gate.ts
@@ -1,5 +1,7 @@
 export type GateName = "iteration" | "merge" | "release";
 
+export const VALID_GATE_NAMES: readonly GateName[] = ["iteration", "merge", "release"] as const;
+
 const GATE_TO_PROFILE: Record<GateName, string> = {
   iteration: "local",
   merge: "ci",

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -90,6 +90,10 @@ export function createProgram(): Command {
     .description("User-facing summary dashboard (summary-only, no promotion decision)")
     .option("--window-days <days>", "Analysis window in days", "30")
     .option("--json", "Output as JSON")
+    .option("--markdown", "Render output as Markdown (mutually exclusive with --json)")
+    .option("--list <mode>", "Standalone list mode: flaky | quarantined")
+    .option("--detail", "Append per-threshold drift actuals after the summary")
+    .option("--gate <name>", "Narrow the gates block to a single gate: iteration | merge | release")
     .action(statusAction);
 
   const doctorCmd = program

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -103,11 +103,10 @@ export function createProgram(): Command {
     .description("Execute a read-only SQL query against the metrics database")
     .action(analyzeQueryAction);
 
-  const doctorCmd = program
+  program
     .command("doctor")
     .description("Check runtime requirements")
     .action(debugDoctorAction);
-  deprecate(doctorCmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker debug doctor" });
 
   const originalHelpInformation = program.helpInformation.bind(program);
   program.helpInformation = () => {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -7,7 +7,8 @@ import { registerExecCommands, execRunAction, RUN_COMMAND_HELP } from "./categor
 import { registerCollectCommands } from "./categories/collect.js";
 import { registerImportCommands } from "./categories/import.js";
 import { registerReportCommands } from "./categories/report.js";
-import { registerAnalyzeCommands, analyzeKpiAction, statusAction } from "./categories/analyze.js";
+import { registerAnalyzeCommands, analyzeKpiAction, statusAction, analyzeQueryAction } from "./categories/analyze.js";
+import { registerExplainCommands } from "./categories/explain.js";
 import { registerGateCommands } from "./categories/gate.js";
 import { registerOpsCommands } from "./categories/ops.js";
 import { registerQuarantineCommands } from "./categories/quarantine.js";
@@ -34,6 +35,7 @@ export function createProgram(): Command {
   registerOpsCommands(program);
   registerQuarantineCommands(program);
   registerAnalyzeCommands(program);
+  registerExplainCommands(program);
   registerDebugCommands(program);
   registerPolicyCommands(program);
   registerDevCommands(program);
@@ -95,6 +97,11 @@ export function createProgram(): Command {
     .option("--detail", "Append per-threshold drift actuals after the summary")
     .option("--gate <name>", "Narrow the gates block to a single gate: iteration | merge | release")
     .action(statusAction);
+
+  program
+    .command("query <sql>")
+    .description("Execute a read-only SQL query against the metrics database")
+    .action(analyzeQueryAction);
 
   const doctorCmd = program
     .command("doctor")

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -43,7 +43,7 @@ export function createProgram(): Command {
   program
     .name("flaker")
     .description("Intelligent test selection — run fewer tests, catch more failures")
-    .version("0.5.0")
+    .version("0.7.0-next.0")
     .showHelpAfterError()
     .showSuggestionAfterError();
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -121,40 +121,41 @@ Getting started:
   flaker status                     KPI dashboard (sampling, flaky, data quality)
 
 Primary commands:
-  init        Create flaker.toml and bootstrap config
-  run         Run the selected gate or profile
-  status      Show the user-facing health dashboard
-  doctor      Check local runtime requirements
-  gate        Review gate readiness and sampling health
-  ops         Generate operator review artifacts
-  quarantine  Suggest quarantine add/remove plans
+  init                                          Bootstrap flaker.toml
+  plan                                          Preview actions apply would take
+  apply                                         Reconcile repo to flaker.toml (idempotent)
+  status                                        Dashboard + promotion drift
+  run --gate <iteration|merge|release>          Execute the selected gate
+  doctor                                        Verify local environment
+  debug <retry|confirm|bisect|diagnose>         Incident investigation
+  query <sql>                                   SQL escape hatch
+  explain <topic>                               AI-assisted analysis
+  import <file>                                 Ingest reports (adapter auto-detected)
+  report <file> --summary|--diff|--aggregate    Local report shaping
 
-Gate model:
-  iteration   -> profile.local      Fast author feedback
-  merge       -> profile.ci         PR / mainline gate
-  release     -> profile.scheduled  Full or near-full verification
+Advanced:
+  gate review <name>                Authoritative promotion metrics (--json)
+  ops weekly|incident               Cadence artifact bundles
+  analyze query                     (legacy — use \`flaker query\`)
+  dev <train|tune|self-eval|...>    Maintainer tools
 
-Run \`flaker run --help\` for gate mapping and advanced run options.
-Run \`flaker status --help\` or \`flaker doctor --help\` for user-facing commands.
+Deprecated (removed in 0.8.0):
+  setup init                        → flaker init
+  exec run / exec affected          → flaker run
+  ops daily                         → flaker apply
+  collect ci|local|coverage|calibrate → flaker apply
+  quarantine suggest|apply          → flaker apply
+  policy quarantine|check|report    → flaker apply
+  analyze kpi|eval|flaky|flaky-tag  → flaker status (see --list, --markdown)
+  analyze reason|insights|cluster|bundle|context → flaker explain <topic>
+  analyze query                     → flaker query
+  import report|parquet             → flaker import <file>
+  report summary|diff|aggregate     → flaker report <file> --summary|--diff|--aggregate
+  debug doctor                      → flaker doctor
+  gate review|history|explain       → flaker status --gate <name> [--detail]
+  kpi                               → flaker analyze kpi (also deprecated)
 
-Management and advanced categories:
-  gate       Gate review and readiness        (review)
-  ops        Operator cadence artifacts       (weekly)
-  quarantine Read-only quarantine planning    (suggest)
-  collect    Import history and calibration (ci, local, coverage, commit-changes, calibrate)
-  import     Ingest external reports        (report, parquet)
-  report     Normalize and diff reports     (summary, diff, aggregate)
-  analyze    Read-only inspection           (bundle, kpi, flaky, reason, insights, eval, context, query)
-  debug      Active investigation           (diagnose, bisect, confirm, retry, doctor)
-  policy     Enforcement and ownership      (quarantine, check)
-  dev        Model training and benchmarks  (train, tune, self-eval, eval-fixture, eval-co-failure, test-key)
-
-Compatibility and internal categories remain available:
-  setup      Project scaffolding            (init)
-  exec       Test selection and execution   (run, affected)
-
-Run \`flaker <category> --help\` for the full list under each category.
-Run \`flaker <category> <command> --help\` for per-command options.
+Run \`flaker <command> --help\` for details.
 `;
     return base + extras;
   };

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { Command, type HelpContext } from "commander";
+import { Command } from "commander";
 import { registerSetupCommands, setupInitAction } from "./categories/setup.js";
 import { registerExecCommands, execRunAction, RUN_COMMAND_HELP } from "./categories/exec.js";
 import { registerCollectCommands } from "./categories/collect.js";
@@ -15,23 +15,7 @@ import { registerDebugCommands, debugDoctorAction } from "./categories/debug.js"
 import { registerPolicyCommands } from "./categories/policy.js";
 import { registerDevCommands } from "./categories/dev.js";
 import { registerApplyCommands } from "./categories/apply.js";
-
-function warnDeprecated(aliasName: string, canonical: string): void {
-  process.stderr.write(
-    `warning: \`flaker ${aliasName}\` is deprecated and will be removed in 0.7.0. `
-    + `Use \`${canonical}\` instead.\n`,
-  );
-}
-
-function attachDeprecationWarning(cmd: Command, aliasName: string, canonical: string): void {
-  const origOutputHelp = cmd.outputHelp.bind(cmd);
-  const wrapped = (context?: HelpContext) => {
-    warnDeprecated(aliasName, canonical);
-    return origOutputHelp(context);
-  };
-  // Commander's outputHelp has overloads; cast to satisfy the assignment
-  cmd.outputHelp = wrapped as typeof cmd.outputHelp;
-}
+import { deprecate } from "./deprecation.js";
 
 function isDirectCliExecution(): boolean {
   return process.argv[1] != null
@@ -95,14 +79,11 @@ export function createProgram(): Command {
 
   const kpiCmd = program
     .command("kpi")
-    .description("DEPRECATED alias for `flaker analyze kpi` (removed in 0.7.0)")
+    .description("KPI dashboard (sampling effectiveness, flaky, data quality)")
     .option("--window-days <days>", "Analysis window in days", "30")
     .option("--json", "Output as JSON")
-    .action((opts) => {
-      warnDeprecated("kpi", "flaker analyze kpi");
-      return analyzeKpiAction(opts);
-    });
-  attachDeprecationWarning(kpiCmd, "kpi", "flaker analyze kpi");
+    .action(analyzeKpiAction);
+  deprecate(kpiCmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker analyze kpi" });
 
   program
     .command("status")
@@ -113,12 +94,9 @@ export function createProgram(): Command {
 
   const doctorCmd = program
     .command("doctor")
-    .description("DEPRECATED alias for `flaker debug doctor` (removed in 0.7.0)")
-    .action(() => {
-      warnDeprecated("doctor", "flaker debug doctor");
-      return debugDoctorAction();
-    });
-  attachDeprecationWarning(doctorCmd, "doctor", "flaker debug doctor");
+    .description("Check runtime requirements")
+    .action(debugDoctorAction);
+  deprecate(doctorCmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker debug doctor" });
 
   const originalHelpInformation = program.helpInformation.bind(program);
   program.helpInformation = () => {

--- a/tests/cli/deprecation-analyze.test.ts
+++ b/tests/cli/deprecation-analyze.test.ts
@@ -1,0 +1,23 @@
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+
+const __filename = fileURLToPath(import.meta.url);
+const CLI = resolve(__filename, "../../../dist/cli/main.js");
+
+describe("analyze leaves deprecation warnings", () => {
+  for (const [cmd, canonical] of [
+    ["kpi", "flaker status"],
+    ["eval", "flaker status --markdown"],
+    ["flaky", "flaker status --list flaky"],
+    ["flaky-tag", "flaker apply"],
+  ] as const) {
+    it(`\`flaker analyze ${cmd} --help\` emits deprecation warning pointing to ${canonical}`, () => {
+      const res = spawnSync("node", [CLI, "analyze", cmd, "--help"], { encoding: "utf8" });
+      expect(res.status).toBe(0);
+      expect(res.stderr).toContain("deprecated");
+      expect(res.stderr).toContain(canonical);
+    });
+  }
+});

--- a/tests/cli/deprecation-blanket.test.ts
+++ b/tests/cli/deprecation-blanket.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Blanket deprecation tests for Task 10.
+ * Each deprecated command must emit "deprecated" on stderr and include the
+ * canonical pointer when run with --help.
+ */
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+
+const CLI = join(process.cwd(), "dist/cli/main.js");
+
+function helpOf(args: string[]): { stdout: string; stderr: string } {
+  const res = spawnSync("node", [CLI, ...args, "--help"], {
+    encoding: "utf8",
+  });
+  return { stdout: res.stdout ?? "", stderr: res.stderr ?? "" };
+}
+
+const cases: Array<{ cmd: string[]; canonical: string }> = [
+  // setup init → flaker init
+  { cmd: ["setup", "init"], canonical: "flaker init" },
+  // exec run → flaker run
+  { cmd: ["exec", "run"], canonical: "flaker run" },
+  // exec affected → flaker run --gate iteration --changed <paths>
+  { cmd: ["exec", "affected"], canonical: "flaker run" },
+  // ops daily → flaker apply
+  { cmd: ["ops", "daily"], canonical: "flaker apply" },
+  // collect (bare) → flaker apply
+  { cmd: ["collect"], canonical: "flaker apply" },
+  // collect ci → flaker apply
+  { cmd: ["collect", "ci"], canonical: "flaker apply" },
+  // collect local → flaker apply
+  { cmd: ["collect", "local"], canonical: "flaker apply" },
+  // collect coverage → flaker apply
+  { cmd: ["collect", "coverage"], canonical: "flaker apply" },
+  // collect commit-changes → flaker apply
+  { cmd: ["collect", "commit-changes"], canonical: "flaker apply" },
+  // collect calibrate → flaker apply
+  { cmd: ["collect", "calibrate"], canonical: "flaker apply" },
+  // quarantine suggest → flaker apply
+  { cmd: ["quarantine", "suggest"], canonical: "flaker apply" },
+  // quarantine apply → flaker apply
+  { cmd: ["quarantine", "apply"], canonical: "flaker apply" },
+  // policy quarantine → flaker apply
+  { cmd: ["policy", "quarantine"], canonical: "flaker apply" },
+  // policy check → flaker apply
+  { cmd: ["policy", "check"], canonical: "flaker apply" },
+  // policy quarantine report → flaker apply
+  { cmd: ["policy", "quarantine", "report"], canonical: "flaker apply" },
+  // gate review → flaker status --gate <name> --detail
+  { cmd: ["gate", "review"], canonical: "flaker status" },
+  // gate history → flaker status --gate <name>
+  { cmd: ["gate", "history"], canonical: "flaker status" },
+  // gate explain → flaker status --gate <name> --detail
+  { cmd: ["gate", "explain"], canonical: "flaker status" },
+  // debug doctor → flaker doctor
+  { cmd: ["debug", "doctor"], canonical: "flaker doctor" },
+];
+
+describe("deprecation-blanket: deprecated commands emit warning on --help", () => {
+  for (const { cmd, canonical } of cases) {
+    it(`flaker ${cmd.join(" ")} --help warns and points to ${canonical}`, () => {
+      const { stderr } = helpOf(cmd);
+      expect(stderr.toLowerCase()).toContain("deprecated");
+      expect(stderr).toContain(canonical);
+    });
+  }
+});

--- a/tests/cli/deprecation-fullpath.test.ts
+++ b/tests/cli/deprecation-fullpath.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { Command } from "commander";
+import { deprecate } from "../../src/cli/deprecation.js";
+
+describe("deprecate() uses the full command path", () => {
+  it("warning references parent → child path, not leaf alone", async () => {
+    const root = new Command("flaker");
+    const analyze = root.command("analyze").description("group");
+    const query = analyze.command("query").description("run sql").action(() => {});
+    deprecate(query, { since: "0.7.0", remove: "0.8.0", canonical: "flaker query <sql>" });
+
+    const writes: string[] = [];
+    const orig = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((c: any) => { writes.push(String(c)); return true; }) as any;
+    try {
+      await root.parseAsync(["analyze", "query"], { from: "user" });
+    } finally {
+      process.stderr.write = orig;
+    }
+    const msg = writes.join("");
+    expect(msg).toContain("flaker analyze query");
+    expect(msg).not.toMatch(/`flaker query`.*is deprecated/);
+  });
+
+  it("three-level nesting also works", async () => {
+    const root = new Command("flaker");
+    const import_ = root.command("import").description("imports");
+    const parquet = import_.command("parquet").description("parquet").action(() => {});
+    deprecate(parquet, { since: "0.7.0", remove: "0.8.0", canonical: "flaker import <file>" });
+
+    const writes: string[] = [];
+    const orig = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((c: any) => { writes.push(String(c)); return true; }) as any;
+    try {
+      await root.parseAsync(["import", "parquet"], { from: "user" });
+    } finally {
+      process.stderr.write = orig;
+    }
+    expect(writes.join("")).toContain("flaker import parquet");
+  });
+});

--- a/tests/cli/deprecation-infra.test.ts
+++ b/tests/cli/deprecation-infra.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { Command } from "commander";
+import { deprecate } from "../../src/cli/deprecation.js";
+
+describe("deprecate()", () => {
+  it("rewrites the description to carry the DEPRECATED marker", () => {
+    const cmd = new Command("foo").description("Does foo");
+    deprecate(cmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker bar" });
+    expect(cmd.description()).toMatch(/DEPRECATED.*0\.8\.0/);
+    expect(cmd.description()).toMatch(/flaker bar/);
+  });
+
+  it("warns on .action invocation (stderr)", async () => {
+    const cmd = new Command("foo");
+    let called = false;
+    cmd.action(() => { called = true; });
+    deprecate(cmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker bar" });
+
+    const writes: string[] = [];
+    const orig = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: any) => { writes.push(String(chunk)); return true; }) as any;
+    try {
+      const parent = new Command().addCommand(cmd);
+      await parent.parseAsync(["foo"], { from: "user" });
+    } finally {
+      process.stderr.write = orig;
+    }
+    expect(writes.join("")).toMatch(/deprecated/);
+    expect(writes.join("")).toMatch(/flaker bar/);
+    expect(called).toBe(true);
+  });
+
+  it("warns on --help invocation (outputHelp)", () => {
+    const cmd = new Command("foo").helpOption(false);
+    cmd.action(() => {});
+    deprecate(cmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker bar" });
+
+    const writes: string[] = [];
+    const orig = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: any) => { writes.push(String(chunk)); return true; }) as any;
+    try {
+      cmd.outputHelp();
+    } finally {
+      process.stderr.write = orig;
+    }
+    expect(writes.join("")).toMatch(/deprecated/);
+  });
+
+  it("returns the same Command (fluent)", () => {
+    const cmd = new Command("foo");
+    const result = deprecate(cmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker bar" });
+    expect(result).toBe(cmd);
+  });
+});

--- a/tests/cli/doctor-canonical.test.ts
+++ b/tests/cli/doctor-canonical.test.ts
@@ -6,15 +6,14 @@ import { fileURLToPath } from "node:url";
 const __filename = fileURLToPath(import.meta.url);
 const CLI = resolve(__filename, "../../../dist/cli/main.js");
 
-describe("deprecation warnings", () => {
-  it("`flaker kpi --help` emits a deprecation note on stderr", () => {
-    const res = spawnSync("node", [CLI, "kpi", "--help"], { encoding: "utf8" });
+describe("flaker doctor (canonical) is not deprecated", () => {
+  it("flaker doctor --help does NOT emit deprecation warning", () => {
+    const res = spawnSync("node", [CLI, "doctor", "--help"], { encoding: "utf8" });
     expect(res.status).toBe(0);
-    expect(res.stderr).toContain("deprecated");
-    expect(res.stderr).toContain("flaker analyze kpi");
+    expect(res.stderr).not.toContain("deprecated");
   });
 
-  it("`flaker debug doctor --help` emits a deprecation note on stderr pointing to flaker doctor", () => {
+  it("flaker debug doctor --help DOES emit deprecation warning pointing at flaker doctor", () => {
     const res = spawnSync("node", [CLI, "debug", "doctor", "--help"], { encoding: "utf8" });
     expect(res.status).toBe(0);
     expect(res.stderr).toContain("deprecated");

--- a/tests/cli/explain.test.ts
+++ b/tests/cli/explain.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const CLI = resolve(__filename, "../../../dist/cli/main.js");
+
+describe("flaker explain umbrella", () => {
+  it("`flaker explain --help` lists the five topics", () => {
+    const res = spawnSync("node", [CLI, "explain", "--help"], { encoding: "utf8" });
+    expect(res.status).toBe(0);
+    for (const topic of ["reason", "insights", "cluster", "bundle", "context"]) {
+      expect(res.stdout).toContain(topic);
+    }
+  });
+
+  for (const topic of ["reason", "insights", "cluster", "bundle", "context"] as const) {
+    it(`\`flaker explain ${topic} --help\` works`, () => {
+      const res = spawnSync("node", [CLI, "explain", topic, "--help"], { encoding: "utf8" });
+      expect(res.status).toBe(0);
+    });
+    it(`\`flaker analyze ${topic} --help\` emits deprecation warning pointing to flaker explain ${topic}`, () => {
+      const res = spawnSync("node", [CLI, "analyze", topic, "--help"], { encoding: "utf8" });
+      expect(res.status).toBe(0);
+      expect(res.stderr).toContain("deprecated");
+      expect(res.stderr).toContain(`flaker explain ${topic}`);
+    });
+  }
+});

--- a/tests/cli/help-primary-shape.test.ts
+++ b/tests/cli/help-primary-shape.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Tests for Task 11: `flaker --help` must expose 10 primary commands in a
+ * "Primary" section, followed by "Advanced" and "Deprecated" sections.
+ */
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+
+const CLI = join(process.cwd(), "dist/cli/main.js");
+
+describe("flaker --help top-level shape (Task 11)", () => {
+  const res = spawnSync("node", [CLI, "--help"], { encoding: "utf8" });
+  const stdout = res.stdout;
+
+  it("exits cleanly", () => {
+    expect(res.status).toBe(0);
+  });
+
+  it("contains a Primary commands section", () => {
+    expect(stdout).toMatch(/Primary commands?:/i);
+  });
+
+  it("contains an Advanced section", () => {
+    expect(stdout).toMatch(/Advanced:/i);
+  });
+
+  it("contains a Deprecated section", () => {
+    expect(stdout).toMatch(/Deprecated/i);
+  });
+
+  const primaryNames = [
+    "init",
+    "plan",
+    "apply",
+    "status",
+    "run",
+    "doctor",
+    "debug",
+    "query",
+    "explain",
+    "import",
+  ];
+
+  it("lists all 10 primary commands before the Advanced section", () => {
+    // Everything before "Advanced:" is the "primary" region
+    const primarySection = stdout.split(/Advanced:/i)[0];
+    for (const name of primaryNames) {
+      expect(primarySection).toContain(name);
+    }
+  });
+
+  it("lists report command", () => {
+    expect(stdout).toContain("report");
+  });
+
+  it("mentions gate review under Advanced", () => {
+    const advancedSection = stdout.split(/Advanced:/i)[1] ?? "";
+    expect(advancedSection).toContain("gate");
+  });
+
+  it("mentions ops under Advanced", () => {
+    const advancedSection = stdout.split(/Advanced:/i)[1] ?? "";
+    expect(advancedSection).toContain("ops");
+  });
+});

--- a/tests/cli/help-shape.test.ts
+++ b/tests/cli/help-shape.test.ts
@@ -17,12 +17,12 @@ describe("flaker --help", () => {
     expect(top).toContain("Primary commands:");
   });
 
-  it("contains Gate model section", () => {
-    expect(top).toContain("Gate model:");
+  it("contains Advanced section", () => {
+    expect(top).toContain("Advanced:");
   });
 
-  it("contains Management and advanced categories section", () => {
-    expect(top).toContain("Management and advanced categories:");
+  it("contains Deprecated section", () => {
+    expect(top).toContain("Deprecated (removed in 0.8.0):");
   });
 
   for (const category of ["setup", "exec", "collect", "import", "report", "analyze", "debug", "policy", "dev"]) {

--- a/tests/cli/help.test.ts
+++ b/tests/cli/help.test.ts
@@ -14,7 +14,7 @@ describe("CLI help", () => {
     expect(help).toContain("flaker run --gate merge");
     expect(help).toContain("gate");
     expect(help).toContain("Primary commands");
-    expect(help).toContain("Management and advanced categories");
+    expect(help).toContain("Advanced:");
   });
 
   it("shows exec run help with --dry-run and --explain flags", () => {

--- a/tests/cli/import-autodetect.test.ts
+++ b/tests/cli/import-autodetect.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { detectAdapter } from "../../src/cli/categories/import.js";
+
+describe("import adapter auto-detect", () => {
+  it(".xml → junit", () => {
+    expect(detectAdapter("results.xml")).toBe("junit");
+  });
+  it(".parquet → parquet", () => {
+    expect(detectAdapter("runs.parquet")).toBe("parquet");
+  });
+  it(".json defaults to playwright", () => {
+    expect(detectAdapter("report.json")).toBe("playwright");
+  });
+  it("unknown extension returns undefined", () => {
+    expect(detectAdapter("report.txt")).toBeUndefined();
+  });
+  it("case insensitive", () => {
+    expect(detectAdapter("Report.JSON")).toBe("playwright");
+    expect(detectAdapter("Results.XML")).toBe("junit");
+  });
+});

--- a/tests/cli/import-cli.test.ts
+++ b/tests/cli/import-cli.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const CLI = resolve(__filename, "../../../dist/cli/main.js");
+
+describe("flaker import (top-level)", () => {
+  it("`flaker import --help` works", () => {
+    const res = spawnSync("node", [CLI, "import", "--help"], { encoding: "utf8" });
+    expect(res.status).toBe(0);
+    expect(res.stdout).toMatch(/file/i);
+  });
+
+  it("deprecated: `flaker import report --help` warns", () => {
+    const res = spawnSync("node", [CLI, "import", "report", "--help"], { encoding: "utf8" });
+    expect(res.status).toBe(0);
+    expect(res.stderr).toContain("deprecated");
+    expect(res.stderr).toContain("flaker import");
+  });
+
+  it("deprecated: `flaker import parquet --help` warns", () => {
+    const res = spawnSync("node", [CLI, "import", "parquet", "--help"], { encoding: "utf8" });
+    expect(res.status).toBe(0);
+    expect(res.stderr).toContain("deprecated");
+    expect(res.stderr).toContain("flaker import");
+  });
+});

--- a/tests/cli/query-top-level.test.ts
+++ b/tests/cli/query-top-level.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const CLI = resolve(__filename, "../../../dist/cli/main.js");
+
+describe("flaker query", () => {
+  it("`flaker query --help` lists the SQL positional argument", () => {
+    const res = spawnSync("node", [CLI, "query", "--help"], { encoding: "utf8" });
+    expect(res.status).toBe(0);
+    expect(res.stdout).toMatch(/sql/i);
+  });
+
+  it("`flaker analyze query --help` emits the deprecation warning", () => {
+    const res = spawnSync("node", [CLI, "analyze", "query", "--help"], { encoding: "utf8" });
+    expect(res.status).toBe(0);
+    expect(res.stderr).toContain("deprecated");
+    expect(res.stderr).toContain("flaker query");
+  });
+});

--- a/tests/cli/report-flags.test.ts
+++ b/tests/cli/report-flags.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const CLI = resolve(__filename, "../../../dist/cli/main.js");
+
+describe("flaker report flag-based API", () => {
+  it("`flaker report --help` lists --summary/--diff/--aggregate", () => {
+    const res = spawnSync("node", [CLI, "report", "--help"], { encoding: "utf8" });
+    expect(res.status).toBe(0);
+    expect(res.stdout).toMatch(/--summary/);
+    expect(res.stdout).toMatch(/--diff/);
+    expect(res.stdout).toMatch(/--aggregate/);
+  });
+
+  it("deprecated subcommands warn", () => {
+    for (const sub of ["summary", "diff", "aggregate"]) {
+      const res = spawnSync("node", [CLI, "report", sub, "--help"], { encoding: "utf8" });
+      expect(res.status).toBe(0);
+      expect(res.stderr).toContain("deprecated");
+      expect(res.stderr).toContain(`flaker report`);
+    }
+  });
+});

--- a/tests/cli/status-detail.test.ts
+++ b/tests/cli/status-detail.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { renderDetail } from "../../src/cli/commands/status/summary.js";
+import { DEFAULT_PROMOTION } from "../../src/cli/config.js";
+
+describe("status --detail rendering", () => {
+  it("shows actual/threshold ratio for unmet rows", () => {
+    const drift = {
+      ok: false,
+      unmet: [
+        { field: "matched_commits", actual: 18, threshold: 20 },
+        { field: "data_confidence", actual: "low", threshold: "moderate" },
+      ],
+    };
+    const text = renderDetail(drift, DEFAULT_PROMOTION);
+    expect(text).toMatch(/matched_commits:\s*18\s*\/\s*20/);
+    expect(text).toMatch(/data_confidence:\s*low\s*(→|->|\/)\s*moderate/);
+  });
+});

--- a/tests/cli/status-gate-filter.test.ts
+++ b/tests/cli/status-gate-filter.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { formatStatusSummary } from "../../src/cli/commands/status/summary.js";
+
+describe("formatStatusSummary with filtered gates", () => {
+  it("does not crash when only one gate is present", () => {
+    const summary: any = {
+      generatedAt: "2026-04-19T00:00:00Z",
+      windowDays: 30,
+      activity: { totalRuns: 0, ciRuns: 0, localRuns: 0, passedResults: 0, failedResults: 0 },
+      health: { dataConfidence: "low", matchedCommits: 0, sampleRatio: null, brokenTests: 0, intermittentFlaky: 0, flakyTrend: 0 },
+      gates: {
+        merge: { profile: "ci", strategy: "hybrid", samplePercentage: 30, maxDurationSeconds: null, adaptive: true },
+      },
+      quarantine: { currentCount: 0, pendingAddCount: 0, pendingRemoveCount: 0 },
+      drift: { ok: false, unmet: [] },
+    };
+    const text = formatStatusSummary(summary);
+    expect(text).toContain("merge:");
+    expect(text).not.toContain("iteration:");
+    expect(text).not.toContain("release:");
+  });
+
+  it("shows all three gates when gates is the full set", () => {
+    const summary: any = {
+      generatedAt: "2026-04-19T00:00:00Z",
+      windowDays: 30,
+      activity: { totalRuns: 0, ciRuns: 0, localRuns: 0, passedResults: 0, failedResults: 0 },
+      health: { dataConfidence: "low", matchedCommits: 0, sampleRatio: null, brokenTests: 0, intermittentFlaky: 0, flakyTrend: 0 },
+      gates: {
+        iteration: { profile: "local", strategy: "random", samplePercentage: 20, maxDurationSeconds: 60, adaptive: false },
+        merge: { profile: "ci", strategy: "hybrid", samplePercentage: 30, maxDurationSeconds: null, adaptive: true },
+        release: { profile: "full", strategy: "full", samplePercentage: null, maxDurationSeconds: null, adaptive: false },
+      },
+      quarantine: { currentCount: 0, pendingAddCount: 0, pendingRemoveCount: 0 },
+      drift: { ok: true, unmet: [] },
+    };
+    const text = formatStatusSummary(summary);
+    expect(text).toContain("iteration:");
+    expect(text).toContain("merge:");
+    expect(text).toContain("release:");
+  });
+});
+
+describe("statusAction gate validation", () => {
+  it("VALID_GATE_NAMES contains the three canonical gates and not arbitrary strings", async () => {
+    const { VALID_GATE_NAMES } = await import("../../src/cli/gate.js");
+    expect(VALID_GATE_NAMES).toContain("iteration");
+    expect(VALID_GATE_NAMES).toContain("merge");
+    expect(VALID_GATE_NAMES).toContain("release");
+    expect((VALID_GATE_NAMES as readonly string[]).includes("bogus")).toBe(false);
+  });
+});

--- a/tests/cli/status-list.test.ts
+++ b/tests/cli/status-list.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderListFlaky, renderListQuarantined } from "../../src/cli/commands/status/summary.js";
+
+describe("status --list rendering", () => {
+  it("formats flaky rows", () => {
+    const rows = [
+      { suite: "tests/a.test.ts", test_name: "reconnect", flaky_rate: 0.18, runs: 40 },
+      { suite: "tests/b.test.ts", test_name: "retry",     flaky_rate: 0.12, runs: 35 },
+    ];
+    const out = renderListFlaky(rows as any);
+    expect(out).toMatch(/reconnect/);
+    expect(out).toMatch(/18%|0\.18/);
+  });
+
+  it("formats quarantined rows", () => {
+    const rows = [
+      { suite: "tests/a.test.ts", test_name: "flake1", added_at: "2026-04-01" },
+      { suite: "tests/b.test.ts", test_name: "flake2", added_at: "2026-04-05" },
+    ];
+    const out = renderListQuarantined(rows as any);
+    expect(out).toMatch(/flake1/);
+    expect(out).toMatch(/flake2/);
+  });
+});

--- a/tests/cli/status-markdown.test.ts
+++ b/tests/cli/status-markdown.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { formatStatusMarkdown } from "../../src/cli/commands/status/summary.js";
+
+const sampleSummary: any = {
+  generatedAt: "2026-04-19T00:00:00Z",
+  windowDays: 30,
+  activity: { totalRuns: 10, ciRuns: 5, localRuns: 5, passedResults: 100, failedResults: 2 },
+  health: {
+    dataConfidence: "moderate",
+    matchedCommits: 25,
+    sampleRatio: 40,
+    brokenTests: 1,
+    intermittentFlaky: 3,
+    flakyTrend: -1,
+  },
+  gates: {
+    iteration: { profile: "local", strategy: "affected", samplePercentage: null, maxDurationSeconds: 60, adaptive: false },
+    merge:     { profile: "ci",    strategy: "hybrid",   samplePercentage: 30,   maxDurationSeconds: null, adaptive: true },
+    release:   { profile: "scheduled", strategy: "full", samplePercentage: null, maxDurationSeconds: null, adaptive: false },
+  },
+  quarantine: { currentCount: 2, pendingAddCount: 1, pendingRemoveCount: 0 },
+  drift: { ok: true, unmet: [] },
+};
+
+describe("formatStatusMarkdown", () => {
+  it("renders Markdown with headers and tables", () => {
+    const md = formatStatusMarkdown(sampleSummary);
+    expect(md).toContain("# flaker Status");
+    expect(md).toContain("## Activity");
+    expect(md).toContain("| iteration |");
+    expect(md).toContain("| merge |");
+    expect(md).toContain("| release |");
+    expect(md).toMatch(/data confidence.*moderate/i);
+  });
+});

--- a/tests/cli/surface-reduction.test.ts
+++ b/tests/cli/surface-reduction.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const CLI = resolve(__filename, "../../../dist/cli/main.js");
+
+/**
+ * The 0.7.0 surface reduction contract.
+ * The "Primary commands:" block of `flaker --help` MUST list exactly these
+ * 11 entries (10 primary + `report` for IO). Adding a new primary command
+ * requires updating this list AND the 2026-04-19 plan doc.
+ */
+const PRIMARY = [
+  "init",
+  "plan",
+  "apply",
+  "status",
+  "run",
+  "doctor",
+  "debug",
+  "query",
+  "explain",
+  "import",
+  "report",
+];
+
+describe("primary command surface", () => {
+  it("lists exactly the 11 primary entries before 'Advanced'", () => {
+    const res = spawnSync("node", [CLI, "--help"], { encoding: "utf8" });
+    expect(res.status).toBe(0);
+    const stdout = res.stdout;
+    const primaryStart = stdout.indexOf("Primary commands:");
+    const advancedStart = stdout.indexOf("Advanced:");
+    expect(primaryStart).toBeGreaterThan(-1);
+    expect(advancedStart).toBeGreaterThan(primaryStart);
+    const block = stdout.slice(primaryStart, advancedStart);
+
+    // Each PRIMARY name must appear as a left-aligned command token.
+    // Use a word-boundary-ish match on `  <name>  ` or `  <name> --` prefix
+    // at column position to avoid false positives from the description text.
+    for (const name of PRIMARY) {
+      // name is on its own word, followed by at least one space and a
+      // description (command listings use fixed-width padding). Allow
+      // optional arg like "run --gate <...>"
+      const pattern = new RegExp(`(?:^|\\n)\\s+${name}(?:\\s|$|\\s--)`);
+      expect(block).toMatch(pattern);
+    }
+  });
+
+  it("does not list any deprecated command in the Primary block", () => {
+    const res = spawnSync("node", [CLI, "--help"], { encoding: "utf8" });
+    const stdout = res.stdout;
+    const primaryStart = stdout.indexOf("Primary commands:");
+    const advancedStart = stdout.indexOf("Advanced:");
+    const block = stdout.slice(primaryStart, advancedStart);
+
+    // Sanity: ensure legacy names don't accidentally leak back into Primary.
+    const LEAKAGE_GUARDS = ["exec", "setup init", "collect ci", "analyze kpi", "policy quarantine"];
+    for (const leak of LEAKAGE_GUARDS) {
+      expect(block).not.toContain(leak);
+    }
+  });
+});

--- a/tests/cli/top-level-aliases.test.ts
+++ b/tests/cli/top-level-aliases.test.ts
@@ -86,10 +86,10 @@ describe("top-level aliases", () => {
     expect(help).toContain("--run");
   });
 
-  it("flaker doctor --help shows the top-level doctor alias", () => {
+  it("flaker doctor --help shows the canonical doctor command (not deprecated)", () => {
     const help = execSync(`node ${cliPath} doctor --help`, { encoding: "utf-8" });
-    expect(help).toContain("DEPRECATED");
-    expect(help).toContain("flaker debug doctor");
+    expect(help).toContain("Check runtime requirements");
+    expect(help).not.toContain("DEPRECATED");
   });
 
   it("flaker collect --help shows collect subcommands and ci options", () => {

--- a/tests/cli/top-level-aliases.test.ts
+++ b/tests/cli/top-level-aliases.test.ts
@@ -88,7 +88,8 @@ describe("top-level aliases", () => {
 
   it("flaker doctor --help shows the top-level doctor alias", () => {
     const help = execSync(`node ${cliPath} doctor --help`, { encoding: "utf-8" });
-    expect(help).toContain("DEPRECATED alias for `flaker debug doctor`");
+    expect(help).toContain("DEPRECATED");
+    expect(help).toContain("flaker debug doctor");
   });
 
   it("flaker collect --help shows collect subcommands and ci options", () => {


### PR DESCRIPTION
## Summary

Phase 1 of the 0.7.0 surface reduction plan. Consolidates 53 leaf commands down to 11 user-facing primary entries by absorbing secondary commands into `apply` / `status` / `explain` and collapsing import/report subcommands into flag-based APIs.

Every deprecated command still works; they now emit stderr warnings pointing at the canonical replacement and are scheduled for removal in 0.8.0.

## Primary surface (0.7.0)

| # | Command | Absorbs |
|---|---|---|
| 1 | `flaker init` | `setup init` |
| 2 | `flaker plan` | — (0.6.0) |
| 3 | `flaker apply` | `collect *`, `quarantine suggest/apply`, `ops daily`, `policy *`, `analyze flaky-tag` |
| 4 | `flaker status` | `analyze kpi`, `analyze eval`, `analyze flaky`, `gate review/history/explain` (via `--markdown`, `--list`, `--detail`, `--gate`) |
| 5 | `flaker run --gate <name>` | `exec run`, `exec affected` |
| 6 | `flaker doctor` | `debug doctor` |
| 7 | `flaker debug <retry\|confirm\|bisect\|diagnose>` | — (kept first-class) |
| 8 | `flaker query <sql>` | `analyze query` |
| 9 | `flaker explain <topic>` | `analyze reason/insights/cluster/bundle/context` |
| 10 | `flaker import <file>` | `import report/parquet` (adapter auto-detected from extension) |
| 11 | `flaker report <file> --summary\|--diff\|--aggregate` | `report summary/diff/aggregate` |

## Breakdown by commit

1. `refactor(cli): generalize deprecation helper` — extracts `deprecate(cmd, { since, remove, canonical })` into `src/cli/deprecation.ts`
2. `feat(status): absorb kpi/eval/flaky/gate-review` — adds `--markdown`, `--list <flaky|quarantined>`, `--detail`, `--gate <name>`
3. `feat(cli): deprecate analyze kpi/eval/flaky/flaky-tag`
4. `feat(cli): promote query to top-level and add explain umbrella`
5. `feat(cli): unify import and report surfaces under flag-based top-level commands`
6. `feat(cli): blanket-deprecate 17 commands and reorganize help around 10 primary`
7. `chore(release): 0.7.0-next.0` — version bump + CHANGELOG + `tests/cli/surface-reduction.test.ts` invariant

## Non-goals (follow-up phases)

- **Phase 2**: rewrite `flaker-setup` / `flaker-management` skills for the new surface; extend `apply` to emit daily/weekly artifacts (absorbing `ops daily` fully); update `docs/*.ja.md` and `docs/*.md` checklists and guides.
- **Phase 3 / 0.8.0**: actually remove the 17+ deprecated commands.

## Test plan

- [x] `pnpm test` — 165 test files, 776 passed, 1 skipped
- [x] `pnpm typecheck` — clean
- [x] `pnpm build` — clean
- [x] `tests/cli/surface-reduction.test.ts` asserts the 11-entry invariant
- [x] `tests/cli/deprecation-blanket.test.ts` covers all 17 deprecated commands
- [ ] Manual dogfood of `flaker apply` / `flaker status --list flaky` on a real repo before publishing 0.7.0 proper

## Notes

- All seven reviewer-surface-sensitive tests (`help-shape`, `help-primary-shape`, `top-level-aliases`, `deprecation-warning`, `deprecation-analyze`, `deprecation-blanket`, `surface-reduction`) now work together as a regression net.
- `package.json` is pinned to `0.7.0-next.0` so the stable 0.7.0 only ships after Phase 2 (docs + skill migration) lands.