### PR TITLE
chore(release): 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 0.7.1
+
+Runner-agnostic docs fix. Resolves the Vitest/Jest overfit issue surfaced by the Iter 6.5 hold-out evaluation (closes #53).
+
+### Fixed
+
+- `flaker init` now defaults to `resolver = "simple"` instead of the misleading `"git"` alias. Both resolve to `SimpleResolver`, but `"simple"` is self-documenting. The generated TOML includes an inline comment enumerating all 5 supported resolver values.
+- Docs: `how-to-use.ja.md` Vitest example now writes `[adapter] type = "vitest"` (not `"playwright"`). The previous note claiming "vitest --reporter json is Playwright-compatible" was misleading — `vitest` is a first-class adapter.
+
+### Docs
+
+- New Jest section and JUnit XML (runner-agnostic) section in `how-to-use.ja.md`.
+- New `[runner.actrun]` examples now cover both Playwright and Vitest.
+- New runner-by-runner `flaky_tag_pattern` / `skip_flaky_tagged` behavior matrix: `@flaky` grep is Playwright-only. For Vitest and Jest, `skip_flaky_tagged = true` is a documented no-op; workarounds (`test.skipIf`, `--testNamePattern`) are listed.
+- Unified resolver selection table across `how-to-use.ja.md` and `new-project-checklist.ja.md`: all 5 values (`simple` / `workspace` / `glob` / `bitflow` / `moon`) with usage guidance. `git` documented as alias of `simple`.
+- `vitest run --reporter=json --outputFile=report.json` → `flaker import <file>` / `flaker report <file> --summary --adapter vitest` flow now documented end-to-end.
+
+### Evaluation
+
+Iter 6.5 hold-out scenario (Vitest single-package library) re-ran against the updated docs:
+
+- **Accuracy**: 42% → **91.7%** (+49.7pt)
+- **[critical] 1 (Vitest flaker.toml)**: 部分的 → ○
+- **[critical] 2 (resolver selection)**: 部分的 → ○
+
+Target was ≥82% (Iter 6 A/B/C average − 15pt); cleared by 9.7pt. Overfit resolved.
+
 ## 0.7.0
 
 ### Deprecated (removed in 0.8.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mizchi/flaker",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Flaky test detection, sampling, and test runner orchestration",
   "type": "module",
   "bin": {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -43,7 +43,7 @@ export function createProgram(): Command {
   program
     .name("flaker")
     .description("Intelligent test selection — run fewer tests, catch more failures")
-    .version("0.7.0")
+    .version("0.7.1")
     .showHelpAfterError()
     .showSuggestionAfterError();
 


### PR DESCRIPTION
## Summary

Release 0.7.1 — runner-agnostic docs fix. Resolves #53.

## Iter 6.5 hold-out evaluation

Vitest single-package library scenario re-ran against the updated docs (after PR #54 landed):

| | 0.7.0 | 0.7.1 |
|---|---|---|
| Accuracy | 42% | **91.7%** |
| [critical] 1 (Vitest flaker.toml) | 部分的 | ○ |
| [critical] 2 (resolver selection) | 部分的 | ○ |

+49.7pt. Target was ≥82% (Iter 6 A/B/C avg − 15pt); cleared by 9.7pt. Overfit resolved.

## Diff

- `package.json` / `src/cli/main.ts` — version 0.7.0 → 0.7.1
- `CHANGELOG.md` — 0.7.1 section with Fixed / Docs / Evaluation subsections

## Test plan
- [x] `pnpm build` clean
- [x] `pnpm test tests/cli/version*` — 3/3 pass (version string end-to-end)
- [ ] After merge: tag `v0.7.1` and npm publish (manual, or release-please picks it up)