### PR TITLE
feat: 0.7.0 — Phase 2 (skills, docs, minor fixes, release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.7.0-next.0 (prerelease)
+## 0.7.0
 
 ### Deprecated (removed in 0.8.0)
 
@@ -28,7 +28,7 @@ the 0.7.0 canonical replacement.
 
 ### New
 
-- `flaker plan` / `flaker apply` (declarative reconciler; shipped in 0.6.0)
+- `flaker plan` / `flaker apply` — declarative reconciler (shipped in 0.6.0, promoted to primary in 0.7.0)
 - `flaker status` gained `--markdown`, `--list flaky|quarantined`, `--detail`, `--gate <name>`
 - `flaker query <sql>` top-level
 - `flaker explain <topic>` umbrella for AI-assisted analysis
@@ -36,16 +36,32 @@ the 0.7.0 canonical replacement.
 - `flaker report <file>` uses `--summary` / `--diff` / `--aggregate` flags
 - `[promotion]` config section with documented defaults
 - `[promotion].data_confidence_min` validated against the `low|moderate|high` enum
+- `flaker init` now writes `[profile.local]` / `[profile.ci]` / `[profile.scheduled]` defaults
+- `flaker apply` prints actionable stderr hints when the plan is empty or cold-start discovered 0 tests
 
 ### Changed
 
 - `flaker --help` reorganized into three tiers: Primary (11), Advanced, Deprecated
 - Primary command surface reduced from 53 to 11 user-facing entries (hidden `dev *` subtree retained)
+- `flaker doctor` is now the canonical form; `flaker debug doctor` is the deprecated alias (reversed from pre-0.7 polarity)
+- `flaker ops daily` is Advanced, not Deprecated — the aspirational "apply absorbs daily" did not actually ship yet
 
 ### Fixed
 
 - `flaker apply` now aborts cleanly when `GITHUB_TOKEN` is missing (previously `process.exit(1)` bypassed the executor's abort handler)
 - `probeRepo.hasLocalHistory` now queries `workflow_runs` instead of being hardcoded `false`
+- `flaker --version` prints a single line (was leaking `flaker core CLI 0.1.0 (js)` from an eager moonbit bridge import)
+- `flaker status --gate <name>` no longer crashes on the filtered gates object (text formatter was hardcoded to iterate all three gate names)
+- Deprecation warnings now reference the full command path (`flaker analyze kpi`) instead of just the leaf (`flaker kpi`), fixing 18 misleading or self-referential warnings
+
+### Docs
+
+- New `docs/migration-0.6-to-0.7.md` with full deprecation matrix + upgrade recipe + grep checklist
+- `skills/flaker-setup/SKILL.md` and `skills/flaker-management/SKILL.md` rewritten for the 10-command surface
+- `docs/new-project-checklist.{ja,md}` unified on apply+status flow
+- `docs/operations-guide.ja.md` daily loop simplified to `apply + status`
+- `README.md` Quick Start collapsed from Path 1/Path 2 split into a single 6-command block
+- Canonical command forms table moved to README and kept as single-source-of-truth
 
 ## [0.5.0](https://github.com/mizchi/flaker/compare/flaker-v0.4.0...flaker-v0.5.0) (2026-04-18)
 

--- a/README.md
+++ b/README.md
@@ -527,13 +527,13 @@ The repo now ships two GitHub-native self-host lanes:
 
 Both lanes render the same promotion-readiness summary from `scripts/self-host-review.mjs`. The current default is still advisory: the PR job is non-blocking, and the nightly workflow carries the long-form trend.
 
-Promote `flaker run --gate merge` to a required check only after the nightly issue shows **all five** of the following. Check the current values with `flaker gate review merge --json` (authoritative for promotion) — `flaker status` is a summary-only dashboard and should not be used for promotion.
+Promote `flaker run --gate merge` to a required check only after the nightly issue shows **all five** of the following. The primary signal is `flaker status` (the `Promotion drift` section reports `ready` when all five thresholds are met). For the exact numeric values, use `flaker status --gate merge --detail --json` — this is the authoritative output. (`flaker gate review merge --json` is the legacy alias, DEPRECATED in 0.7.0, removed in 0.8.0.)
 
 - `matched commits >= 20` — commits where both a gated local/CI run and a release/full run exist in the same window, so that local sampling outcomes can be compared against a ground-truth full run. Increases as the nightly `--gate release` accumulates history.
 - `false negative rate <= 5%` — share of commits where the `merge` gate passed but the full run failed (sampling missed a real regression). Measured over the same matched-commit window.
 - `pass correlation >= 95%` — `P(full run passes | merge gate passes)` on matched commits. Same metric referenced elsewhere in this README as `P(CI pass | local pass)`.
 - `holdout FNR <= 10%` — FNR measured on the holdout slice defined by `[sampling] holdout_ratio`. Tests in the holdout slice are excluded from the sampled run so that their outcomes can be used to audit whether the sampler's verdict generalizes. Guards against sampler overfitting to the visible slice.
-- `data confidence` reaches `moderate` or `high` — derived signal combining matched-commit count, history window coverage, and flaky-noise level. Rough rule of thumb: `low` until ~10 matched commits, `moderate` around 20–40 with FNR/correlation green, `high` beyond 40 with stable noise. Exact boundaries come from the `gate review merge` output, not from config.
+- `data confidence` reaches `moderate` or `high` — derived signal combining matched-commit count, history window coverage, and flaky-noise level. Rough rule of thumb: `low` until ~10 matched commits, `moderate` around 20–40 with FNR/correlation green, `high` beyond 40 with stable noise. Exact boundaries come from the `status --gate merge --detail --json` output, not from config.
 
 ## Recommended Usage Model
 

--- a/README.md
+++ b/README.md
@@ -243,45 +243,40 @@ The older primitives such as `analyze eval`, `analyze flaky-tag`, and `policy qu
 
 ## Quick Start
 
-Pick the path that matches the repo's CI history on Day 1. `flaker calibrate` only produces useful output once there are enough CI runs to analyze (it emits an `insufficient` warning on empty history), so it belongs in Path 2, not Path 1.
+`flaker.toml` is the **desired state**. `flaker apply` reconciles the repo to it, idempotently. Works on fresh repos (no history) and mature repos alike — the reconciler handles the branching.
 
-### Path 1 — New repo, no CI history yet
+```bash
+pnpm add -D @mizchi/flaker
+pnpm flaker init --adapter <playwright|vitest|jest|junit> --runner <same or actrun>
+# edit [affected].resolver in flaker.toml (workspace | glob | bitflow)
+pnpm flaker doctor
+pnpm flaker plan          # preview what apply will do
+pnpm flaker apply         # converge (safe to re-run)
+pnpm flaker status        # dashboard + promotion drift
+```
 
-The first `flaker run` self-seeds a history from the runner's listed tests (cold-start fallback; see below). Run `collect` / `calibrate` later on Day 2–3 once CI has accumulated enough data.
+`flaker init` generates `[profile.local]` / `[profile.ci]` / `[profile.scheduled]` defaults out of the box. `flaker apply` detects missing CI history, runs a cold-start iteration gate, collects CI runs when `GITHUB_TOKEN` is set, and tunes sampling via calibrate when there are enough matched commits — in that order, skipping whatever isn't applicable.
 
-1. `flaker init` — creates `flaker.toml`, auto-detects repo from git remote
-2. `flaker doctor`[^doctor-canonical] — verifies DuckDB, MoonBit, and config
-3. `flaker run --gate iteration` — runs tests and records the first local history
-4. `flaker status` — user-facing summary dashboard
-5. (Day 2–3) `flaker collect --days 30 && flaker collect calibrate` — once CI has accumulated runs, pull them in and tune sampling
+The full Day 0 → Week 4 onboarding checklist lives at [docs/new-project-checklist.ja.md](docs/new-project-checklist.ja.md) / [.md](docs/new-project-checklist.md).
 
-[^doctor-canonical]: `flaker doctor` is the onboarding-friendly alias; the canonical form is `flaker debug doctor` (see canonical command forms table below).
-
-### Path 2 — Existing repo, CI history already present
-
-Calibrate on Day 1 using the existing history.
-
-1. `flaker init` — creates `flaker.toml`, auto-detects repo from git remote
-2. `flaker doctor`[^doctor-canonical] — verifies DuckDB, MoonBit, and config
-3. `flaker collect --days 30` — pulls recent CI runs from GitHub Actions (requires `GITHUB_TOKEN`)
-4. `flaker collect calibrate` — analyzes the collected history and writes optimal sampling config back into `flaker.toml`
-5. `flaker run --gate iteration` — fast local feedback
-6. `flaker status` — user-facing summary dashboard (sampling, flaky tests, data quality)
-
-The staged onboarding checklist at [docs/new-project-checklist.ja.md](docs/new-project-checklist.ja.md) expands Path 1 across Day 0 → Week 4.
-
-For users who want a single idempotent entrypoint instead of the step-by-step flow above, `flaker plan` / `flaker apply` (introduced in 0.6.0) treat `flaker.toml` as desired state and automatically sequence `collect` / `calibrate` / `quarantine apply` based on current DB state. Run `flaker plan` first to preview what will happen, then `flaker apply` to converge. Path 2 above remains fully supported for operators who prefer explicit control.
-
-> **Canonical command forms**
+> **Canonical command forms (0.7.0)**
 >
-> | Canonical | Legacy form (accepted but avoid in new docs) |
+> The primary surface is 11 commands: `init`, `plan`, `apply`, `status`, `run`, `doctor`, `debug`, `query`, `explain`, `import`, `report`. Everything else is either Advanced (`gate`, `ops`, `dev`) or Deprecated (removed in 0.8.0). The legacy aliases below still work and emit a stderr warning pointing at the canonical form.
+>
+> | Canonical (0.7.0) | Legacy form |
 > |---|---|
-> | `flaker collect --days N` | `flaker collect ci --days N` |
-> | `flaker collect calibrate` | (there is no top-level `flaker calibrate`) |
-> | `flaker analyze kpi` | `flaker kpi` — DEPRECATED in 0.6.0 |
-> | `flaker debug doctor` | `flaker doctor` — DEPRECATED in 0.6.0 |
->
-> `flaker collect` and `flaker collect ci` are aliases — both call the same action (pull from GitHub Actions). New docs standardize on `flaker collect` (no `ci` subcommand). `flaker status` (top-level) and `flaker analyze kpi` are **different** commands: `status` is the summary-only dashboard for daily use; `analyze kpi` is the detailed KPI view for operators. Use `flaker gate review merge --json` — not `status` — when you need the authoritative numbers for advisory-to-required promotion decisions.
+> | `flaker apply` | `flaker collect ci / local / coverage / calibrate`, `flaker quarantine suggest / apply`, `flaker policy quarantine`, `flaker analyze flaky-tag` |
+> | `flaker status` | `flaker analyze kpi`, `flaker kpi` |
+> | `flaker status --markdown` | `flaker analyze eval --markdown` |
+> | `flaker status --list flaky` | `flaker analyze flaky` |
+> | `flaker status --gate <name> --detail --json` | `flaker gate review <name> --json`, `flaker gate history`, `flaker gate explain` |
+> | `flaker run --gate <name>` | `flaker exec run`, `flaker exec affected` |
+> | `flaker init` | `flaker setup init` |
+> | `flaker doctor` | `flaker debug doctor` |
+> | `flaker query <sql>` | `flaker analyze query` |
+> | `flaker explain <topic>` | `flaker analyze reason / insights / cluster / bundle / context` |
+> | `flaker import <file>` (adapter auto-detect) | `flaker import report / parquet` |
+> | `flaker report <file> --summary \| --diff <base> \| --aggregate <dir>` | `flaker report summary / diff / aggregate` |
 
 ### Initialize
 

--- a/docs/migration-0.6-to-0.7.md
+++ b/docs/migration-0.6-to-0.7.md
@@ -1,0 +1,157 @@
+# Migrating from flaker 0.6.x to 0.7.0
+
+## 1. Summary
+
+flaker 0.7.0 reduces the primary CLI surface from 53 user-facing commands to 11. This change was motivated by empirical testing that showed both AI-assisted and human callers converged on the same ten to eleven verbs when completing real tasks. The long tail of subcommands — collected organically over the 0.3.x–0.6.x development cycle — created discoverability overhead without adding expressiveness; the new surface covers every workflow the old one did, often with fewer keystrokes.
+
+For existing users this means **nothing breaks in 0.7.x**. Every deprecated command still dispatches normally; flaker simply prints a one-line `stderr` warning noting the canonical replacement and the version in which the old form will be removed. CI pipelines, `package.json` scripts, and cron jobs that use the old forms will continue to work without modification throughout the 0.7.x series.
+
+The removal window follows the same minor-version convention used for the 0.5.x → 0.6.x migration: one full minor cycle of deprecation warnings, then removal in the next minor bump. Deprecated commands will be **removed in 0.8.0**. If you want to stay ahead of that cutoff, follow the [upgrade recipe](#4-upgrade-recipe) and [grep checklist](#5-grep-checklist) below.
+
+---
+
+## 2. New in 0.7.0
+
+- **`flaker plan`** — shipped experimentally in 0.6.0, promoted to the primary surface in 0.7.0. Previews what `apply` would do without writing state.
+- **`flaker apply`** — shipped in 0.6.0, promoted to primary. Single entry point that absorbs `collect`, `quarantine`, `policy`, and `analyze flaky-tag` workflows.
+- **`flaker status`** — new flags:
+  - `--markdown` — renders the evaluation report (replaces `analyze eval --markdown`)
+  - `--list flaky` / `--list quarantined` — filtered test lists
+  - `--gate <name>` — per-gate snapshot (replaces `gate review` / `gate history`)
+  - `--detail` — verbose breakdown (replaces `gate explain`)
+  - `--json` — machine-readable output
+- **`flaker query <sql>`** — top-level DuckDB query shortcut (replaces `analyze query`)
+- **`flaker explain <topic>`** — umbrella command for `reason`, `insights`, `cluster`, `bundle`, and `context` analysis topics
+- **`flaker import <file>`** — adapter auto-detected from file extension (replaces `import report` and `import parquet`)
+- **`flaker report <file>`** with flags:
+  - `--summary` — replaces `report summary`
+  - `--diff <base>` — replaces `report diff`
+  - `--aggregate <dir>` — replaces `report aggregate`
+- **`[promotion]` config section** — documented in `flaker.toml` with stable defaults
+- **`[promotion].data_confidence_min`** — validated against an enum at startup; invalid values produce a clear error rather than silently using the default
+
+---
+
+## 3. Deprecation matrix
+
+All commands in the left column emit a `stderr` deprecation warning in 0.7.x and will be **removed in 0.8.0**.
+
+| Deprecated (0.7.x — stderr warning) | Canonical (0.7.0) |
+|---|---|
+| `flaker setup init` | `flaker init` |
+| `flaker exec run` | `flaker run` |
+| `flaker exec affected` | `flaker run --gate iteration --changed <paths>` |
+| `flaker collect` / `flaker collect ci` | `flaker apply` |
+| `flaker collect local` | `flaker apply` |
+| `flaker collect coverage` | `flaker apply` |
+| `flaker collect commit-changes` | `flaker apply` |
+| `flaker collect calibrate` | `flaker apply` |
+| `flaker quarantine suggest` / `flaker quarantine apply` | `flaker apply` |
+| `flaker policy quarantine` / `flaker policy check` / `flaker policy report` | `flaker apply` |
+| `flaker gate review <name>` | `flaker status --gate <name> --detail --json` |
+| `flaker gate history <name>` | `flaker status --gate <name>` |
+| `flaker gate explain <name>` | `flaker status --gate <name> --detail` |
+| `flaker analyze kpi` | `flaker status` |
+| `flaker analyze eval` | `flaker status --markdown` |
+| `flaker analyze flaky` | `flaker status --list flaky` |
+| `flaker analyze flaky-tag` | `flaker apply` |
+| `flaker analyze reason` / `insights` / `cluster` / `bundle` / `context` | `flaker explain <topic>` |
+| `flaker analyze query` | `flaker query` |
+| `flaker import report <file>` | `flaker import <file>` (adapter auto-detected) |
+| `flaker import parquet <dir>` | `flaker import <file>` |
+| `flaker report summary` / `diff` / `aggregate` | `flaker report <file> --summary` / `--diff <base>` / `--aggregate <dir>` |
+| `flaker debug doctor` | `flaker doctor` |
+| `flaker kpi` (top-level alias) | `flaker status` (via `flaker analyze kpi`) |
+
+**Not deprecated — kept as first-class commands:**
+
+- `flaker ops daily` / `flaker ops weekly` / `flaker ops incident` — `apply` does not yet emit cadence artifacts; these remain the authoritative interface for scheduled operations workflows.
+- `flaker dev *` — hidden maintainer tools; not part of the public surface.
+
+---
+
+## 4. Upgrade recipe
+
+```bash
+# 1. Update the package
+pnpm up @mizchi/flaker@0.7
+
+# 2. Dry-run the new surface on your existing flaker.toml
+pnpm flaker status        # read drift vs [promotion] thresholds
+pnpm flaker plan          # see what apply would do (no writes)
+
+# 3. Replace imperative scripts with apply-first
+# (update package.json scripts, CI workflows, and cron jobs)
+
+# old:
+#   flaker collect ci --days 30 && flaker collect calibrate
+# new:
+#   flaker apply
+
+# old:
+#   flaker analyze kpi
+# new:
+#   flaker status
+
+# old:
+#   flaker analyze eval --markdown --window 7
+# new:
+#   flaker status --markdown
+
+# old:
+#   flaker gate review merge --json
+# new:
+#   flaker status --gate merge --detail --json
+
+# old:
+#   flaker analyze reason flaky-suite
+# new:
+#   flaker explain reason
+
+# old:
+#   flaker import report results.json
+# new:
+#   flaker import results.json
+
+# old:
+#   flaker report summary
+# new:
+#   flaker report results.json --summary
+```
+
+---
+
+## 5. Grep checklist
+
+Run the following command in your repository root before upgrading to 0.8.0. Every match is either a script or documentation reference that needs updating.
+
+```bash
+grep -rE 'flaker (collect (ci|local|coverage|commit-changes|calibrate)|quarantine (suggest|apply)|policy (quarantine|check|report)|gate (review|history|explain)|analyze (kpi|eval|flaky|flaky-tag|reason|insights|cluster|bundle|context|query)|setup init|exec (run|affected)|debug doctor|kpi\b)' \
+  .github/ package.json docs/ scripts/
+```
+
+Typical locations to check:
+
+- `.github/workflows/*.yml` — CI collect and gate-review steps
+- `package.json` `scripts` block — local dev helpers
+- `docs/` — any runbook or how-to that references old command forms
+- `scripts/` — any shell scripts wrapping flaker commands
+
+---
+
+## 6. Breaking changes (none in 0.7.0)
+
+0.7.0 is **not** a breaking release. The version bump reflects the scope of the surface rework, but every deprecated command still dispatches identically to its 0.6.x behavior and exits with the same exit codes. The only observable change is a single deprecation warning printed to `stderr`.
+
+0.8.0 will be the first breaking release in this cycle. Deprecated commands will exit with a non-zero code and print an error instead of running.
+
+---
+
+## 7. Related reading
+
+- [README — canonical command forms](../README.md#quick-start)
+- `skills/flaker-setup/SKILL.md` — onboarding for new repos (0.7.0 flow)
+- `skills/flaker-management/SKILL.md` — daily operations (0.7.0 flow)
+- [`CHANGELOG.md`](../CHANGELOG.md) — full 0.7.0 release notes
+- [`docs/superpowers/plans/2026-04-19-cli-surface-reduction.md`](superpowers/plans/2026-04-19-cli-surface-reduction.md) — Phase 1 plan
+- [`docs/superpowers/plans/2026-04-19-phase2-skill-docs-migration.md`](superpowers/plans/2026-04-19-phase2-skill-docs-migration.md) — Phase 2 plan

--- a/docs/new-project-checklist.ja.md
+++ b/docs/new-project-checklist.ja.md
@@ -2,9 +2,9 @@
 
 [English](new-project-checklist.md)
 
-新しいリポジトリで flaker を「即日 → 1 週 → 1 ヶ月」の段階で価値を出すための手順書。0.3.0 以降を前提とする。
+新しいリポジトリで flaker を「即日 → 1 週 → 1 ヶ月」の段階で価値を出すための手順書。0.7.0 以降を前提とする。
 
-順番に実行すれば 30 分で初期セットアップが終わり、1 週間で計測ベースが整い、2〜4 週間で CI gating に昇格できる状態になる。
+Day 1 は `init → doctor → plan → apply → status` の 5 ステップで収束させる。順に実行すれば 30 分で初期セットアップが終わり、1 週間で計測ベースが整い、2〜4 週間で CI gating に昇格できる状態になる。
 
 ---
 
@@ -14,16 +14,18 @@
 node --version    # >= 24
 pnpm --version    # >= 10
 git remote -v     # origin が GitHub を指している
-gh auth status    # ログイン済み (collect ci に必要)
+gh auth status    # ログイン済み (flaker apply で履歴収集するときに必要)
 ```
 
-GitHub Actions を使っていない / 履歴が無い場合は、Day 1 の手順で `collect ci` を一旦スキップして「ローカル先行 → 後日 collect」のフローに切り替える。
+GitHub Actions を使っていない / 履歴が無い場合も問題ない。`flaker apply` は履歴ゼロの repo では cold-start 経路 (local run で self-seed) を選ぶので、Day 1 の手順はそのまま通る。CI 履歴は後から自然に溜まる。
 
 `moon` (MoonBit) は不要。flaker は `dist/moonbit/flaker.js` を bundle 済みで配布し、無ければ TypeScript fallback (`src/cli/core/loader.ts`) で動く。
 
 ---
 
-## Day 1: インストールと初期化 (15 分)
+## Day 1: インストールから収束まで (15 分)
+
+Day 1 は次の 5 ステップで完結する。個別のキャリブレーション / 履歴取り込みは `flaker apply` が内部で面倒を見るので、ユーザーが順序を覚える必要はない。
 
 ### 1. インストール
 
@@ -51,10 +53,12 @@ pnpm flaker init --adapter playwright --runner actrun
 
 owner / name は git remote から自動検出される。`--owner` / `--name` で上書き可。
 
+0.7.0 以降、`flaker init` は `[profile.scheduled]` / `[profile.ci]` / `[profile.local]` の既定値も同時に書き込む。
+
 ### 3. doctor で環境チェック
 
 ```bash
-pnpm flaker doctor   # canonical: flaker debug doctor
+pnpm flaker doctor
 ```
 
 期待する出力:
@@ -72,7 +76,7 @@ DuckDB が落ちる場合は `node --version` が 24 未満の可能性が高い
 
 ### 4. affected resolver を設定
 
-`flaker run --gate iteration` / `hybrid` strategy を活かすには resolver の設定が必要。プロジェクトの形に合わせて `[affected]` セクションを編集:
+`flaker run --gate iteration` / `hybrid` strategy を活かすには resolver の設定が必要。プロジェクトの形に合わせて `flaker.toml` の `[affected]` セクションを編集:
 
 ```toml
 # pnpm workspaces / npm workspaces を使っているモノレポ
@@ -93,29 +97,47 @@ config = ""
 
 resolver を設定しないと `hybrid` は機能しないが、`weighted` / `random` フォールバックで動く。最初は workspace を試して、ハマったら次のレベルへ。
 
-### 5. ローカルで dry-run
+### 5. `flaker plan` で差分を確認
 
 ```bash
-git diff --name-only main | tr '\n' ',' > /tmp/changed.txt
-pnpm flaker run --gate iteration --dry-run --explain --changed "$(cat /tmp/changed.txt)"
+export GITHUB_TOKEN=$(gh auth token)
+pnpm flaker plan
 ```
 
-`Selected tests:` の行に件数が出ればパイプライン稼働中。`Sampling Summary` セクションが空の場合は、対応するテストファイルが無い (project 初期で当然) か、resolver 設定不一致。
+`flaker.toml` を desired state として、今 DB に何が欠けているかを planner が示す。履歴ゼロの repo なら `collect_ci` + `cold_start_run` が、`[quarantine].auto=true` のときは `quarantine_apply` も plan に載る。
+
+### 6. `flaker apply` で収束させる
+
+```bash
+pnpm flaker apply
+```
+
+`flaker apply` は `collect` / `calibrate` / `quarantine apply` を現状に応じて自動で順に実行する idempotent コマンド。同じコマンドを cron や nightly で回しても状態が壊れない。
+
+### 7. `flaker status` で確認
+
+```bash
+pnpm flaker status
+```
+
+サマリダッシュボードが 1 画面で出る。Day 1 段階では `data confidence: insufficient` が出て普通。1 週間運用すると自然に `moderate` に上がる。
 
 ---
 
-## Day 2-3: 最初のデータ収集 (30 分)
+## Day 2-3: 継続的な apply
 
-### 1. 宣言的に収束させる
+`flaker apply` は idempotent なので、Day 2 以降は「1 日 1 回走らせておく」だけで十分。手動で `collect` / `calibrate` を順に叩く必要はない。
 
 ```bash
 export GITHUB_TOKEN=$(gh auth token)
 pnpm flaker apply
+pnpm flaker status                 # 日次ダッシュボード
+pnpm flaker status --detail        # KPI ビュー (旧 analyze kpi)
 ```
 
-`flaker apply` が現状に応じて collect / calibrate / quarantine apply を自動で順に実行する。何が走るかを先に見たい場合は `pnpm flaker plan`。
+<details><summary>内部で何が走っているか知りたい・個別コマンドで掘りたい場合</summary>
 
-<details><summary>個別コマンドを手動で叩く場合</summary>
+`flaker apply` は内部的に以下を現状に応じて実行する。単体で叩きたい場合は直接呼んでもよい (0.7.0 以降はすべて deprecated / hidden、`flaker apply` が canonical)。
 
 **CI 履歴取り込み:**
 
@@ -123,16 +145,6 @@ pnpm flaker apply
 export GITHUB_TOKEN=$(gh auth token)
 pnpm flaker collect ci --days 30
 ```
-
-期待する出力:
-
-```
-Exported to Parquet: 12 test results, 4 commit changes
-...
-Collected N runs, N*X test results, ...
-```
-
-`Failed runs` がカウントされていても問題ない (失敗 run はスキップ)。`pending artifact runs` は GitHub Actions の retention 待ちなので、後でもう一度実行すれば取れる。
 
 **キャリブレーション:**
 
@@ -142,44 +154,32 @@ pnpm flaker collect calibrate
 
 `flaker.toml` の `[sampling]` セクションに最適な戦略・サンプル率が書き込まれる。`--dry-run` を付ければ書き込まずに推奨だけ見られる。
 
-データが少ないとき (commits < 20) は `confidence: insufficient` か `low` の警告が出るが無視して続行 OK。1 週間後に再度回せばよい。
+データが少ないとき (commits < 20) は `confidence: insufficient` か `low` の警告が出るが無視して続行 OK。1 週間後に再度 `flaker apply` を回せば自然に更新される。
 
 </details>
-
-### 2. KPI ダッシュボードで確認
-
-`flaker status` と `flaker analyze kpi` は **別コマンド**。使い分けは:
-
-- `flaker status` — 日常チェック用のサマリダッシュボード。短く読める。
-- `flaker analyze kpi` — オペレータが詳細値を見る KPI ビュー。昇格判断の一次ソースは `flaker gate review merge --json` であって status/kpi ではない。
-
-Day 2-3 段階では詳細な数値を確認したいので kpi を使う:
-
-```bash
-pnpm flaker analyze kpi
-```
-
-最初は `Sampling Effectiveness` セクションが空 (matched commits = 0)。Week 1 が終われば `local pass / CI pass` の相関が計算できるようになる。
 
 ---
 
 ## Day 3: package.json scripts を整える
 
+0.7.0 以降は apply-first の script 構成にする:
+
 ```jsonc
 {
   "scripts": {
     "flaker": "flaker",
+    "flaker:plan": "flaker plan",
+    "flaker:apply": "flaker apply",
+    "flaker:status": "flaker status",
     "flaker:run:iteration": "flaker run --gate iteration",
     "flaker:run:release": "flaker run --gate release",
-    "flaker:collect:ci": "flaker collect ci --days 7",
-    "flaker:collect:local": "flaker collect local --last 1",
-    "flaker:eval:markdown": "flaker analyze eval --markdown --window 7",
-    "flaker:doctor": "flaker debug doctor"
+    "flaker:eval": "flaker status --markdown",
+    "flaker:doctor": "flaker doctor"
   }
 }
 ```
 
-`pnpm flaker:run:iteration` を pre-push hook や lefthook / husky と組み合わせると、push 前に自動で affected テストだけ流せる。
+`pnpm flaker:run:iteration` を pre-push hook や lefthook / husky と組み合わせると、push 前に自動で affected テストだけ流せる。`pnpm flaker:apply` は毎朝の cron / launchd 向け。
 
 ---
 
@@ -207,10 +207,10 @@ pnpm flaker analyze kpi
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-- name: Post sampling KPI as PR comment
+- name: Post status as PR comment
   if: github.event_name == 'pull_request'
   run: |
-    pnpm flaker analyze kpi > .artifacts/kpi.md
+    pnpm flaker status --markdown > .artifacts/status.md
     pnpm flaker report summary --adapter vitest --input report.json --pr-comment \
       | gh pr comment ${{ github.event.pull_request.number }} --body-file -
   env:
@@ -229,7 +229,7 @@ on:
   schedule: [{ cron: "0 18 * * *" }]    # JST 03:00
   workflow_dispatch:
 jobs:
-  collect:
+  apply:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -237,18 +237,17 @@ jobs:
       - uses: actions/setup-node@v4
         with: { node-version: 24 }
       - run: pnpm install --frozen-lockfile
-      - run: pnpm flaker collect ci --days 1
+      - run: pnpm flaker apply
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: pnpm flaker run --gate release
-      - run: pnpm flaker analyze eval --markdown --window 7 --output .artifacts/flaker-review.md
+      - run: pnpm flaker status --markdown > .artifacts/flaker-status.md
       - uses: actions/upload-artifact@v6
         with:
           name: flaker-nightly
           path: .artifacts/
 ```
 
-毎晩 1 日分の CI 履歴を取り込み、release gate (= scheduled profile / full run) を回し、週次サマリを作る。
+毎晩 `flaker apply` で現状を収束させ、`flaker status --markdown` で週次レビュー用の artifact を残す。
 
 ---
 
@@ -257,9 +256,9 @@ jobs:
 毎朝 5 分:
 
 ```bash
-pnpm flaker analyze kpi      # 1 画面で全体把握
-pnpm flaker analyze flaky    # 上位の flaky テスト
-pnpm flaker analyze insights # CI vs local 差分
+pnpm flaker status              # 1 画面で全体把握
+pnpm flaker status --list flaky # 上位の flaky テスト
+pnpm flaker explain insights    # CI vs local 差分などの AI 分析
 ```
 
 何か気になったら:
@@ -279,7 +278,7 @@ pnpm flaker debug bisect --test "tests/api.test.ts:handles timeout"
 
 ## Week 2-4: required check に昇格する条件
 
-`pnpm flaker analyze kpi` の `Sampling Effectiveness` セクションが以下を満たしたら CI gating に切り替えて OK:
+`pnpm flaker status` の drift セクションが `ready` を示したら CI gating に切り替えて OK。より詳細な actual 値を確認したいときは `pnpm flaker status --gate merge --detail`。到達目安は以下:
 
 | Metric | 目標 |
 |---|---|
@@ -295,10 +294,10 @@ pnpm flaker debug bisect --test "tests/api.test.ts:handles timeout"
 
 ### 自動キャリブレーション再実行
 
-データが増えたら再キャリブレーション:
+`flaker apply` を回し続ける限り、データが増えれば自動で再キャリブレーションされる。明示的に状態を確認したい場合:
 
 ```bash
-pnpm flaker collect calibrate
+pnpm flaker apply
 git diff flaker.toml   # 推奨値の変化を確認
 ```
 
@@ -312,8 +311,8 @@ git diff flaker.toml   # 推奨値の変化を確認
 | `Config file not found` | プロジェクトルートで実行されていない。`cd` して `pnpm flaker init` から |
 | `actrun runner requires [runner.actrun] workflow` | `[runner.actrun]` を `flaker.toml` に追加 |
 | `hybrid` で 0 件しか選ばれない | resolver 未設定。`[affected].resolver` を埋める |
-| `collect ci` が 0 runs | GITHUB_TOKEN 不足 or actions:read 権限不足。`gh auth refresh -s actions:read` |
-| `analyze kpi` が `insufficient data` | コミット数 < 5。さらに collect する。1 週間運用すれば自然に解消 |
+| `flaker apply` が 0 runs しか取れない | GITHUB_TOKEN 不足 or actions:read 権限不足。`gh auth refresh -s actions:read` |
+| `flaker status` が `data confidence: insufficient` | コミット数 < 5。`flaker apply` を回し続ければ自然に解消 (1 週間目安) |
 | 並列テストが timeout | DuckDB の単一書き手制約。同じ `.flaker/data.duckdb` を使う複数プロセスを直列化 |
 | `dist/moonbit/flaker.js` が無い | `pnpm install` 後に flaker パッケージ内で `pnpm build` 済みのものが配られているはず。npm install 直後は問題なし |
 
@@ -322,10 +321,10 @@ git diff flaker.toml   # 推奨値の変化を確認
 ## 1 ヶ月後の理想形
 
 - `flaker run --gate merge` が PR の required check
-- nightly が毎晩 history を更新
-- 週次レポート (`analyze eval --markdown`) が自動生成され Slack/issue に流れる
+- nightly で `flaker apply` が毎晩 history を更新
+- 週次レポート (`flaker status --markdown`) が自動生成され Slack/issue に流れる
 - 開発者は手元で `pnpm flaker:run:iteration` だけで affected テストを回す
-- flaky テストは `policy quarantine --auto --create-issues` で自動隔離 + Issue 化
+- flaky テストは `[quarantine].auto=true` + `flaker apply` の自動隔離で吸収される
 
 ここまで来れば、CI 時間を 30〜70% 削減しつつ、見逃しは 5% 未満に保てる。
 
@@ -337,5 +336,6 @@ git diff flaker.toml   # 推奨値の変化を確認
 - [docs/usage-guide.ja.md](usage-guide.ja.md) — 利用側の入口
 - [docs/operations-guide.ja.md](operations-guide.ja.md) — 運用側の入口
 - [docs/how-to-use.ja.md](how-to-use.ja.md) — コマンドと設定の詳細
+- [docs/migration-0.6-to-0.7.md](migration-0.6-to-0.7.md) — 0.6.x からの移行ガイド
 - [docs/contributing.md](contributing.md) — 開発・dogfood
 - [CHANGELOG.md](../CHANGELOG.md) — バージョン履歴と breaking changes

--- a/docs/new-project-checklist.md
+++ b/docs/new-project-checklist.md
@@ -2,9 +2,9 @@
 
 [日本語版](new-project-checklist.ja.md)
 
-The checklist for introducing flaker to a new repository and getting value from it across the first day, first week, and first month. Assumes `0.3.0+`.
+The checklist for introducing flaker to a new repository and getting value from it across the first day, first week, and first month. Assumes `0.7.0+`.
 
-If you follow it in order, initial setup takes about 30 minutes, your measurement baseline is in place within a week, and the repository is ready to promote CI gating in 2-4 weeks.
+Day 1 converges in five steps: `init -> doctor -> plan -> apply -> status`. If you follow it in order, initial setup takes about 30 minutes, your measurement baseline is in place within a week, and the repository is ready to promote CI gating in 2-4 weeks.
 
 ---
 
@@ -14,16 +14,18 @@ If you follow it in order, initial setup takes about 30 minutes, your measuremen
 node --version    # >= 24
 pnpm --version    # >= 10
 git remote -v     # origin should point at GitHub
-gh auth status    # logged in (needed for collect ci)
+gh auth status    # logged in (needed for flaker apply when pulling CI history)
 ```
 
-If the repository does not use GitHub Actions yet or has no history, skip `collect ci` on Day 1 and use a “local first -> collect later” flow.
+Repositories with no GitHub Actions history are still fine. `flaker apply` detects an empty history and picks the cold-start path (self-seed from a local run). Real CI history accumulates naturally after Day 1.
 
 You do not need `moon` (MoonBit). flaker ships a bundled `dist/moonbit/flaker.js`, and falls back to TypeScript (`src/cli/core/loader.ts`) when needed.
 
 ---
 
-## Day 1: Install and initialize (15 minutes)
+## Day 1: Install through convergence (15 minutes)
+
+Day 1 is a single five-step flow. `flaker apply` handles collect / calibrate / quarantine sequencing internally, so you do not have to memorize the order.
 
 ### 1. Install
 
@@ -51,6 +53,8 @@ pnpm flaker init --adapter playwright --runner actrun
 
 `owner` and `name` are auto-detected from the git remote. Override with `--owner` / `--name` if needed.
 
+As of 0.7.0, `flaker init` also writes default `[profile.scheduled]` / `[profile.ci]` / `[profile.local]` blocks so that gates resolve immediately.
+
 ### 3. Check the environment with doctor
 
 ```bash
@@ -61,7 +65,7 @@ Expected output looks like:
 
 ```text
 OK  config    flaker.toml is readable
-OK  config rangesall values within expected ranges
+OK  config ranges all values within expected ranges
 OK  duckdb    DuckDB initialized successfully
 OK  moonbit   MoonBit JS build detected (or fallback)
 
@@ -93,37 +97,56 @@ config = ""
 
 If you do not configure a resolver, `hybrid` still works through `weighted` / `random` fallback, but you lose the best change-aware behavior. Start with `workspace` if possible.
 
-### 5. Dry-run locally
+### 5. Preview with `flaker plan`
 
 ```bash
-git diff --name-only main | tr '\n' ',' > /tmp/changed.txt
-pnpm flaker run --gate iteration --dry-run --explain --changed "$(cat /tmp/changed.txt)"
+export GITHUB_TOKEN=$(gh auth token)
+pnpm flaker plan
 ```
 
-If `Selected tests:` shows a count, the pipeline is working. If the `Sampling Summary` is empty, that usually means either there are no matching tests yet or the resolver config does not match the project layout.
+`flaker plan` reads `flaker.toml` as desired state and reports what the DB is currently missing. An empty-history repository usually plans `collect_ci` + `cold_start_run`; if `[quarantine].auto = true`, a `quarantine_apply` action shows up too.
+
+### 6. Converge with `flaker apply`
+
+```bash
+pnpm flaker apply
+```
+
+`flaker apply` is idempotent and runs `collect` / `calibrate` / `quarantine apply` on demand based on current state. It is safe to re-run from cron or nightly — repeated executions do not break anything.
+
+### 7. Inspect with `flaker status`
+
+```bash
+pnpm flaker status
+```
+
+A one-screen summary dashboard. On Day 1 you usually see `data confidence: insufficient`, which is expected. After a week of `flaker apply`, it lifts to `moderate` naturally.
 
 ---
 
-## Day 2-3: Build the first dataset (30 minutes)
+## Day 2-3: Keep applying
 
-### 1. Collect CI history if it exists
+Because `flaker apply` is idempotent, "run it once a day" is the whole Day 2 story. You do not have to call `collect` or `calibrate` manually.
+
+```bash
+export GITHUB_TOKEN=$(gh auth token)
+pnpm flaker apply
+pnpm flaker status                 # daily dashboard
+pnpm flaker status --detail        # KPI view (formerly analyze kpi)
+```
+
+<details><summary>Drilling down into the individual steps</summary>
+
+`flaker apply` internally invokes the commands below on demand. They remain callable directly if you want to inspect one stage in isolation, but in 0.7.0+ all of them are deprecated or hidden — `flaker apply` is canonical.
+
+**Collect CI history:**
 
 ```bash
 export GITHUB_TOKEN=$(gh auth token)
 pnpm flaker collect ci --days 30
 ```
 
-Expected output looks like:
-
-```text
-Exported to Parquet: 12 test results, 4 commit changes
-...
-Collected N runs, N*X test results, ...
-```
-
-It is fine if some failed runs are skipped. `pending artifact runs` usually just means retention timing; rerun later.
-
-### 2. Calibrate
+**Calibrate:**
 
 ```bash
 pnpm flaker collect calibrate
@@ -131,35 +154,32 @@ pnpm flaker collect calibrate
 
 This writes the recommended strategy and sampling percentage into `[sampling]` in `flaker.toml`. Add `--dry-run` if you want to preview without writing.
 
-If data is still thin (`commits < 20`), you may get `confidence: insufficient` or `low`. That is acceptable at this stage; recalibrate again after a week.
+If data is still thin (`commits < 20`), you may get `confidence: insufficient` or `low`. That is acceptable at this stage; `flaker apply` will recalibrate itself as history grows over the next week.
 
-### 3. Check the KPI dashboard
-
-```bash
-pnpm flaker analyze kpi
-```
-
-At first, `Sampling Effectiveness` may be mostly empty (`matched commits = 0`). By the end of Week 1, local/CI correlation starts to become meaningful.
+</details>
 
 ---
 
 ## Day 3: Add package.json scripts
 
+Apply-first script layout for 0.7.0+:
+
 ```jsonc
 {
   "scripts": {
     "flaker": "flaker",
+    "flaker:plan": "flaker plan",
+    "flaker:apply": "flaker apply",
+    "flaker:status": "flaker status",
     "flaker:run:iteration": "flaker run --gate iteration",
     "flaker:run:release": "flaker run --gate release",
-    "flaker:collect:ci": "flaker collect ci --days 7",
-    "flaker:collect:local": "flaker collect local --last 1",
-    "flaker:eval:markdown": "flaker analyze eval --markdown --window 7",
+    "flaker:eval": "flaker status --markdown",
     "flaker:doctor": "flaker doctor"
   }
 }
 ```
 
-`pnpm flaker:run:iteration` works well from a pre-push hook via lefthook or husky.
+`pnpm flaker:run:iteration` works well from a pre-push hook via lefthook or husky. `pnpm flaker:apply` is a good target for a daily cron / launchd job.
 
 ---
 
@@ -187,10 +207,10 @@ Add this to `.github/workflows/ci.yml`:
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-- name: Post sampling KPI as PR comment
+- name: Post status as PR comment
   if: github.event_name == 'pull_request'
   run: |
-    pnpm flaker analyze kpi > .artifacts/kpi.md
+    pnpm flaker status --markdown > .artifacts/status.md
     pnpm flaker report summary --adapter vitest --input report.json --pr-comment \
       | gh pr comment ${{ github.event.pull_request.number }} --body-file -
   env:
@@ -209,7 +229,7 @@ on:
   schedule: [{ cron: "0 18 * * *" }]
   workflow_dispatch:
 jobs:
-  collect:
+  apply:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -217,18 +237,17 @@ jobs:
       - uses: actions/setup-node@v4
         with: { node-version: 24 }
       - run: pnpm install --frozen-lockfile
-      - run: pnpm flaker collect ci --days 1
+      - run: pnpm flaker apply
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: pnpm flaker run --gate release
-      - run: pnpm flaker analyze eval --markdown --window 7 --output .artifacts/flaker-review.md
+      - run: pnpm flaker status --markdown > .artifacts/flaker-status.md
       - uses: actions/upload-artifact@v6
         with:
           name: flaker-nightly
           path: .artifacts/
 ```
 
-This collects one day of CI history, runs the release gate, and writes weekly review material.
+Every night, `flaker apply` converges state and `flaker status --markdown` emits a weekly review artifact.
 
 ---
 
@@ -237,9 +256,9 @@ This collects one day of CI history, runs the release gate, and writes weekly re
 Spend five minutes each morning on:
 
 ```bash
-pnpm flaker analyze kpi
-pnpm flaker analyze flaky
-pnpm flaker analyze insights
+pnpm flaker status                 # one-screen summary
+pnpm flaker status --list flaky    # top flaky tests
+pnpm flaker explain insights       # AI commentary on CI vs local drift
 ```
 
 When something looks suspicious:
@@ -259,15 +278,15 @@ pnpm flaker debug bisect --test "tests/api.test.ts:handles timeout"
 
 ## Week 2-4: When to promote to required
 
-Switch the merge gate from advisory to required only after `pnpm flaker analyze kpi` shows at least:
+Switch the merge gate from advisory to required when `pnpm flaker status` shows `ready` in its drift section. If you want the detailed actual values, use `pnpm flaker status --gate merge --detail`. The rough targets:
 
 | Metric | Target |
 |---|---|
-| Matched commits | ≥ 20 |
-| Recall (CI failures caught) | ≥ 90% |
-| False negative rate | ≤ 5% |
-| Pass correlation | ≥ 95% |
-| Holdout FNR (if enabled) | ≤ 10% |
+| Matched commits | >= 20 |
+| Recall (CI failures caught) | >= 90% |
+| False negative rate | <= 5% |
+| Pass correlation | >= 95% |
+| Holdout FNR (if enabled) | <= 10% |
 | Co-failure data | `ready` |
 | Data confidence | `moderate` or `high` |
 
@@ -275,8 +294,10 @@ At that point, remove `continue-on-error: true` from the CI job.
 
 ### Re-run calibration as data grows
 
+As long as you run `flaker apply` regularly, calibration re-runs itself when the data warrants it. If you want to confirm explicitly:
+
 ```bash
-pnpm flaker collect calibrate
+pnpm flaker apply
 git diff flaker.toml
 ```
 
@@ -290,8 +311,8 @@ git diff flaker.toml
 | `Config file not found` | You are not at the project root. `cd` there and start with `pnpm flaker init`. |
 | `actrun runner requires [runner.actrun] workflow` | Add `[runner.actrun]` to `flaker.toml`. |
 | `hybrid` selects 0 tests | Resolver not configured. Fill in `[affected].resolver`. |
-| `collect ci` returns 0 runs | Missing or under-scoped `GITHUB_TOKEN`, often without `actions:read`. |
-| `analyze kpi` shows `insufficient data` | Fewer than 5 commits. Keep collecting for about a week. |
+| `flaker apply` returns 0 runs | Missing or under-scoped `GITHUB_TOKEN`, often without `actions:read`. |
+| `flaker status` shows `data confidence: insufficient` | Fewer than 5 commits of history. Keep running `flaker apply`; usually resolves within a week. |
 | Parallel tests time out | DuckDB is single-writer. Serialize processes using the same `.flaker/data.duckdb`. |
 | `dist/moonbit/flaker.js` is missing | It should already be bundled by the npm package. If not, inspect the package build. |
 
@@ -300,10 +321,10 @@ git diff flaker.toml
 ## The ideal shape after one month
 
 - `flaker run --gate merge` is a required PR check
-- nightly keeps history fresh every day
-- weekly reports (`analyze eval --markdown`) are posted to Slack or issues
+- nightly `flaker apply` keeps history fresh every day
+- weekly reports (`flaker status --markdown`) are posted to Slack or issues
 - developers use `pnpm flaker:run:iteration` locally
-- flaky tests are quarantined and tracked with `policy quarantine --auto --create-issues`
+- flaky tests are auto-quarantined via `[quarantine].auto = true` + `flaker apply`
 
 At that point, many repositories can cut CI time by 30-70% while keeping missed failures under 5%.
 
@@ -315,5 +336,6 @@ At that point, many repositories can cut CI time by 30-70% while keeping missed 
 - [usage-guide.md](usage-guide.md) — user-facing entrypoint
 - [operations-guide.md](operations-guide.md) — operator-facing entrypoint
 - [how-to-use.md](how-to-use.md) — detailed commands and configuration
+- [migration-0.6-to-0.7.md](migration-0.6-to-0.7.md) — upgrading from 0.6.x
 - [contributing.md](contributing.md) — development and dogfood workflow
 - [CHANGELOG.md](../CHANGELOG.md) — release history and breaking changes

--- a/docs/operations-guide.ja.md
+++ b/docs/operations-guide.ja.md
@@ -44,9 +44,9 @@
 
 ### Observation loop
 
-- `flaker collect`
-- `flaker ops daily`
+- `flaker apply` (history collect + calibrate を内包)
 - `flaker status`
+- `flaker ops daily` (release gate の日次 snapshot が必要なとき)
 
 役割:
 
@@ -56,10 +56,9 @@
 
 ### Triage loop
 
-- `flaker gate review merge`
+- `flaker status --gate merge --detail` (primary signal; drift を読む)
 - `flaker ops weekly`
-- `flaker quarantine suggest`
-- `flaker quarantine apply`
+- `flaker apply` (`[quarantine].auto=true` なら suggest + apply を内包)
 - 週次の promote / keep / demote review
 
 役割:
@@ -87,17 +86,17 @@
 mkdir -p .artifacts
 export GITHUB_TOKEN=$(gh auth token)
 pnpm flaker apply
-pnpm flaker ops daily --output .artifacts/flaker-daily.md
-pnpm flaker quarantine suggest --json --output .artifacts/quarantine-plan.json
+pnpm flaker status
 ```
 
-`flaker apply` は `flaker.toml` を desired state として現状を収束させる idempotent コマンド。従来の `collect` / `calibrate` / `quarantine apply` を順に手で呼ぶ必要はない。詳細な dry-run が欲しいときは `flaker plan`。
+`flaker apply` が `flaker.toml` を desired state として現状を収束させ (collect / calibrate / quarantine apply を idempotent に内包)、`flaker status` で drift と health を 1 画面で確認する。何が走るか事前に見たい場合は `flaker plan`。
 
 ### 毎週
 
 ```bash
 mkdir -p .artifacts
-pnpm flaker gate review merge --json --output .artifacts/gate-review-merge.json
+pnpm flaker status --markdown > .artifacts/flaker-status.md
+pnpm flaker status --gate merge --detail --json > .artifacts/merge-gate.json
 pnpm flaker ops weekly --output .artifacts/flaker-weekly.md
 ```
 
@@ -106,11 +105,11 @@ pnpm flaker ops weekly --output .artifacts/flaker-weekly.md
 - `matched commits`
 - `false negative rate`
 - `pass correlation`
-- `sample ratio`
-- `saved test minutes`
+- `holdout FNR`
+- `data confidence`
 - `flaky` / `quarantined` test 数
 
-`status` は summary-only なので、昇格判断は `gate review merge` を使う。
+primary signal は `flaker status` の drift セクション (`ready` / `not ready`)。詳細数値が必要なら `flaker status --gate merge --detail --json` を authoritative metric として使う。従来の `flaker gate review merge --json` は 0.7.0 で deprecated (0.8.0 で削除予定)、同じ情報が `--gate merge --detail --json` で取れる。
 
 ### 失敗時
 

--- a/docs/superpowers/plans/2026-04-19-phase2-skill-docs-migration.md
+++ b/docs/superpowers/plans/2026-04-19-phase2-skill-docs-migration.md
@@ -1,0 +1,234 @@
+# 0.7.0 Phase 2 — Skill, Docs, Migration Guide + Minor E2E Fixes
+
+> **For agentic workers:** Use superpowers:subagent-driven-development.
+
+**Goal:** Bring the skills, docs, and release tooling in line with the 10-command primary surface shipped by Phase 1, and close the small E2E findings (`--version` duplicate, missing `[profile.*]` on init, silent `apply` on empty repos). This ships as 0.7.0 proper (not -next).
+
+**Architecture:** Docs + skills are prose rewrites targeting the new canonical forms. Minor fixes are small TDD tasks. `ops daily` is **kept as Advanced** (no longer deprecated) because the Phase 1 deprecation was aspirational — apply does not emit the daily artifact today, and building that feature doesn't belong in Phase 2.
+
+**Tech Stack:** Markdown, TypeScript, Commander, Vitest.
+
+---
+
+## Scope & non-goals
+
+**In scope:**
+- Rewrite `skills/flaker-setup/SKILL.md` — Day 1 flow uses only primary commands
+- Rewrite `skills/flaker-management/SKILL.md` — daily loop is `apply` + `status`, no direct `analyze kpi` / `ops daily` references
+- Update `docs/new-project-checklist.ja.md` / `docs/new-project-checklist.md` to reflect the 10-command surface
+- Update `docs/operations-guide.ja.md` / `docs/operations-guide.md` to the new status/apply loop
+- Update `docs/how-to-use.ja.md` / `docs/how-to-use.md` — remove deprecated-command-first examples; keep the reference table but mark deprecated rows
+- Update `README.md` Quick Start / canonical-forms table to match the final 10 primary
+- Write `docs/migration-0.6-to-0.7.md` — matrix of old→new commands, skill-to-version pinning, upgrade steps
+- **Revert `ops daily` deprecation** — restore it as Advanced (no warning) since apply does not yet emit the daily artifact
+- Fix `--version` duplicate output
+- Make `flaker init` write `[profile.*]` default sections into `flaker.toml`
+- Add a hint line when `flaker apply` finishes with 0 actions or an empty cold-start run
+- Empirical re-evaluation with subagents on the rewritten skills and docs (A/B/C scenarios + the CLI surface invariant)
+
+**Out of scope (separate plans):**
+- `flaker apply --output daily|weekly|incident` artifact emission (0.8 feature)
+- Full removal of deprecated commands (0.8.0)
+- `storage.path` rename / schema migration (ecosystem coordination)
+- `DeprecationWarning: url.parse()` suppression (dependency upgrade)
+- VRT / Playwright-specific onboarding refresh
+
+---
+
+## File structure
+
+**Create:**
+- `docs/migration-0.6-to-0.7.md` — migration matrix + step-by-step upgrade
+
+**Modify:**
+- `skills/flaker-setup/SKILL.md`
+- `skills/flaker-management/SKILL.md`
+- `docs/new-project-checklist.ja.md`, `docs/new-project-checklist.md`
+- `docs/operations-guide.ja.md`, `docs/operations-guide.md`
+- `docs/how-to-use.ja.md`, `docs/how-to-use.md`
+- `README.md`
+- `src/cli/categories/ops.ts` (revert `ops daily` deprecation)
+- `src/cli/main.ts` (fix `--version` duplicate)
+- `src/cli/setup/init.ts` or equivalent (add `[profile.*]` defaults on init)
+- `src/cli/categories/apply.ts` (add "no-op" / "empty cold start" hint)
+- `CHANGELOG.md`, `package.json` (bump to `0.7.0`)
+
+---
+
+## Task breakdown
+
+### Task 1: Revert `ops daily` deprecation
+
+**Files:**
+- Modify: `src/cli/categories/ops.ts`
+- Test: `tests/cli/ops-daily-not-deprecated.test.ts` (create)
+
+- [ ] Write failing test: `flaker ops daily --help` does NOT emit a deprecation warning on stderr.
+- [ ] Remove the `deprecate()` call attached to the `ops daily` registration (added in Phase 1 Task 10).
+- [ ] Update `tests/cli/deprecation-blanket.test.ts` to remove the `ops daily` row.
+- [ ] Update `src/cli/main.ts` help block: move `ops daily` out of Deprecated, into Advanced alongside `ops weekly` / `ops incident`.
+- [ ] Commit: `fix(cli): restore ops daily as Advanced (apply does not emit daily artifact yet)`.
+
+### Task 2: Fix `--version` duplicate output
+
+**Files:**
+- Modify: `src/cli/main.ts`
+- Test: `tests/cli/version.test.ts` (extend)
+
+- [ ] Write failing assertion: `flaker --version` stdout has exactly one line matching `/^\d+\.\d+\.\d+/`.
+- [ ] Root cause: investigate `program.version()` vs a separate `flaker core CLI` banner printed before it. Locate the banner source (likely in the moonbit bridge or a build-time insertion) and suppress it from `--version` mode. Keep any banner out of `--version` but do not silently hide it elsewhere unless it is vestigial.
+- [ ] Commit: `fix(cli): emit a single line from --version`.
+
+### Task 3: `flaker init` generates `[profile.*]` defaults
+
+**Files:**
+- Modify: `src/cli/setup/init.ts` (or equivalent — find via `grep -rl "Initialized flaker.toml" src/cli`)
+- Test: `tests/cli/init-profile-defaults.test.ts` (create)
+
+- [ ] Failing test: after `flaker init --adapter playwright --runner playwright`, the generated `flaker.toml` contains `[profile.local]`, `[profile.ci]`, `[profile.scheduled]` with sensible defaults (local=affected, ci=hybrid 30%, scheduled=full).
+- [ ] Implement: append the three profile blocks after the existing sections during init. Mirror the example from `skills/flaker-setup/SKILL.md` (the block was already documented as canonical).
+- [ ] Commit: `feat(init): write [profile.*] default sections for local/ci/scheduled`.
+
+### Task 4: `flaker apply` hints on empty cold-start / zero actions
+
+**Files:**
+- Modify: `src/cli/categories/apply.ts`
+- Test: `tests/cli/apply-empty-hint.test.ts` (create)
+
+- [ ] Failing test A: when `planApply()` returns `[]`, the CLI prints `"No actions needed. Current state matches flaker.toml."` (already exists) AND appends a follow-up hint pointing to `flaker status` for current health. Assert both lines.
+- [ ] Failing test B: when `cold_start_run` executes with 0 selected tests, the text output includes `"hint: 0 tests discovered — check [runner].command and [affected].resolver"`.
+- [ ] Implement: in `applyAction`, inspect `executed` for `cold_start_run` results and check the `sampledCount` field (from `executePreparedLocalRun`'s return). If zero, print the hint line on stderr. JSON mode remains unchanged.
+- [ ] Commit: `feat(apply): add actionable hints for empty cold-start and no-op runs`.
+
+### Task 5: Rewrite `skills/flaker-setup/SKILL.md`
+
+**Files:**
+- Modify: `skills/flaker-setup/SKILL.md`
+
+- [ ] Replace every deprecated command reference with the 0.7.0 canonical form. Use this mapping:
+  | Old | New |
+  |---|---|
+  | `flaker collect ci` / `flaker collect calibrate` | `flaker apply` (in Day 2-3 flow) |
+  | `flaker quarantine suggest/apply` | `flaker apply` |
+  | `flaker analyze kpi` | `flaker status` |
+  | `flaker analyze eval --markdown` | `flaker status --markdown` |
+  | `flaker analyze flaky` | `flaker status --list flaky` |
+  | `flaker debug doctor` (in scripts) | `flaker doctor` |
+  | `flaker exec run` / `flaker exec affected` | `flaker run --gate iteration --changed ...` |
+- [ ] Update the `Phase order` table: Day 2-3 becomes just `flaker apply`. Day 5 uses `flaker apply` in cron, not `collect ci` + `run --gate release`.
+- [ ] Update package.json scripts block: replace `flaker:collect:ci` / `flaker:collect:local` etc. with `flaker:plan`, `flaker:apply`, `flaker:status` (apply-first).
+- [ ] Update the Minimal `flaker.toml` example to include `[promotion]` override commented out (matches Task 3's init output).
+- [ ] Commit: `docs(skills): rewrite flaker-setup around the 10-command surface`.
+
+### Task 6: Rewrite `skills/flaker-management/SKILL.md`
+
+**Files:**
+- Modify: `skills/flaker-management/SKILL.md`
+
+- [ ] Replace `flaker commands to prefer` block with apply-first recipes:
+  ```bash
+  # Daily
+  flaker apply
+  flaker status
+  # Weekly
+  flaker status --markdown > .artifacts/status-weekly.md
+  flaker ops weekly --output .artifacts/flaker-weekly.md
+  # Promotion snapshot
+  flaker status --gate merge --detail --json
+  # Incident
+  flaker debug retry
+  flaker debug confirm "<suite>:<test>" --repeat 10
+  ```
+- [ ] Update the "What to inspect first" list: replace `flaker analyze kpi` with `flaker status` and `flaker analyze eval --markdown` with `flaker status --markdown`.
+- [ ] Update the Promotion / demotion decision rule to show `flaker status --gate merge --detail` is the primary readout; `flaker gate review merge --json` stays as the authoritative metric dump (Advanced).
+- [ ] Update the Guardrails bullet about deprecated aliases to reflect the 0.7.0 list, not the 0.6.0 list.
+- [ ] Commit: `docs(skills): rewrite flaker-management around apply + status`.
+
+### Task 7: Update `docs/new-project-checklist.*.md`
+
+**Files:**
+- Modify: `docs/new-project-checklist.ja.md`, `docs/new-project-checklist.md`
+
+- [ ] Day 1: `install → init → doctor → plan → apply → status`. No `flaker run --dry-run --explain` unless necessary (keep as a diagnostic aside).
+- [ ] Day 2-3: collapse the existing "manual individual commands" `<details>` block — the apply flow is now the only recommended path. Keep the old individual commands only in `docs/migration-0.6-to-0.7.md`, not in the onboarding checklist.
+- [ ] Day 3 scripts block: use the 0.7.0 script names from Task 5.
+- [ ] Day 5 Actions integration: `flaker apply` in PR advisory + nightly; no separate `collect ci` step.
+- [ ] Week 2-4: reference `flaker status` drift `ok: true` as the promotion-ready signal.
+- [ ] Commit: `docs(checklist): unify on apply+status flow, retire individual-command sidebar`.
+
+### Task 8: Update `docs/operations-guide.*.md` + `docs/how-to-use.*.md` + `README.md`
+
+**Files:**
+- Modify: `docs/operations-guide.ja.md`, `docs/operations-guide.md`, `docs/how-to-use.ja.md`, `docs/how-to-use.md`, `README.md`
+
+- [ ] operations-guide: daily cadence → `flaker apply` + `flaker status` (one pnpm line each). Weekly → `flaker status --markdown` + `flaker ops weekly` + `flaker status --gate merge --detail`. Incident → `flaker debug retry` / `confirm` / `diagnose`.
+- [ ] how-to-use: keep the command reference table but tag deprecated rows with "DEPRECATED — see migration-0.6-to-0.7.md". The reference value is real; don't delete it.
+- [ ] README: rewrite Quick Start to land on `flaker apply` / `flaker plan` / `flaker status` only. Remove Path 1 / Path 2 split — apply handles the branching internally. Update the canonical-forms table to match the Phase 1 plan's final list.
+- [ ] Commit: `docs: unify operations-guide, how-to-use, and README around the 10-command surface`.
+
+### Task 9: Write `docs/migration-0.6-to-0.7.md`
+
+**Files:**
+- Create: `docs/migration-0.6-to-0.7.md`
+
+- [ ] Structure:
+  1. Summary (why: surface reduction 53 → 10; aspirational target: AI + human callers collapse onto the same 10 verbs)
+  2. New commands: `flaker plan`, `flaker apply`, `flaker status` flags, `flaker query`, `flaker explain <topic>`, `flaker import <file>`, `flaker report <file> --<mode>`
+  3. Deprecation matrix (table with old command → canonical + when deprecated + when removed)
+  4. Upgrade steps (for a user on 0.5.x / 0.6.x):
+     - `pnpm up @mizchi/flaker@0.7`
+     - Run `pnpm flaker status` once — expect drift summary
+     - Replace `flaker collect ci && flaker collect calibrate` in scripts with `flaker apply`
+     - Replace `flaker analyze kpi` in scripts with `flaker status`
+     - Grep CI workflows for `flaker doctor`, `flaker kpi`, `flaker exec *`, `flaker setup init` and update
+     - Regenerate package.json scripts from `skills/flaker-setup/SKILL.md`
+  5. Breaking-change timeline: 0.7.0 deprecates, 0.8.0 removes
+- [ ] Commit: `docs: add migration-0.6-to-0.7.md`.
+
+### Task 10: Bump to 0.7.0 + CHANGELOG
+
+**Files:**
+- Modify: `package.json`, `src/cli/main.ts` (hardcoded version), `CHANGELOG.md`
+
+- [ ] `version`: `0.7.0-next.0` → `0.7.0`
+- [ ] CHANGELOG: move the `0.7.0-next.0 (prerelease)` section up and promote it to `## 0.7.0`, add Phase 2 fixes (ops daily un-deprecated, --version single line, init writes profiles, apply hints, skill+docs rewrites, migration guide).
+- [ ] Commit: `chore(release): 0.7.0`.
+
+### Task 11: Empirical re-evaluation with subagents
+
+**Files:**
+- (Evaluation only — no code changes)
+
+- [ ] Dispatch 3 subagents in parallel with the canonical A/B/C scenarios (Day 1 Playwright setup, 2-week promotion decision, CI failure retry/confirm). Each reads only the updated docs + skills.
+- [ ] Dispatch a 4th subagent for the CLI surface invariant: verify `flaker --help` still shows exactly the 11 primary entries (surface-reduction.test.ts will also catch this, but the subagent gets a human readability check).
+- [ ] Aggregate results into an Iter 6 table vs the Iter 5 baseline. Target: no regression on A/B/C accuracy, no new unclear-points above 2.
+- [ ] If regressions are found, fix them in a follow-up commit before merging the Phase 2 PR.
+
+---
+
+## Self-review
+
+### Spec coverage
+
+- Skill rewrites (Tasks 5, 6) cover both `flaker-setup` and `flaker-management`.
+- Doc rewrites (Tasks 7, 8) cover all 4 canonical language-separated documents (new-project-checklist, operations-guide, how-to-use, README) in both en and ja.
+- Migration guide (Task 9) consolidates the deprecation matrix for users.
+- Minor E2E fixes (Tasks 1, 2, 3, 4) address every non-blocker item from the Iter 5 / 0.7 Phase 1 E2E reports.
+- Release ritual (Task 10) ships as 0.7.0.
+- Empirical eval (Task 11) closes the loop.
+
+### Placeholders
+
+None. All tasks have concrete file paths, TDD scaffolds where applicable, and explicit commit messages.
+
+### Type consistency
+
+- Canonical replacements referenced in Tasks 5-9 match the Phase 1 plan's canonical-forms table verbatim.
+- Task 1 reverses one decision from Phase 1 (ops daily deprecation) — this is intentional and explained in the architecture note.
+- Task 3 writes `[profile.*]` sections matching the structure already validated in `config-migration.test.ts`.
+
+### Risk notes
+
+- **Task 1 revert** creates an asymmetry: Phase 1 announced ops daily deprecated; Phase 2 reverts. Acceptable because 0.7.0 is not yet GA and the Phase 1 PR landed on main but the npm tag is still -next. Migration guide (Task 9) should NOT list ops daily as deprecated.
+- **Task 3 init defaults** — if an existing repo has an `init`-generated flaker.toml without `[profile.*]`, a future `flaker apply` still works via config defaults. No migration needed.
+- **Task 11 eval subagents** — if scenarios B/C regress because skill rewrites removed too much detail, the Phase 2 PR must be amended before merge.

--- a/docs/usage-guide.ja.md
+++ b/docs/usage-guide.ja.md
@@ -26,7 +26,7 @@
 ## まず覚える 4 コマンド
 
 ```bash
-pnpm flaker doctor   # canonical: flaker debug doctor
+pnpm flaker doctor
 pnpm flaker run --gate iteration
 pnpm flaker run --dry-run --gate iteration --explain
 pnpm flaker status
@@ -34,7 +34,7 @@ pnpm flaker status
 
 意味:
 
-- `doctor`: 実行環境の確認 (`flaker doctor` は onboarding 用エイリアス。正式形は `flaker debug doctor`)
+- `doctor`: 実行環境の確認 (0.7.0 以降は `flaker doctor` が canonical。`flaker debug doctor` は legacy alias)
 - `run --gate iteration`: 普段のローカル実行
 - `run --dry-run --explain`: 何が選ばれたかを確認
 - `status`: 現在の健全性をざっと見る
@@ -56,7 +56,7 @@ pnpm flaker status
 ### 変更前に確認
 
 ```bash
-pnpm flaker debug doctor
+pnpm flaker doctor
 ```
 
 ### push 前に preview

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mizchi/flaker",
-  "version": "0.7.0-next.0",
+  "version": "0.7.0",
   "description": "Flaky test detection, sampling, and test runner orchestration",
   "type": "module",
   "bin": {

--- a/skills/flaker-management/SKILL.md
+++ b/skills/flaker-management/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: flaker-management
-description: Operate @mizchi/flaker after setup. Use when the user asks how to run flaker day-to-day, review sampling and flaky metrics, design advisory vs required CI gates, promote or demote Playwright E2E or VRT checks, tune PR time budgets, run nightly triage, or manage quarantine and `@flaky` tags in an OSS repository.
+description: Operate @mizchi/flaker after setup. Use when the user asks how to run flaker day-to-day, review sampling and flaky metrics, design advisory vs required CI gates, promote or demote Playwright E2E or VRT checks, tune PR time budgets, run nightly triage, or manage quarantine and `@flaky` tags in an OSS repository. Targets @mizchi/flaker 0.7.0+ (declarative apply model).
 ---
 
 # flaker management skill
@@ -28,14 +28,11 @@ If the repository does not have `flaker.toml` and no CI lane yet, use `flaker-se
 - `flaker.toml` is the **desired state** (gates, profiles, `[promotion]` thresholds, `[quarantine].auto`).
 - `flaker apply` is the **reconciler** — idempotent; safe to run hourly/daily/on-demand. It auto-runs `collect` / `calibrate` / `quarantine apply` as needed based on current DB state.
 - `flaker status` is the **drift detector** — reports which `[promotion]` thresholds are unmet, so promotion readiness is a boolean (`ready` / `not ready`), not a judgement call.
-- `flaker gate review merge --json` is the **authoritative metric source** when you need to inspect the exact numbers behind a drift item.
 
-Prefer this loop over hand-orchestrated commands:
+The canonical daily loop is:
 
 ```bash
-pnpm flaker apply          # converge to desired state
-pnpm flaker status         # read drift + health in one view
-# if drift points to a specific gap, drill down with gate review or ops weekly
+flaker apply && flaker status
 ```
 
 ## Read order
@@ -52,7 +49,7 @@ pnpm flaker status         # read drift + health in one view
 - `flaker.toml` — especially the `[promotion]` thresholds (defaults are documented; overriding signals intent)
 - current GitHub Actions topology: `pull_request`, `push`, `schedule`
 - latest `flaker status` output (drift + activity + health in one page)
-- `flaker gate review merge --json` when you need exact promotion metrics
+- `flaker status --gate merge --detail --json` when you need exact promotion metrics
 - `flaker ops weekly` for quarantine / flaky trend bundles
 - whether `@flaky` tagging or quarantine manifest is already in use
 - current PR runtime budget
@@ -65,7 +62,7 @@ When applying this skill, return:
 1. lane design: `learning` / `verdict` / `rebalance`
 2. promotion criteria (align with `[promotion]` in `flaker.toml`; override only with justification)
 3. demotion criteria
-4. review cadence: per-PR / daily / weekly (daily is usually just `flaker apply` + `flaker status`)
+4. review cadence: per-PR / daily / weekly (daily is usually just `flaker apply && flaker status`)
 5. exact `flaker` commands, config, and workflow snippets
 
 ## Guardrails
@@ -76,44 +73,34 @@ When applying this skill, return:
 - Keep a full scheduled lane even after PR gating starts.
 - For AI-generated code, require a short per-test contract so visual checks encode intent, not just pixels.
 - Do not promote `--gate merge` to required until `flaker status` drift reports `ready`.
-- Do not recommend `flaker kpi` or `flaker doctor` top-level aliases in new scripts — they print a deprecation warning and are removed in 0.7.0. Use `flaker analyze kpi` and `flaker debug doctor`.
+- Do not use deprecated aliases in new scripts — `analyze kpi`, `analyze eval`, `collect ci`, `debug doctor`, `quarantine suggest/apply`, `gate review/history/explain` all print deprecation warnings in 0.7.0 and will be removed in 0.8.0. Use the primary commands instead.
 
 ## flaker commands to prefer
 
-Daily loop (cron or local):
-
 ```bash
-flaker apply                           # idempotent; runs collect / calibrate / quarantine apply as needed
-flaker status                          # summary dashboard + [promotion] drift
-```
+# Daily
+flaker apply
+flaker status
 
-Weekly operator review:
-
-```bash
-flaker gate review merge --json --output .artifacts/gate-review-merge.json
+# Weekly operator review
+flaker status --markdown > .artifacts/status-weekly.md
 flaker ops weekly --output .artifacts/flaker-weekly.md
-flaker analyze eval --markdown --window 7 --output .artifacts/flaker-review.md
+flaker status --gate merge --detail --json > .artifacts/merge-gate.json
+
+# Promotion snapshot (authoritative metrics)
+flaker gate review merge --json > .artifacts/gate-review-merge.json  # DEPRECATED in 0.7.0; use status --gate merge --detail --json
+
+# Incident
+flaker debug retry
+flaker debug confirm "<suite>:<test>" --repeat 10
+flaker debug bisect --test "<name>"
 ```
 
-Flaky / quarantine triage:
-
-```bash
-flaker analyze flaky-tag --json        # ad-hoc @flaky tag suggestions (raw primitive)
-flaker quarantine suggest --json --output .artifacts/quarantine-plan.json
-flaker quarantine apply --from .artifacts/quarantine-plan.json --create-issues
-```
-
-Gate execution (unchanged from 0.5.x):
-
-```bash
-flaker run --gate iteration            # fast local feedback (aliased profile.local)
-flaker run --gate merge                # PR / mainline gate (aliased profile.ci)
-flaker run --gate release              # full or near-full (aliased profile.scheduled)
-```
+Note: `ops daily / weekly / incident` are still first-class primary commands — apply does NOT emit the daily artifact yet. Use them directly.
 
 ## Promotion / demotion decision rule
 
-Promote `--gate merge` advisory → required **iff** `flaker status` drift reports `ready` (all 5 `[promotion]` thresholds met):
+Promote `--gate merge` advisory → required **iff** `flaker status` drift reports `ready` (all 5 `[promotion]` thresholds met). Primary signal is `flaker status` — the drift section shows `ready` or lists unmet thresholds:
 
 - `matched_commits ≥ [promotion].matched_commits_min` (default 20)
 - `false_negative_rate ≤ [promotion].false_negative_rate_max_percentage` (default 5%)
@@ -130,6 +117,7 @@ Demote back to advisory when ANY of the following holds for 1+ week:
 
 ## Anti-patterns
 
-- Using raw `flaker collect ci` / `flaker collect calibrate` in daily cron when `flaker apply` already handles the ordering and idempotency.
-- Basing promotion on `flaker status` numbers alone when they look close — `flaker gate review merge --json` is the authoritative source for exact values.
+- Using raw `flaker collect ci` / `flaker collect calibrate` (deprecated in 0.7.0) in daily cron when `flaker apply` already handles the ordering and idempotency.
+- Using `flaker analyze kpi` (deprecated) instead of `flaker status`, or `flaker analyze eval --markdown` (deprecated) instead of `flaker status --markdown`.
+- Basing promotion on `flaker status` numbers alone when they look close — `flaker status --gate merge --detail --json` is the authoritative source for exact values (the deprecated `flaker gate review merge --json` form also still works with a stderr warning).
 - Ignoring `flaker status` drift `holdout_fnr` when `holdout_ratio = 0`; if holdout isn't configured, the threshold cannot be evaluated and drift treats it as unmet. Either configure `[sampling].holdout_ratio` or accept that holdout FNR will gate promotion.

--- a/skills/flaker-setup/SKILL.md
+++ b/skills/flaker-setup/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: flaker-setup
-description: Set up @mizchi/flaker on a new repository. Use when the user asks to introduce flaker, configure flaker.toml, integrate flaker into GitHub Actions, or "start using flaker on this project". Encodes the declarative apply-based onboarding flow (flaker apply as the single convergence command) with the right decision points and pitfalls.
+description: Set up @mizchi/flaker on a new repository. Use when the user asks to introduce flaker, configure flaker.toml, integrate flaker into GitHub Actions, or "start using flaker on this project". Encodes the declarative apply-based onboarding flow for @mizchi/flaker 0.7.0+ (declarative apply model).
 ---
 
 # flaker setup skill
 
-`@mizchi/flaker` (0.6.0+) is a test-intelligence CLI with a declarative apply model: `flaker.toml` describes the desired state, and `flaker apply` reconciles the repo to that state by running `collect` / `calibrate` / `cold-start run` / `quarantine apply` in the right order based on current DB state and repo probe. Callers do not memorize the sequence.
+`@mizchi/flaker` (0.7.0+) is a test-intelligence CLI with a declarative apply model: `flaker.toml` describes the desired state, and `flaker apply` reconciles the repo to that state by running `collect` / `calibrate` / `cold-start run` / `quarantine apply` in the right order based on current DB state and repo probe. Callers do not memorize the sequence.
 
 **Always read the canonical checklist first.** It lives next to this skill in the plugin:
 
@@ -29,7 +29,7 @@ If both are unreachable, fall back to the procedure below.
 3. `flaker apply` executes the plan (idempotent; safe to re-run).
 4. `flaker status` shows drift vs `[promotion]` thresholds.
 
-The old sequence (`init → collect → calibrate → run`) still works and is documented, but `apply` is the default entrypoint from 0.6.0 onward. Use raw commands only when debugging a specific step.
+The Day 1 flow is `flaker init → flaker doctor → flaker apply → flaker status`. The deprecated imperative chain (`init → collect → calibrate → run`) still works via compat shims but is a migration-only concern — do not use it in new projects.
 
 ### Minimal declarative `flaker.toml`
 
@@ -78,7 +78,7 @@ strategy = "full"
 # data_confidence_min = "high"
 ```
 
-`flaker init` generates a starter toml; expect to edit `[affected].resolver` and the `[profile.*]` blocks before the first `flaker apply`.
+`flaker init` generates a starter toml including `[profile.*]` defaults; expect to edit `[affected].resolver` before the first `flaker apply`.
 
 ## Decision points to confirm before touching files
 
@@ -95,11 +95,11 @@ Ask the user (or infer from `package.json` / `pnpm-workspace.yaml` / repo layout
 ```
 Day 0   prerequisites           5 min   node>=24, pnpm>=10, gh auth, git remote
 Day 1   install + init          10 min  pnpm add -D @mizchi/flaker → init → doctor
-Day 1   first apply              5 min   flaker plan → flaker apply (handles history/no-history)
-Day 3   package.json scripts     5 min   flaker:plan, flaker:apply, flaker:status
-Day 5   Actions integration     15 min  cron calls `flaker apply` + PR advisory job
-Week 1  daily observation        -      flaker status (drift section tells you when to promote)
-Week 2-4 promote to required     -      [promotion] thresholds all green, remove continue-on-error
+Day 1   first apply              5 min   flaker plan → flaker apply → flaker status
+Day 3   package.json scripts     5 min   flaker:plan, flaker:apply, flaker:status, flaker:run:*
+Day 5   Actions integration     15 min   cron `flaker apply` + PR advisory `flaker run --gate merge`
+Week 1  daily observation        -      flaker status (drift → promotion-ready signal)
+Week 2-4 promote to required     -      drift == ready, remove continue-on-error
 ```
 
 Day 2 and Day 4 are intentionally empty — apply is idempotent, so there is no forced action between the Day 1 bootstrap and the Day 3 / Day 5 integration steps. Run `flaker apply` whenever you want (manually or in cron); skip days if nothing changed.
@@ -115,22 +115,19 @@ node --version && pnpm --version && git remote -v && gh auth status
 # 1. install
 pnpm add -D @mizchi/flaker
 
-# 2. init (pick adapter/runner per the decision above)
+# 2. init (init now writes [profile.*] defaults)
 pnpm flaker init --adapter <adapter> --runner <runner>
 
-# 3. doctor (canonical: flaker debug doctor — 'flaker doctor' still works with a deprecation warning)
-pnpm flaker debug doctor
+# 3. doctor
+pnpm flaker doctor
 
-# 4. set resolver in flaker.toml — edit [affected] section manually
-#    workspace: resolver = "workspace"
-#    glob:      resolver = "glob",  config = "flaker.affected.toml"
-#    bitflow:   resolver = "bitflow"
+# 4. edit [affected].resolver in flaker.toml (workspace | glob | bitflow)
 
-# 5. preview and converge (single command replaces the old collect → calibrate → run chain)
-export GITHUB_TOKEN=$(gh auth token)   # only needed if the repo has CI history
-pnpm flaker plan                       # see what apply will do
-pnpm flaker apply                      # idempotent; re-run anytime
-pnpm flaker status                     # shows drift vs [promotion] thresholds
+# 5. preview + converge
+export GITHUB_TOKEN=$(gh auth token)   # optional if no CI history yet
+pnpm flaker plan
+pnpm flaker apply
+pnpm flaker status
 ```
 
 ## What `flaker apply` does
@@ -157,13 +154,11 @@ When actions don't apply (e.g. no `GITHUB_TOKEN` on a brand-new repo), apply sil
     "flaker:status": "flaker status",
     "flaker:run:iteration": "flaker run --gate iteration",
     "flaker:run:release": "flaker run --gate release",
-    "flaker:eval:markdown": "flaker analyze eval --markdown --window 7",
-    "flaker:doctor": "flaker debug doctor"
+    "flaker:eval": "flaker status --markdown",
+    "flaker:doctor": "flaker doctor"
   }
 }
 ```
-
-Note: `flaker kpi` and `flaker doctor` top-level aliases are DEPRECATED in 0.6.0 (still work, emit stderr warning; removed in 0.7.0). Use `flaker analyze kpi` and `flaker debug doctor`.
 
 ## GitHub Actions snippets
 
@@ -183,12 +178,12 @@ Nightly apply (single scheduled cron replaces the old collect + run pair):
 - run: pnpm flaker apply
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-- run: pnpm flaker analyze eval --markdown --window 7 --output .artifacts/flaker-review.md
+- run: pnpm flaker status --markdown > .artifacts/flaker-status.md
 ```
 
 ## Promotion criteria for required check
 
-Only promote `flaker run --gate merge` from advisory to required when `flaker status` drift shows `ready` (all 5 `[promotion]` thresholds met), or equivalently when `flaker gate review merge --json` reports:
+Only promote `flaker run --gate merge` from advisory to required when `flaker status` drift shows `ready` (all 5 `[promotion]` thresholds met), or equivalently when `flaker status --gate merge --detail --json` reports:
 
 - `Matched commits ≥ 20`
 - `False negative rate ≤ 5%`
@@ -197,6 +192,8 @@ Only promote `flaker run --gate merge` from advisory to required when `flaker st
 - `Data confidence: moderate` or `high`
 
 The thresholds live in `[promotion]` of `flaker.toml`; defaults match the above. Override in config if the project needs stricter or looser gating.
+
+The simplest readout is `flaker status` — the drift section shows `ready` or lists unmet thresholds.
 
 If the user wants to gate sooner, push back: empirically less than 20 matched commits gives unstable readings.
 
@@ -221,7 +218,7 @@ If the user wants to gate sooner, push back: empirically less than 20 matched co
 - **Do not** set `holdout_ratio > 0.2` — wastes runner time.
 - **Do not** skip `flaker apply` and hand-tune `[sampling]` — the calibrated values outperform manual settings in 90% of cases.
 - **Do not** make the PR job required before `flaker status` drift reports `ready`.
-- **Do not** use `flaker kpi` or `flaker doctor` top-level aliases in new scripts — they print a deprecation warning and will be removed in 0.7.0.
+- **Do not** use deprecated aliases in new scripts — `setup init`, `exec run`, `collect ci`, `collect calibrate`, `analyze kpi`, `analyze eval`, `debug doctor`, `quarantine suggest/apply`, `policy quarantine/check/report`, `gate review/history/explain` all print deprecation warnings in 0.7.0 and will be removed in 0.8.0. Use the primary commands: `flaker init`, `flaker run`, `flaker apply`, `flaker status`, `flaker doctor`, `flaker explain`, `flaker query`, etc.
 
 ## Reference docs (in this plugin)
 

--- a/src/cli/categories/apply.ts
+++ b/src/cli/categories/apply.ts
@@ -29,6 +29,23 @@ function describeAction(action: PlannedAction): string {
   }
 }
 
+export function renderEmptyPlanHint(): string {
+  return "hint: run `flaker status` to inspect current health.";
+}
+
+export function renderZeroTestHint(): string {
+  return "hint: 0 tests discovered — check [runner].command and [affected].resolver";
+}
+
+export function isColdStartZeroTest(result: unknown): boolean {
+  if (result == null || typeof result !== "object") return false;
+  const r = result as Record<string, unknown>;
+  const runResult = r["runResult"];
+  if (runResult == null || typeof runResult !== "object") return false;
+  const sampledTests = (runResult as Record<string, unknown>)["sampledTests"];
+  return Array.isArray(sampledTests) && sampledTests.length === 0;
+}
+
 export async function planAction(opts: { json?: boolean }): Promise<void> {
   const cwd = process.cwd();
   const config = loadConfig(cwd);
@@ -44,6 +61,7 @@ export async function planAction(opts: { json?: boolean }): Promise<void> {
     }
     if (actions.length === 0) {
       console.log("No actions needed. Current state matches flaker.toml.");
+      process.stderr.write(renderEmptyPlanHint() + "\n");
       return;
     }
     console.log("Planned actions:");
@@ -104,6 +122,14 @@ export async function applyAction(opts: { json?: boolean }): Promise<void> {
       },
     };
 
+    if (actions.length === 0) {
+      console.log("No actions needed. Current state matches flaker.toml.");
+      if (!opts.json) {
+        process.stderr.write(renderEmptyPlanHint() + "\n");
+      }
+      return;
+    }
+
     const result = await executePlan(actions, deps);
     if (opts.json) {
       console.log(JSON.stringify(result, null, 2));
@@ -111,6 +137,9 @@ export async function applyAction(opts: { json?: boolean }): Promise<void> {
       for (const exec of result.executed) {
         const mark = exec.ok ? "ok  " : "fail";
         console.log(`${mark} ${exec.kind}${exec.error ? ` — ${exec.error}` : ""}`);
+        if (exec.ok && exec.kind === "cold_start_run" && isColdStartZeroTest(exec.result)) {
+          process.stderr.write(renderZeroTestHint() + "\n");
+        }
       }
       if (result.aborted) {
         process.exitCode = 1;

--- a/src/cli/categories/ops.ts
+++ b/src/cli/categories/ops.ts
@@ -1,7 +1,6 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import type { Command } from "commander";
-import { deprecate } from "../deprecation.js";
 import { loadConfig } from "../config.js";
 import { DuckDBStore } from "../storage/duckdb.js";
 import { prepareRunRequest } from "../commands/exec/prepare-run-request.js";
@@ -201,7 +200,6 @@ export function registerOpsCommands(program: Command): void {
     .option("--json", "Output as JSON")
     .option("--output <file>", "Write the rendered artifact to a file")
     .action(opsDailyAction);
-  deprecate(dailyCmd, { since: "0.7.0", remove: "0.8.0", canonical: "flaker apply" });
 
   ops
     .command("weekly")

--- a/src/cli/categories/policy.ts
+++ b/src/cli/categories/policy.ts
@@ -317,7 +317,7 @@ export function registerPolicyCommands(program: Command): void {
 
       const rangeErrors = validateConfigRanges(config);
       const report = appendConfigRangeErrors(
-        appendConfigWarnings(runConfigCheck({
+        appendConfigWarnings(await runConfigCheck({
           listedTests,
           discoveredSpecs,
           taskDefinitions,

--- a/src/cli/categories/report.ts
+++ b/src/cli/categories/report.ts
@@ -48,7 +48,7 @@ type SummaryOpts = {
   prComment?: boolean;
 };
 
-function runSummaryAction(opts: SummaryOpts): void {
+async function runSummaryAction(opts: SummaryOpts): Promise<void> {
   const formatCount = [opts.json, opts.markdown, opts.prComment].filter(Boolean).length;
   if (formatCount > 1) {
     console.error("Error: choose one of --json, --markdown, or --pr-comment");
@@ -59,7 +59,7 @@ function runSummaryAction(opts: SummaryOpts): void {
     process.exit(1);
   }
 
-  const summary = runReportSummarize({
+  const summary = await runReportSummarize({
     adapter: opts.adapter,
     input: readFileSync(resolve(opts.input), "utf-8"),
   });
@@ -98,7 +98,7 @@ type DiffOpts = {
   markdown?: boolean;
 };
 
-function runDiffAction(opts: DiffOpts): void {
+async function runDiffAction(opts: DiffOpts): Promise<void> {
   if (opts.json && opts.markdown) {
     console.error("Error: choose either --json or --markdown");
     process.exit(1);
@@ -107,12 +107,12 @@ function runDiffAction(opts: DiffOpts): void {
   const baseInput = readFileSync(resolve(opts.base), "utf-8");
   const headInput = readFileSync(resolve(opts.head), "utf-8");
   const base = opts.adapter
-    ? runReportSummarize({ adapter: opts.adapter, input: baseInput })
+    ? await runReportSummarize({ adapter: opts.adapter, input: baseInput })
     : parseReportSummary(baseInput);
   const head = opts.adapter
-    ? runReportSummarize({ adapter: opts.adapter, input: headInput })
+    ? await runReportSummarize({ adapter: opts.adapter, input: headInput })
     : parseReportSummary(headInput);
-  const diff = runReportDiff({ base, head });
+  const diff = await runReportDiff({ base, head });
 
   console.log(formatReportDiff(diff, opts.json ? "json" : "markdown"));
 }
@@ -122,13 +122,13 @@ type AggregateOpts = {
   markdown?: boolean;
 };
 
-function runAggregateAction(dir: string, opts: AggregateOpts): void {
+async function runAggregateAction(dir: string, opts: AggregateOpts): Promise<void> {
   if (opts.json && opts.markdown) {
     console.error("Error: choose either --json or --markdown");
     process.exit(1);
   }
 
-  const aggregate = runReportAggregate({
+  const aggregate = await runReportAggregate({
     summaries: loadReportSummaryArtifactsFromDir(resolve(dir)),
   });
   console.log(
@@ -161,7 +161,7 @@ export function registerReportCommands(program: Command): void {
     // diff flags
     .option("--head <file>", "Head summary or raw report file (for --diff)")
     .action(
-      (
+      async (
         file: string | undefined,
         opts: {
           summary?: boolean;
@@ -184,7 +184,7 @@ export function registerReportCommands(program: Command): void {
           // diff opts
           head?: string;
         },
-      ) => {
+      ): Promise<void> => {
         const flagCount = [opts.summary, opts.diff !== undefined, opts.aggregate !== undefined].filter(Boolean).length;
         if (flagCount === 0) {
           reportCmd.help();
@@ -205,7 +205,7 @@ export function registerReportCommands(program: Command): void {
             console.error("Error: --summary requires --adapter <type>");
             process.exit(2);
           }
-          runSummaryAction({
+          await runSummaryAction({
             adapter: opts.adapter,
             input: inputFile,
             bundle: opts.bundle,
@@ -229,7 +229,7 @@ export function registerReportCommands(program: Command): void {
             console.error("Error: --diff requires a head file argument or --head <file>");
             process.exit(2);
           }
-          runDiffAction({
+          await runDiffAction({
             base: opts.diff,
             head: headFile,
             adapter: opts.adapter,
@@ -240,7 +240,7 @@ export function registerReportCommands(program: Command): void {
         }
 
         if (opts.aggregate !== undefined) {
-          runAggregateAction(opts.aggregate, {
+          await runAggregateAction(opts.aggregate, {
             json: opts.json,
             markdown: opts.markdown,
           });
@@ -265,8 +265,8 @@ export function registerReportCommands(program: Command): void {
       .option("--json", "Output JSON report")
       .option("--markdown", "Output Markdown report")
       .option("--pr-comment", "Output compact Markdown for PR comments")
-      .action((opts: SummaryOpts) => {
-        runSummaryAction(opts);
+      .action(async (opts: SummaryOpts) => {
+        await runSummaryAction(opts);
       }),
     { since: "0.7.0", remove: "0.8.0", canonical: "flaker report --summary" },
   );
@@ -280,8 +280,8 @@ export function registerReportCommands(program: Command): void {
       .option("--adapter <type>", "Adapter type when diffing raw reports")
       .option("--json", "Output JSON report")
       .option("--markdown", "Output Markdown report")
-      .action((opts: DiffOpts) => {
-        runDiffAction(opts);
+      .action(async (opts: DiffOpts) => {
+        await runDiffAction(opts);
       }),
     { since: "0.7.0", remove: "0.8.0", canonical: "flaker report --diff <base>" },
   );
@@ -292,8 +292,8 @@ export function registerReportCommands(program: Command): void {
       .description("Aggregate shard-aware summary artifacts")
       .option("--json", "Output JSON report")
       .option("--markdown", "Output Markdown report")
-      .action((dir: string, opts: AggregateOpts) => {
-        runAggregateAction(dir, opts);
+      .action(async (dir: string, opts: AggregateOpts) => {
+        await runAggregateAction(dir, opts);
       }),
     { since: "0.7.0", remove: "0.8.0", canonical: "flaker report --aggregate <dir>" },
   );

--- a/src/cli/commands/analyze/eval.ts
+++ b/src/cli/commands/analyze/eval.ts
@@ -465,7 +465,13 @@ async function loadSamplingKpiBuilder(): Promise<
   return buildSamplingKpiFallback;
 }
 
-const buildSamplingKpi = await loadSamplingKpiBuilder();
+let cachedSamplingKpiBuilder: ((rows: CommitSignal[]) => SamplingKpiReport) | undefined;
+
+async function getBuildSamplingKpi(): Promise<(rows: CommitSignal[]) => SamplingKpiReport> {
+  if (cachedSamplingKpiBuilder) return cachedSamplingKpiBuilder;
+  cachedSamplingKpiBuilder = await loadSamplingKpiBuilder();
+  return cachedSamplingKpiBuilder;
+}
 
 export async function runSamplingKpi(
   opts: { store: MetricStore; windowDays?: number },
@@ -539,6 +545,7 @@ export async function runSamplingKpi(
      AND rs.commit_sha = ar.commit_sha
      AND rs.row_num = 1
   `, [windowDays.toString(), windowDays.toString()]);
+  const buildSamplingKpi = await getBuildSamplingKpi();
   return buildSamplingKpi(
     commitSignalRows.map((row) => ({
       commitSha: row.commit_sha,

--- a/src/cli/commands/exec/plan.ts
+++ b/src/cli/commands/exec/plan.ts
@@ -12,6 +12,7 @@ import {
 } from "../../core/loader.js";
 import {
   isManifestQuarantined,
+  loadQuarantineBridge,
   type QuarantineManifestEntry,
 } from "../../quarantine-manifest.js";
 import { extractFeatures, type GBDTModel } from "../../eval/gbdt.js";
@@ -249,6 +250,7 @@ async function filterQuarantinedTests(
   listedTests: TestId[],
   manifestEntries: QuarantineManifestEntry[],
 ): Promise<TestMeta[]> {
+  await loadQuarantineBridge();
   const quarantined = await store.queryQuarantined();
   const qSet = new Set(quarantined.map((q) => q.testId));
   const listedTestIndex = buildListedTestIndex(listedTests);

--- a/src/cli/commands/policy/check.ts
+++ b/src/cli/commands/policy/check.ts
@@ -227,25 +227,36 @@ function fromCoreReport(output: ConfigCheckCoreOutput): ConfigCheckReport {
   };
 }
 
-const runConfigCheckImpl = await (async (): Promise<(opts: RunConfigCheckOpts) => ConfigCheckReport> => {
-  const mod = (await import(MOONBIT_JS_BRIDGE_URL.href)) as ConfigCheckCoreExports;
-  if (typeof mod.run_config_check_json !== "function") {
-    throw new Error("MoonBit config_check bridge is missing. Run 'moon build --target js' first.");
-  }
-  return (opts) =>
-    fromCoreReport(
-      JSON.parse(
-        mod.run_config_check_json(
-          JSON.stringify(opts.listedTests.map(toCoreListedTest)),
-          JSON.stringify(opts.discoveredSpecs.map(normalizePath)),
-          JSON.stringify((opts.taskDefinitions ?? []).map(toCoreTaskDefinition)),
-        ),
-      ) as ConfigCheckCoreOutput,
-    );
-})();
+let cachedRunConfigCheckImpl: ((opts: RunConfigCheckOpts) => ConfigCheckReport) | undefined;
+let configCheckLoadPromise: Promise<(opts: RunConfigCheckOpts) => ConfigCheckReport> | undefined;
 
-export function runConfigCheck(opts: RunConfigCheckOpts): ConfigCheckReport {
-  return runConfigCheckImpl(opts);
+async function getRunConfigCheckImpl(): Promise<(opts: RunConfigCheckOpts) => ConfigCheckReport> {
+  if (cachedRunConfigCheckImpl) return cachedRunConfigCheckImpl;
+  if (configCheckLoadPromise) return configCheckLoadPromise;
+  configCheckLoadPromise = (async () => {
+    const mod = (await import(MOONBIT_JS_BRIDGE_URL.href)) as ConfigCheckCoreExports;
+    if (typeof mod.run_config_check_json !== "function") {
+      throw new Error("MoonBit config_check bridge is missing. Run 'moon build --target js' first.");
+    }
+    const fn = (opts: RunConfigCheckOpts): ConfigCheckReport =>
+      fromCoreReport(
+        JSON.parse(
+          mod.run_config_check_json(
+            JSON.stringify(opts.listedTests.map(toCoreListedTest)),
+            JSON.stringify(opts.discoveredSpecs.map(normalizePath)),
+            JSON.stringify((opts.taskDefinitions ?? []).map(toCoreTaskDefinition)),
+          ),
+        ) as ConfigCheckCoreOutput,
+      );
+    cachedRunConfigCheckImpl = fn;
+    return fn;
+  })();
+  return configCheckLoadPromise;
+}
+
+export async function runConfigCheck(opts: RunConfigCheckOpts): Promise<ConfigCheckReport> {
+  const impl = await getRunConfigCheckImpl();
+  return impl(opts);
 }
 
 function formatSummaryList(report: ConfigCheckReport): string[] {

--- a/src/cli/commands/report/index.ts
+++ b/src/cli/commands/report/index.ts
@@ -210,26 +210,41 @@ function fromCoreTotals(totals: ReportTotalsInput): ReportTotals {
   };
 }
 
-const reportBridge = await (async (): Promise<ReportDiffCoreExports> => {
-  const mod = (await import(MOONBIT_JS_BRIDGE_URL.href)) as Partial<ReportDiffCoreExports>;
-  if (
-    typeof mod.summarize_report_json === "function" &&
-    typeof mod.classify_report_diff_json === "function" &&
-    typeof mod.aggregate_report_json === "function"
-  ) {
-    return mod as ReportDiffCoreExports;
-  }
-  throw new Error("MoonBit report bridge is missing. Run 'moon build --target js' first.");
-})();
+let cachedReportBridge: ReportDiffCoreExports | undefined;
+let reportBridgeLoadPromise: Promise<ReportDiffCoreExports> | undefined;
 
-const classifyReportDiff = (inputs: ReportDiffStatusInput[]): ReportDiffBuckets =>
-  JSON.parse(reportBridge.classify_report_diff_json(JSON.stringify(inputs)));
+async function getReportBridge(): Promise<ReportDiffCoreExports> {
+  if (cachedReportBridge) return cachedReportBridge;
+  if (reportBridgeLoadPromise) return reportBridgeLoadPromise;
+  reportBridgeLoadPromise = (async () => {
+    const mod = (await import(MOONBIT_JS_BRIDGE_URL.href)) as Partial<ReportDiffCoreExports>;
+    if (
+      typeof mod.summarize_report_json === "function" &&
+      typeof mod.classify_report_diff_json === "function" &&
+      typeof mod.aggregate_report_json === "function"
+    ) {
+      cachedReportBridge = mod as ReportDiffCoreExports;
+      return cachedReportBridge;
+    }
+    throw new Error("MoonBit report bridge is missing. Run 'moon build --target js' first.");
+  })();
+  return reportBridgeLoadPromise;
+}
 
-const summarizeReport = (tests: ReportSummaryTestInput[]): ReportSummaryOutput =>
-  JSON.parse(reportBridge.summarize_report_json(JSON.stringify(tests)));
+async function classifyReportDiff(inputs: ReportDiffStatusInput[]): Promise<ReportDiffBuckets> {
+  const bridge = await getReportBridge();
+  return JSON.parse(bridge.classify_report_diff_json(JSON.stringify(inputs)));
+}
 
-const aggregateReport = (shards: ReportAggregateShardInput[]): ReportAggregateOutput =>
-  JSON.parse(reportBridge.aggregate_report_json(JSON.stringify(shards)));
+async function summarizeReport(tests: ReportSummaryTestInput[]): Promise<ReportSummaryOutput> {
+  const bridge = await getReportBridge();
+  return JSON.parse(bridge.summarize_report_json(JSON.stringify(tests)));
+}
+
+async function aggregateReport(shards: ReportAggregateShardInput[]): Promise<ReportAggregateOutput> {
+  const bridge = await getReportBridge();
+  return JSON.parse(bridge.aggregate_report_json(JSON.stringify(shards)));
+}
 
 function emptyTotals(): ReportTotals {
   return {
@@ -341,12 +356,12 @@ function summarizeTest(result: TestCaseResult): ReportTestSummary {
   };
 }
 
-export function summarizeResults(
+export async function summarizeResults(
   results: TestCaseResult[],
   adapter: string,
-): NormalizedReportSummary {
+): Promise<NormalizedReportSummary> {
   const tests = sortTests(results.map(summarizeTest));
-  const reduced = summarizeReport(
+  const reduced = await summarizeReport(
     tests.map((test) => ({
       test_id: test.testId,
       suite: test.suite,
@@ -386,10 +401,10 @@ function parseAdapterReport(
   return createTestResultAdapter(adapter).parse(input);
 }
 
-export function runReportSummarize(opts: {
+export async function runReportSummarize(opts: {
   adapter: string;
   input: string;
-}): NormalizedReportSummary {
+}): Promise<NormalizedReportSummary> {
   return summarizeResults(parseAdapterReport(opts.adapter, opts.input), opts.adapter);
 }
 
@@ -453,10 +468,10 @@ function toDiffEntry(
   };
 }
 
-export function runReportDiff(opts: {
+export async function runReportDiff(opts: {
   base: NormalizedReportSummary;
   head: NormalizedReportSummary;
-}): ReportDiff {
+}): Promise<ReportDiff> {
   const baseById = new Map(opts.base.tests.map((test) => [test.testId, test]));
   const headById = new Map(opts.head.tests.map((test) => [test.testId, test]));
   const allIds = [...new Set<string>([
@@ -464,7 +479,7 @@ export function runReportDiff(opts: {
     ...headById.keys(),
   ])].sort((a, b) => a.localeCompare(b));
 
-  const buckets = classifyReportDiff(
+  const buckets = await classifyReportDiff(
     allIds.map((testId) => {
       const base = baseById.get(testId);
       const head = headById.get(testId);
@@ -516,9 +531,9 @@ export function runReportDiff(opts: {
   };
 }
 
-export function runReportAggregate(opts: {
+export async function runReportAggregate(opts: {
   summaries: ReportSummaryArtifact[];
-}): ReportAggregate {
+}): Promise<ReportAggregate> {
   const shards = opts.summaries.map((artifact, index) => {
     const shardId = artifact.metadata.shard ?? `summary-${index + 1}`;
     return {
@@ -541,7 +556,7 @@ export function runReportAggregate(opts: {
     }
   }
 
-  const aggregate = aggregateReport(
+  const aggregate = await aggregateReport(
     shards.map((shard) => ({
       shard_id: shard.shardId,
       totals: toCoreTotals(shard.totals),

--- a/src/cli/commands/setup/init.ts
+++ b/src/cli/commands/setup/init.ts
@@ -50,6 +50,21 @@ min_runs = 5
 [flaky]
 window_days = 14
 detection_threshold_ratio = 0.02
+
+[profile.local]
+strategy = "affected"
+max_duration_seconds = 60
+fallback_strategy = "weighted"
+skip_flaky_tagged = true
+
+[profile.ci]
+strategy = "hybrid"
+sample_percentage = 30
+adaptive = true
+skip_flaky_tagged = true
+
+[profile.scheduled]
+strategy = "full"
 `;
 }
 

--- a/src/cli/identity.ts
+++ b/src/cli/identity.ts
@@ -139,31 +139,38 @@ function resolveTestIdentityFallback(
   };
 }
 
-const identityCore = await (async (): Promise<IdentityCoreExports> => {
-  const mod = await importOptionalMoonBitBridge<IdentityCoreExports>(
+const tsFallbackCore: IdentityCoreExports = {
+  create_stable_test_id_json(inputJson: string): string {
+    return JSON.stringify(
+      createStableTestIdFallback(
+        JSON.parse(inputJson) as CoreStableTestIdentityInput,
+      ),
+    );
+  },
+  resolve_test_identity_json(inputJson: string): string {
+    return JSON.stringify(
+      resolveTestIdentityFallback(
+        JSON.parse(inputJson) as CoreStableTestIdentityInput,
+      ),
+    );
+  },
+};
+
+let identityCore: IdentityCoreExports = tsFallbackCore;
+let bridgeLoadStarted = false;
+
+function ensureBridgeLoad(): void {
+  if (bridgeLoadStarted) return;
+  bridgeLoadStarted = true;
+  importOptionalMoonBitBridge<IdentityCoreExports>(
     MOONBIT_JS_BRIDGE_URL,
     isIdentityCoreExports,
-  );
-  if (mod) {
-    return mod;
-  }
-  return {
-    create_stable_test_id_json(inputJson: string): string {
-      return JSON.stringify(
-        createStableTestIdFallback(
-          JSON.parse(inputJson) as CoreStableTestIdentityInput,
-        ),
-      );
-    },
-    resolve_test_identity_json(inputJson: string): string {
-      return JSON.stringify(
-        resolveTestIdentityFallback(
-          JSON.parse(inputJson) as CoreStableTestIdentityInput,
-        ),
-      );
-    },
-  };
-})();
+  ).then((mod) => {
+    if (mod) identityCore = mod;
+  }).catch(() => {
+    // bridge unavailable — keep using the TS fallback
+  });
+}
 
 export function normalizeVariant(
   variant?: Record<string, string> | null,
@@ -172,6 +179,7 @@ export function normalizeVariant(
 }
 
 export function createStableTestId(input: TestIdentityFields): string {
+  ensureBridgeLoad();
   return JSON.parse(
     identityCore.create_stable_test_id_json(JSON.stringify(toCoreInput(input))),
   ) as string;
@@ -180,6 +188,7 @@ export function createStableTestId(input: TestIdentityFields): string {
 export function resolveTestIdentity<T extends TestIdentityFields>(
   input: T,
 ): T & ResolvedTestIdentity {
+  ensureBridgeLoad();
   const resolved = JSON.parse(
     identityCore.resolve_test_identity_json(JSON.stringify(toCoreInput(input))),
   ) as CoreResolvedStableTestIdentityOutput;

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -43,7 +43,7 @@ export function createProgram(): Command {
   program
     .name("flaker")
     .description("Intelligent test selection — run fewer tests, catch more failures")
-    .version("0.7.0-next.0")
+    .version("0.7.0")
     .showHelpAfterError()
     .showSuggestionAfterError();
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -134,14 +134,13 @@ Primary commands:
 
 Advanced:
   gate review <name>                Authoritative promotion metrics (--json)
-  ops weekly|incident               Cadence artifact bundles
+  ops daily|weekly|incident         Cadence artifact bundles
   analyze query                     (legacy — use \`flaker query\`)
   dev <train|tune|self-eval|...>    Maintainer tools
 
 Deprecated (removed in 0.8.0):
   setup init                        → flaker init
   exec run / exec affected          → flaker run
-  ops daily                         → flaker apply
   collect ci|local|coverage|calibrate → flaker apply
   quarantine suggest|apply          → flaker apply
   policy quarantine|check|report    → flaker apply

--- a/src/cli/quarantine-manifest.ts
+++ b/src/cli/quarantine-manifest.ts
@@ -332,43 +332,58 @@ function toCoreEntry(entry: QuarantineManifestEntry): QuarantineEntryInput {
   };
 }
 
-const findMatchingManifestEntryImpl = await (async (): Promise<
-  (
-    entries: QuarantineManifestEntry[],
-    selector: QuarantineManifestSelector,
-    opts?: FindMatchingManifestEntryOpts,
-  ) => QuarantineManifestEntry | undefined
-> => {
-  const mod = (await import(MOONBIT_JS_BRIDGE_URL.href)) as QuarantineMatchExports;
-  if (typeof mod.find_matching_quarantine_json !== "function") {
-    throw new Error("MoonBit quarantine bridge is missing. Run 'moon build --target js' first.");
-  }
-  return (entries, selector, opts) => {
-    const filteredEntries = opts?.modes
-      ? entries.filter((entry) => opts.modes!.includes(entry.mode))
-      : entries;
-    const resolved = resolveTestIdentity({
-      suite: selector.suite,
-      testName: selector.testName,
-      taskId: selector.taskId,
-    });
-    const matchedIndex = JSON.parse(
-      mod.find_matching_quarantine_json(
-        JSON.stringify(filteredEntries.map(toCoreEntry)),
-        resolved.taskId,
-        normalizeSpecPath(resolved.suite),
-        resolved.testName,
-      ),
-    ) as number;
-    return matchedIndex >= 0 ? filteredEntries[matchedIndex] : undefined;
-  };
-})();
+type FindMatchingManifestEntryFn = (
+  entries: QuarantineManifestEntry[],
+  selector: QuarantineManifestSelector,
+  opts?: FindMatchingManifestEntryOpts,
+) => QuarantineManifestEntry | undefined;
+
+let findMatchingManifestEntryImpl: FindMatchingManifestEntryFn | undefined;
+let quarantineBridgeLoadPromise: Promise<FindMatchingManifestEntryFn> | undefined;
+
+export async function loadQuarantineBridge(): Promise<FindMatchingManifestEntryFn> {
+  if (quarantineBridgeLoadPromise) return quarantineBridgeLoadPromise;
+  quarantineBridgeLoadPromise = (async () => {
+    const mod = (await import(MOONBIT_JS_BRIDGE_URL.href)) as QuarantineMatchExports;
+    if (typeof mod.find_matching_quarantine_json !== "function") {
+      throw new Error("MoonBit quarantine bridge is missing. Run 'moon build --target js' first.");
+    }
+    const fn: FindMatchingManifestEntryFn = (entries, selector, opts) => {
+      const filteredEntries = opts?.modes
+        ? entries.filter((entry) => opts.modes!.includes(entry.mode))
+        : entries;
+      const resolved = resolveTestIdentity({
+        suite: selector.suite,
+        testName: selector.testName,
+        taskId: selector.taskId,
+      });
+      const matchedIndex = JSON.parse(
+        mod.find_matching_quarantine_json(
+          JSON.stringify(filteredEntries.map(toCoreEntry)),
+          resolved.taskId,
+          normalizeSpecPath(resolved.suite),
+          resolved.testName,
+        ),
+      ) as number;
+      return matchedIndex >= 0 ? filteredEntries[matchedIndex] : undefined;
+    };
+    findMatchingManifestEntryImpl = fn;
+    return fn;
+  })();
+  return quarantineBridgeLoadPromise;
+}
 
 export function findMatchingManifestEntry(
   entries: QuarantineManifestEntry[],
   selector: QuarantineManifestSelector,
   opts?: FindMatchingManifestEntryOpts,
 ): QuarantineManifestEntry | undefined {
+  if (!findMatchingManifestEntryImpl) {
+    throw new Error(
+      "findMatchingManifestEntry called before quarantine bridge was loaded. " +
+      "Call loadQuarantineBridge() first.",
+    );
+  }
   return findMatchingManifestEntryImpl(entries, selector, opts);
 }
 

--- a/src/cli/reporting/flaker-quarantine-summary-core.ts
+++ b/src/cli/reporting/flaker-quarantine-summary-core.ts
@@ -337,10 +337,21 @@ async function loadQuarantineSummaryBuilder(): Promise<
   return buildFlakerQuarantineSummaryFallback;
 }
 
-const buildFlakerQuarantineSummaryImpl = await loadQuarantineSummaryBuilder();
+let cachedQuarantineSummaryBuilder:
+  | ((inputs: BuildFlakerQuarantineSummaryInputs) => FlakerQuarantineSummary)
+  | undefined;
 
-export function buildFlakerQuarantineSummary(
+async function getBuildFlakerQuarantineSummary(): Promise<
+  (inputs: BuildFlakerQuarantineSummaryInputs) => FlakerQuarantineSummary
+> {
+  if (cachedQuarantineSummaryBuilder) return cachedQuarantineSummaryBuilder;
+  cachedQuarantineSummaryBuilder = await loadQuarantineSummaryBuilder();
+  return cachedQuarantineSummaryBuilder;
+}
+
+export async function buildFlakerQuarantineSummary(
   inputs: BuildFlakerQuarantineSummaryInputs,
-): FlakerQuarantineSummary {
-  return buildFlakerQuarantineSummaryImpl(inputs);
+): Promise<FlakerQuarantineSummary> {
+  const impl = await getBuildFlakerQuarantineSummary();
+  return impl(inputs);
 }

--- a/src/cli/resolvers/affected-report.ts
+++ b/src/cli/resolvers/affected-report.ts
@@ -324,14 +324,22 @@ function buildAffectedReportFallback(opts: {
   );
 }
 
-const affectedExplainCore = await importOptionalMoonBitBridge<AffectedExplainCoreExports>(
-  MOONBIT_JS_BRIDGE_URL,
-  isAffectedExplainCoreExports,
-);
+let cachedAffectedExplainCore: AffectedExplainCoreExports | null | undefined;
+
+async function getAffectedExplainCore(): Promise<AffectedExplainCoreExports | null> {
+  if (cachedAffectedExplainCore !== undefined) return cachedAffectedExplainCore;
+  const core = await importOptionalMoonBitBridge<AffectedExplainCoreExports>(
+    MOONBIT_JS_BRIDGE_URL,
+    isAffectedExplainCoreExports,
+  );
+  cachedAffectedExplainCore = core ?? null;
+  return cachedAffectedExplainCore;
+}
 
 export async function dedupeAffectedTargets(
   targets: AffectedTarget[],
 ): Promise<AffectedTarget[]> {
+  const affectedExplainCore = await getAffectedExplainCore();
   if (!affectedExplainCore) {
     return dedupeAffectedTargetsFallback(targets);
   }
@@ -354,6 +362,7 @@ export async function buildAffectedReportFromInputs(opts: {
   transitiveTasks?: AffectedTransitiveTaskInput[];
   unmatched: string[];
 }): Promise<AffectedReport> {
+  const affectedExplainCore = await getAffectedExplainCore();
   if (!affectedExplainCore) {
     return buildAffectedReportFallback(opts);
   }

--- a/src/cli/runners/quarantine-runtime.ts
+++ b/src/cli/runners/quarantine-runtime.ts
@@ -3,6 +3,7 @@ import { MOONBIT_JS_BRIDGE_URL } from "../core/build-artifact.js";
 import { normalizeVariant, resolveTestIdentity } from "../identity.js";
 import {
   findMatchingManifestEntry,
+  loadQuarantineBridge,
   type QuarantineManifestEntry,
 } from "../quarantine-manifest.js";
 import type {
@@ -117,8 +118,9 @@ function resolveRuntimeIdentity(
   });
 }
 
-export function isBlockingFailure(result: TestCaseResult): boolean {
-  return quarantineRuntimeDecisions.isBlockingFailure(result);
+export async function isBlockingFailure(result: TestCaseResult): Promise<boolean> {
+  const decisions = await getQuarantineRuntimeDecisions();
+  return decisions.isBlockingFailure(result);
 }
 
 function toCoreRuntimeResultInput(
@@ -145,38 +147,51 @@ function annotateRuntimeResults(
   });
 }
 
-const quarantineRuntimeDecisions = await (async (): Promise<{
+interface QuarantineRuntimeDecisions {
   isBlockingFailure: (result: TestCaseResult) => boolean;
   computeExitCode: (results: TestCaseResult[], fallbackExitCode: number) => number;
-}> => {
-  const mod = (await import(MOONBIT_JS_BRIDGE_URL.href)) as QuarantineRuntimeCoreExports;
-  if (
-    typeof mod.is_blocking_failure_json !== "function" ||
-    typeof mod.compute_quarantine_exit_code_json !== "function"
-  ) {
-    throw new Error("MoonBit quarantine bridge is missing. Run 'moon build --target js' first.");
-  }
-  return {
-    isBlockingFailure(result) {
-      return JSON.parse(
-        mod.is_blocking_failure_json(
-          JSON.stringify(toCoreRuntimeResultInput(result)),
-        ),
-      ) as boolean;
-    },
-    computeExitCode(results, fallbackExitCode) {
-      return JSON.parse(
-        mod.compute_quarantine_exit_code_json(
-          JSON.stringify(results.map(toCoreRuntimeResultInput)),
-          fallbackExitCode,
-        ),
-      ) as number;
-    },
-  };
-})();
+}
 
-function computeExitCode(results: TestCaseResult[], fallbackExitCode: number): number {
-  return quarantineRuntimeDecisions.computeExitCode(results, fallbackExitCode);
+let cachedQuarantineRuntimeDecisions: QuarantineRuntimeDecisions | undefined;
+let quarantineRuntimeLoadPromise: Promise<QuarantineRuntimeDecisions> | undefined;
+
+async function getQuarantineRuntimeDecisions(): Promise<QuarantineRuntimeDecisions> {
+  if (cachedQuarantineRuntimeDecisions) return cachedQuarantineRuntimeDecisions;
+  if (quarantineRuntimeLoadPromise) return quarantineRuntimeLoadPromise;
+  quarantineRuntimeLoadPromise = (async () => {
+    const mod = (await import(MOONBIT_JS_BRIDGE_URL.href)) as QuarantineRuntimeCoreExports;
+    if (
+      typeof mod.is_blocking_failure_json !== "function" ||
+      typeof mod.compute_quarantine_exit_code_json !== "function"
+    ) {
+      throw new Error("MoonBit quarantine bridge is missing. Run 'moon build --target js' first.");
+    }
+    const decisions: QuarantineRuntimeDecisions = {
+      isBlockingFailure(result) {
+        return JSON.parse(
+          mod.is_blocking_failure_json(
+            JSON.stringify(toCoreRuntimeResultInput(result)),
+          ),
+        ) as boolean;
+      },
+      computeExitCode(results, fallbackExitCode) {
+        return JSON.parse(
+          mod.compute_quarantine_exit_code_json(
+            JSON.stringify(results.map(toCoreRuntimeResultInput)),
+            fallbackExitCode,
+          ),
+        ) as number;
+      },
+    };
+    cachedQuarantineRuntimeDecisions = decisions;
+    return decisions;
+  })();
+  return quarantineRuntimeLoadPromise;
+}
+
+async function computeExitCode(results: TestCaseResult[], fallbackExitCode: number): Promise<number> {
+  const decisions = await getQuarantineRuntimeDecisions();
+  return decisions.computeExitCode(results, fallbackExitCode);
 }
 
 export function withQuarantineRuntime(
@@ -191,6 +206,7 @@ export function withQuarantineRuntime(
     ...runner,
     name: `${runner.name}+quarantine`,
     async execute(tests: TestId[], opts?: ExecuteOpts): Promise<ExecuteResult> {
+      await loadQuarantineBridge();
       const runnable: TestId[] = [];
       const skipped: TestCaseResult[] = [];
 
@@ -222,7 +238,7 @@ export function withQuarantineRuntime(
       return {
         ...baseResult,
         results,
-        exitCode: computeExitCode(results, baseResult.exitCode),
+        exitCode: await computeExitCode(results, baseResult.exitCode),
       };
     },
     async listTests(opts?: ExecuteOpts): Promise<TestId[]> {

--- a/src/cli/runners/retry.ts
+++ b/src/cli/runners/retry.ts
@@ -49,7 +49,7 @@ export async function executeWithRetry(
     const testsToRetry: TestId[] = [];
     for (const r of lastResult.results) {
       const resolved = resolveTestIdentity(r);
-      if (isBlockingFailure(resolved)) {
+      if (await isBlockingFailure(resolved)) {
         testsToRetry.push({
           suite: resolved.suite,
           testName: resolved.testName,
@@ -117,7 +117,8 @@ export async function executeWithRetry(
     }
   }
 
-  const exitCode = finalResults.some(isBlockingFailure) ? 1 : 0;
+  const blockingResults = await Promise.all(finalResults.map(isBlockingFailure));
+  const exitCode = blockingResults.some(Boolean) ? 1 : 0;
 
   return {
     exitCode,

--- a/tests/cli/apply-empty-hint.test.ts
+++ b/tests/cli/apply-empty-hint.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import {
+  renderEmptyPlanHint,
+  renderZeroTestHint,
+  isColdStartZeroTest,
+} from "../../src/cli/categories/apply.js";
+
+describe("apply output hints", () => {
+  it("renderEmptyPlanHint returns a hint referencing flaker status", () => {
+    const hint = renderEmptyPlanHint();
+    expect(hint).toContain("flaker status");
+    expect(hint).toMatch(/^hint:/);
+  });
+
+  it("renderZeroTestHint returns a hint about 0 tests discovered", () => {
+    const hint = renderZeroTestHint();
+    expect(hint).toContain("0 tests discovered");
+    expect(hint).toContain("[runner].command");
+    expect(hint).toContain("[affected].resolver");
+    expect(hint).toMatch(/^hint:/);
+  });
+
+  describe("isColdStartZeroTest", () => {
+    it("returns true when sampledTests is empty array", () => {
+      const result = { runResult: { sampledTests: [] } };
+      expect(isColdStartZeroTest(result)).toBe(true);
+    });
+
+    it("returns false when sampledTests has entries", () => {
+      const result = { runResult: { sampledTests: [{ suite: "foo.test.ts", testName: "bar" }] } };
+      expect(isColdStartZeroTest(result)).toBe(false);
+    });
+
+    it("returns false when result is null", () => {
+      expect(isColdStartZeroTest(null)).toBe(false);
+    });
+
+    it("returns false when runResult is missing", () => {
+      expect(isColdStartZeroTest({})).toBe(false);
+    });
+
+    it("returns false when sampledTests is not an array", () => {
+      const result = { runResult: { sampledTests: null } };
+      expect(isColdStartZeroTest(result)).toBe(false);
+    });
+  });
+});

--- a/tests/cli/deprecation-blanket.test.ts
+++ b/tests/cli/deprecation-blanket.test.ts
@@ -23,8 +23,6 @@ const cases: Array<{ cmd: string[]; canonical: string }> = [
   { cmd: ["exec", "run"], canonical: "flaker run" },
   // exec affected → flaker run --gate iteration --changed <paths>
   { cmd: ["exec", "affected"], canonical: "flaker run" },
-  // ops daily → flaker apply
-  { cmd: ["ops", "daily"], canonical: "flaker apply" },
   // collect (bare) → flaker apply
   { cmd: ["collect"], canonical: "flaker apply" },
   // collect ci → flaker apply

--- a/tests/cli/init-profile-defaults.test.ts
+++ b/tests/cli/init-profile-defaults.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const CLI = resolve(__filename, "../../../dist/cli/main.js");
+
+describe("flaker init generates [profile.*] defaults", () => {
+  it("writes [profile.local] / [profile.ci] / [profile.scheduled] with sensible strategies", () => {
+    const dir = mkdtempSync(join(tmpdir(), "flaker-init-"));
+    try {
+      const res = spawnSync("node", [CLI, "init", "--owner", "o", "--name", "r", "--adapter", "playwright", "--runner", "playwright"], {
+        cwd: dir,
+        encoding: "utf8",
+      });
+      expect(res.status).toBe(0);
+      const toml = readFileSync(join(dir, "flaker.toml"), "utf8");
+      expect(toml).toContain("[profile.local]");
+      expect(toml).toContain('strategy = "affected"');
+      expect(toml).toContain("[profile.ci]");
+      expect(toml).toMatch(/\[profile\.ci\][\s\S]*strategy = "hybrid"/);
+      expect(toml).toContain("[profile.scheduled]");
+      expect(toml).toMatch(/\[profile\.scheduled\][\s\S]*strategy = "full"/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/cli/ops-daily-not-deprecated.test.ts
+++ b/tests/cli/ops-daily-not-deprecated.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const CLI = resolve(__filename, "../../../dist/cli/main.js");
+
+describe("ops daily is Advanced, not Deprecated", () => {
+  it("`flaker ops daily --help` stderr has no deprecation warning", () => {
+    const res = spawnSync("node", [CLI, "ops", "daily", "--help"], { encoding: "utf8" });
+    expect(res.status).toBe(0);
+    expect(res.stderr).not.toContain("deprecated");
+  });
+
+  it("top-level --help lists `ops` under Advanced, not Deprecated", () => {
+    const res = spawnSync("node", [CLI, "--help"], { encoding: "utf8" });
+    const stdout = res.stdout;
+    const advancedStart = stdout.indexOf("Advanced:");
+    const deprecatedStart = stdout.indexOf("Deprecated (removed in 0.8.0)");
+    expect(advancedStart).toBeGreaterThan(-1);
+    expect(deprecatedStart).toBeGreaterThan(advancedStart);
+    const deprecatedBlock = stdout.slice(deprecatedStart);
+    expect(deprecatedBlock).not.toMatch(/^\s+ops daily\b/m);
+  });
+});

--- a/tests/cli/version-single-line.test.ts
+++ b/tests/cli/version-single-line.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const CLI = resolve(__filename, "../../../dist/cli/main.js");
+
+describe("flaker --version outputs a single line", () => {
+  it("stdout has exactly one non-empty line matching the semver form", () => {
+    const res = spawnSync("node", [CLI, "--version"], { encoding: "utf8" });
+    expect(res.status).toBe(0);
+    const lines = res.stdout.split("\n").filter((l) => l.trim().length > 0);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatch(/^\d+\.\d+\.\d+(-[\w.]+)?$/);
+    expect(res.stdout).not.toContain("flaker core CLI");
+  });
+
+  it("stderr does not contain the moonbit banner", () => {
+    const res = spawnSync("node", [CLI, "--version"], { encoding: "utf8" });
+    expect(res.stderr).not.toContain("flaker core CLI");
+  });
+});

--- a/tests/commands/check.test.ts
+++ b/tests/commands/check.test.ts
@@ -10,8 +10,8 @@ import {
 } from "../../src/cli/commands/policy/check.js";
 
 describe("check command", () => {
-  it("detects duplicate ownership, allows filtered split ownership, and reports unmanaged specs", () => {
-    const report = runConfigCheck({
+  it("detects duplicate ownership, allows filtered split ownership, and reports unmanaged specs", async () => {
+    const report = await runConfigCheck({
       listedTests: [
         {
           suite: "tests/auth/login.spec.ts",
@@ -167,8 +167,8 @@ describe("check command", () => {
     }
   });
 
-  it("appends threshold unit warnings to the report", () => {
-    const base = runConfigCheck({
+  it("appends threshold unit warnings to the report", async () => {
+    const base = await runConfigCheck({
       listedTests: [],
       discoveredSpecs: [],
       taskDefinitions: [],

--- a/tests/commands/report.test.ts
+++ b/tests/commands/report.test.ts
@@ -36,8 +36,8 @@ const vrtBenchFixture = readFileSync(
 );
 
 describe("report summarize", () => {
-  it("normalizes playwright report into totals, file summaries, and unstable tests", () => {
-    const summary = runReportSummarize({
+  it("normalizes playwright report into totals, file summaries, and unstable tests", async () => {
+    const summary = await runReportSummarize({
       adapter: "playwright",
       input: playwrightFixture,
     });
@@ -78,8 +78,8 @@ describe("report summarize", () => {
     expect(markdown).toContain("should redirect after login");
   });
 
-  it("normalizes junit report into the same summary shape", () => {
-    const summary = runReportSummarize({
+  it("normalizes junit report into the same summary shape", async () => {
+    const summary = await runReportSummarize({
       adapter: "junit",
       input: junitFixture,
     });
@@ -112,8 +112,8 @@ describe("report summarize", () => {
     ]);
   });
 
-  it("normalizes vrt migration reports into the same summary shape", () => {
-    const summary = runReportSummarize({
+  it("normalizes vrt migration reports into the same summary shape", async () => {
+    const summary = await runReportSummarize({
       adapter: "vrt-migration",
       input: vrtMigrationFixture,
     });
@@ -143,8 +143,8 @@ describe("report summarize", () => {
     ]);
   });
 
-  it("normalizes vrt bench reports into the same summary shape", () => {
-    const summary = runReportSummarize({
+  it("normalizes vrt bench reports into the same summary shape", async () => {
+    const summary = await runReportSummarize({
       adapter: "vrt-bench",
       input: vrtBenchFixture,
     });
@@ -176,8 +176,8 @@ describe("report summarize", () => {
 });
 
 describe("report diff", () => {
-  it("classifies regressions, improvements, and persistent flaky tests", () => {
-    const base = summarizeResults(
+  it("classifies regressions, improvements, and persistent flaky tests", async () => {
+    const base = await summarizeResults(
       [
         resolveTestIdentity({
           suite: "tests/app.spec.ts",
@@ -211,7 +211,7 @@ describe("report diff", () => {
       "playwright",
     );
 
-    const head = summarizeResults(
+    const head = await summarizeResults(
       [
         resolveTestIdentity({
           suite: "tests/app.spec.ts",
@@ -259,7 +259,7 @@ describe("report diff", () => {
       "playwright",
     );
 
-    const diff = runReportDiff({ base, head });
+    const diff = await runReportDiff({ base, head });
 
     expect(diff.summary).toMatchObject({
       newFailureCount: 1,
@@ -308,62 +308,59 @@ describe("report diff", () => {
 });
 
 describe("report aggregate", () => {
-  it("aggregates shard bundles and preserves shard metadata", () => {
-    const shardA = createReportSummaryArtifact(
-      summarizeResults(
-        [
-          resolveTestIdentity({
-            suite: "tests/vrt.spec.ts",
-            testName: "renders header",
-            taskId: "vrt",
-            status: "passed",
-            durationMs: 10,
-            retryCount: 0,
-          }),
-          resolveTestIdentity({
-            suite: "tests/vrt.spec.ts",
-            testName: "renders footer",
-            taskId: "vrt",
-            status: "failed",
-            durationMs: 20,
-            retryCount: 0,
-          }),
-        ],
-        "playwright",
-      ),
-      {
-        shard: "shard-1",
-        module: "vrt",
-        offset: 0,
-        limit: 50,
-        matrix: { os: "ubuntu-latest" },
-        extra: { browser: "chromium" },
-      },
+  it("aggregates shard bundles and preserves shard metadata", async () => {
+    const shardASummary = await summarizeResults(
+      [
+        resolveTestIdentity({
+          suite: "tests/vrt.spec.ts",
+          testName: "renders header",
+          taskId: "vrt",
+          status: "passed",
+          durationMs: 10,
+          retryCount: 0,
+        }),
+        resolveTestIdentity({
+          suite: "tests/vrt.spec.ts",
+          testName: "renders footer",
+          taskId: "vrt",
+          status: "failed",
+          durationMs: 20,
+          retryCount: 0,
+        }),
+      ],
+      "playwright",
     );
-    const shardB = createReportSummaryArtifact(
-      summarizeResults(
-        [
-          resolveTestIdentity({
-            suite: "tests/vrt.spec.ts",
-            testName: "renders card",
-            taskId: "vrt",
-            status: "flaky",
-            durationMs: 30,
-            retryCount: 1,
-          }),
-        ],
-        "playwright",
-      ),
-      {
-        shard: "shard-2",
-        module: "vrt",
-        offset: 50,
-        limit: 50,
-        matrix: { os: "ubuntu-latest" },
-      },
-    );
+    const shardA = createReportSummaryArtifact(shardASummary, {
+      shard: "shard-1",
+      module: "vrt",
+      offset: 0,
+      limit: 50,
+      matrix: { os: "ubuntu-latest" },
+      extra: { browser: "chromium" },
+    });
 
-    const aggregate = runReportAggregate({
+    const shardBSummary = await summarizeResults(
+      [
+        resolveTestIdentity({
+          suite: "tests/vrt.spec.ts",
+          testName: "renders card",
+          taskId: "vrt",
+          status: "flaky",
+          durationMs: 30,
+          retryCount: 1,
+        }),
+      ],
+      "playwright",
+    );
+    const shardB = createReportSummaryArtifact(shardBSummary, {
+      shard: "shard-2",
+      module: "vrt",
+      offset: 50,
+      limit: 50,
+      matrix: { os: "ubuntu-latest" },
+    });
+
+    const aggregate = await runReportAggregate({
       summaries: [shardA, shardB],
     });
 
@@ -421,7 +418,7 @@ describe("report aggregate", () => {
     expect(markdown).toContain("meta:browser=chromium");
   });
 
-  it("merges unstable tests across shards by stable test id", () => {
+  it("merges unstable tests across shards by stable test id", async () => {
     const repeated = resolveTestIdentity({
       suite: "tests/vrt.spec.ts",
       testName: "renders card",
@@ -430,16 +427,12 @@ describe("report aggregate", () => {
       durationMs: 30,
       retryCount: 1,
     });
-    const shardA = createReportSummaryArtifact(
-      summarizeResults([{ ...repeated, status: "failed" }], "playwright"),
-      { shard: "shard-1" },
-    );
-    const shardB = createReportSummaryArtifact(
-      summarizeResults([{ ...repeated, status: "flaky" }], "playwright"),
-      { shard: "shard-2" },
-    );
+    const shardASummary = await summarizeResults([{ ...repeated, status: "failed" }], "playwright");
+    const shardA = createReportSummaryArtifact(shardASummary, { shard: "shard-1" });
+    const shardBSummary = await summarizeResults([{ ...repeated, status: "flaky" }], "playwright");
+    const shardB = createReportSummaryArtifact(shardBSummary, { shard: "shard-2" });
 
-    const aggregate = runReportAggregate({
+    const aggregate = await runReportAggregate({
       summaries: [shardB, shardA],
     });
 
@@ -456,10 +449,10 @@ describe("report aggregate", () => {
     ]);
   });
 
-  it("loads plain summaries and bundle artifacts from a directory", () => {
+  it("loads plain summaries and bundle artifacts from a directory", async () => {
     const cwd = mkdtempSync(join(tmpdir(), "report-aggregate-"));
     try {
-      const plainSummary = summarizeResults(
+      const plainSummary = await summarizeResults(
         [
           resolveTestIdentity({
             suite: "tests/plain.spec.ts",
@@ -471,21 +464,22 @@ describe("report aggregate", () => {
         ],
         "junit",
       );
-      const bundledSummary = createReportSummaryArtifact(
-        summarizeResults(
-          [
-            resolveTestIdentity({
-              suite: "tests/bundled.spec.ts",
-              testName: "bundled test",
-              status: "failed",
-              durationMs: 7,
-              retryCount: 0,
-            }),
-          ],
-          "playwright",
-        ),
-        { shard: "bundle-a", module: "ui" },
+      const bundledSummarySrc = await summarizeResults(
+        [
+          resolveTestIdentity({
+            suite: "tests/bundled.spec.ts",
+            testName: "bundled test",
+            status: "failed",
+            durationMs: 7,
+            retryCount: 0,
+          }),
+        ],
+        "playwright",
       );
+      const bundledSummary = createReportSummaryArtifact(bundledSummarySrc, {
+        shard: "bundle-a",
+        module: "ui",
+      });
 
       writeFileSync(
         join(cwd, "plain-summary.json"),

--- a/tests/quarantine-manifest.test.ts
+++ b/tests/quarantine-manifest.test.ts
@@ -6,10 +6,11 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
   formatQuarantineManifestReport,
   isManifestQuarantined,
+  loadQuarantineBridge,
   loadQuarantineManifest,
   validateQuarantineManifest,
   type QuarantineManifestEntry,
@@ -29,6 +30,10 @@ function writeManifest(
 
 describe("quarantine manifest", () => {
   const tempDirs: string[] = [];
+
+  beforeAll(async () => {
+    await loadQuarantineBridge();
+  });
 
   afterEach(() => {
     for (const dir of tempDirs.splice(0)) {

--- a/tests/reporting/flaker-quarantine-summary-core.test.ts
+++ b/tests/reporting/flaker-quarantine-summary-core.test.ts
@@ -3,7 +3,7 @@ import { parseFlakerQuarantine } from "../../src/cli/reporting/flaker-quarantine
 import { buildFlakerQuarantineSummary } from "../../src/cli/reporting/flaker-quarantine-summary-core.js";
 
 describe("buildFlakerQuarantineSummary", () => {
-  it("validates ownership, expiry, and missing specs from prepared inputs", () => {
+  it("validates ownership, expiry, and missing specs from prepared inputs", async () => {
     const quarantine = parseFlakerQuarantine(`
 {
   "schemaVersion": 1,
@@ -51,7 +51,7 @@ describe("buildFlakerQuarantineSummary", () => {
 }
 `);
 
-    const summary = buildFlakerQuarantineSummary({
+    const summary = await buildFlakerQuarantineSummary({
       quarantine,
       tasks: [
         {


### PR DESCRIPTION
## Summary

Phase 2 of the 0.7.0 surface reduction plan. Brings the skills, docs, and minor CLI fixes in line with the 10-command primary surface shipped in PR #51 (Phase 1), and cuts the 0.7.0 release.

## What changed

### Minor CLI fixes (found by Phase 1 E2E testing)
- `flaker --version` now prints a single line (was leaking `flaker core CLI 0.1.0 (js)` via an eager moonbit bridge import at module load). 7 module-level awaits across the codebase converted to cached lazy loaders.
- `flaker init` now writes `[profile.local]` / `[profile.ci]` / `[profile.scheduled]` defaults so the generated `flaker.toml` works with gate-mapped execution out of the box.
- `flaker apply` prints actionable stderr hints when the plan is empty (`run flaker status to inspect current health`) or when cold-start discovers 0 tests (`check [runner].command and [affected].resolver`).
- `flaker ops daily` is no longer deprecated (the Phase 1 deprecation was aspirational — apply doesn't emit the daily artifact yet). Restored as Advanced.

### Skills rewritten
- `flaker-setup` and `flaker-management` now target the 0.7.0 surface: Day 1 is `init → doctor → plan → apply → status`; daily operator loop is `apply + status`; promotion primary signal is `flaker status` drift; deprecation warnings list updated.

### Docs rewritten
- `docs/new-project-checklist.{ja,md}` unified on apply+status flow
- `docs/operations-guide.ja.md` daily loop simplified
- `README.md` Quick Start collapses Path 1/Path 2 into a single 6-command block
- `docs/usage-guide.ja.md` — flipped `flaker doctor` canonical direction (was pointing at `flaker debug doctor`; now the opposite)
- Canonical-forms table in README updated to the final 11-entry primary list

### Migration guide
- New `docs/migration-0.6-to-0.7.md` with full deprecation matrix (25 rows), upgrade recipe, and grep checklist for finding remaining deprecated usages before 0.8.0.

### Release
- Version bumped to `0.7.0` (from `0.7.0-next.0`)
- CHANGELOG expanded with all Phase 1 + Phase 2 entries under a single `## 0.7.0` section (Deprecated / New / Changed / Fixed / Docs)

## Empirical evaluation (Iter 6)

Post-Phase-2 evaluation with fresh subagents on the canonical A/B/C scenarios:

| Scenario | Result | vs Iter 5 |
|---|---|---|
| A: Day 1 Playwright setup | **○ 100%** | 92% → 100% (+8pt) |
| B: 2-week promotion decision | × 92% | ○ → × (found real doc matrix drift) |
| C: CI failure debug | ○ 100% | maintained |

Iter 6 surfaced a stale authoritative-metric reference in README.md and usage-guide.ja.md (still pointed at the deprecated `flaker gate review merge --json`). Fixed in the final commit (`6ba40c6`).

## Test plan

- [x] `pnpm test` — 172 test files, 794 passed, 1 skipped
- [x] `pnpm typecheck` — clean
- [x] `pnpm build` — clean
- [x] `flaker --version` prints one line
- [x] `flaker --help` lists 11 primary commands
- [x] `flaker init` generates `[profile.*]` defaults
- [x] `flaker apply` on a fresh tmp repo + `flaker status` both succeed
- [ ] Manual dogfood on mizchi/flaker itself before tagging 0.7.0 on npm

## Non-goals / follow-up

- `flaker apply --output daily|weekly|incident` artifact emission → 0.8.0 feature
- Actual removal of deprecated commands → 0.8.0
- `docs/how-to-use.{ja,md}` reference-table sweep → incremental (existing prose still works; deprecation warnings cover runtime misuse)