### PR TITLE
fix: 0.10.2 — queryFlakyTests deterministic window (real bug, pre-existing flake)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.10.2
+
+Bug fix: `queryFlakyTests` window cutoff is now computed from a caller-supplied `now` (or wall clock) in JS, not from DuckDB's `CURRENT_TIMESTAMP`. Resolves a timezone-dependent flake that surfaced as a failing `tests/commands/ops-daily.test.ts` whenever wall clock advanced past the test's injected `now`.
+
+### Fixed
+
+- `DuckDBStore.queryFlakyTests(opts)` accepts a new optional `opts.now?: Date` parameter. The SQL `FLAKY_QUERY` now takes a pre-computed cutoff literal instead of `CURRENT_TIMESTAMP - INTERVAL (? || ' days')`. Same behavior at wall clock; deterministic under test injection.
+- `runQuarantineSuggest({ now })` threads `now` through to `queryFlakyTests`, so `runOpsDaily({ now, windowDays })` is fully deterministic end-to-end.
+
+### Impact
+
+Production users see no behavior change — the default path uses `new Date()` as the reference time. Tests that inject `now: new Date("2026-04-19T00:00:00Z")` and run later than that now correctly pick up test data within their configured window. The previous behavior silently dropped test data older than the wall-clock window.
+
+### Known limitations
+
+Other `queryFlakyTests` / `queryTestCoFailures` call sites in `src/cli/commands/analyze/*.ts` and `src/cli/commands/policy/quarantine.ts` still use the wall-clock default. They're production code paths where `now` isn't meaningful; left alone to scope the patch. If determinism becomes needed in those paths, extend them with the same `now?` parameter.
+
 ## 0.10.1
 
 Docs patch (closes #60). No code changes.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mizchi/flaker",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Flaky test detection, sampling, and test runner orchestration",
   "type": "module",
   "bin": {

--- a/src/cli/commands/quarantine/suggest.ts
+++ b/src/cli/commands/quarantine/suggest.ts
@@ -89,7 +89,7 @@ export async function runQuarantineSuggest(input: {
   const minRuns = input.minRuns ?? 5;
 
   const [flaky, quarantined] = await Promise.all([
-    input.store.queryFlakyTests({ windowDays }),
+    input.store.queryFlakyTests({ windowDays, now: input.now }),
     input.store.queryQuarantined(),
   ]);
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -32,7 +32,7 @@ export function createProgram(): Command {
   program
     .name("flaker")
     .description("Intelligent test selection — run fewer tests, catch more failures")
-    .version("0.10.1")
+    .version("0.10.2")
     .showHelpAfterError()
     .showSuggestionAfterError();
 

--- a/src/cli/storage/duckdb.ts
+++ b/src/cli/storage/duckdb.ts
@@ -250,7 +250,11 @@ export class DuckDBStore implements MetricStore {
 
   async queryFlakyTests(opts: FlakyQueryOpts): Promise<FlakyScore[]> {
     const windowDays = opts.windowDays ?? 30;
-    const rows = await this.all(FLAKY_QUERY, [windowDays.toString()]);
+    const now = opts.now ?? new Date();
+    const cutoff = new Date(now.getTime() - windowDays * 24 * 60 * 60 * 1000);
+    // ISO 8601 trimmed to DuckDB TIMESTAMP shape (YYYY-MM-DD HH:MM:SS.sss)
+    const cutoffLiteral = cutoff.toISOString().replace("T", " ").replace("Z", "");
+    const rows = await this.all(FLAKY_QUERY, [cutoffLiteral]);
     return rows.map((row: any) => {
       const resolved = resolveTestIdentity({
         suite: row.suite,

--- a/src/cli/storage/schema.ts
+++ b/src/cli/storage/schema.ts
@@ -240,7 +240,7 @@ ORDER BY
 export const FLAKY_QUERY = `
 WITH recent AS (
   SELECT * FROM test_results
-  WHERE created_at > CURRENT_TIMESTAMP - INTERVAL (? || ' days')
+  WHERE created_at > ?::TIMESTAMP
 )
 SELECT
   COALESCE(test_id, '') AS test_id,

--- a/src/cli/storage/types.ts
+++ b/src/cli/storage/types.ts
@@ -100,6 +100,8 @@ export interface FlakyQueryOpts {
   suite?: string;
   testName?: string;
   windowDays?: number;
+  /** Reference time for the window cutoff. Defaults to the wall clock; set for deterministic queries in tests or multi-timezone contexts. */
+  now?: Date;
 }
 
 export interface TestSelector extends TestIdentityFields {


### PR DESCRIPTION
## Summary

Fix the pre-existing \`tests/commands/ops-daily.test.ts\` failure that was tracked as "unrelated flake" through the entire 0.6→0.10.1 session. Turns out to be a **real bug**, not a flake.

## Root cause

\`FLAKY_QUERY\` in \`src/cli/storage/schema.ts\` used \`CURRENT_TIMESTAMP - INTERVAL (? || ' days')\` as the window cutoff. DuckDB \`TIMESTAMP\` columns are timezone-unaware; \`CURRENT_TIMESTAMP\` returns a timezone-aware value. Comparison across the timezone boundary produced an off-by-hours cutoff.

Concrete scenario (probe captured earlier this session):

\`\`\`
inserted created_at   = 2026-04-19 00:00:00  (TIMESTAMP, treated as local)
CURRENT_TIMESTAMP     = 2026-04-20 00:51:01.638734+09 (JST)
CURRENT_TIMESTAMP - 1 = 2026-04-19 00:51:01.638734+09 (JST)
→ 2026-04-19 00:00:00 (local) is treated as JST → 00:00 < 00:51 → filtered out
\`\`\`

Wall clock advanced past the test's injected \`now\` by less than \`windowDays * 24h\` but with JST/UTC skew that still pushed the data out.

## Fix

\`queryFlakyTests({ windowDays, now? })\` computes the cutoff in JS and passes it as a \`TIMESTAMP\` literal. Default \`now = new Date()\` preserves production behavior.

\`runQuarantineSuggest({ now })\` threads the parameter to \`queryFlakyTests\`, so \`runOpsDaily({ now, windowDays })\` is deterministic end-to-end — \`now\` finally reaches the SQL.

## Test plan

- [x] \`pnpm test tests/commands/ops-daily.test.ts\` — passes for the first time this session
- [x] \`pnpm test\` — **820 passed, 1 skipped, 0 failed** (was 1 failed since session start)
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm build\` — clean

## Known limitations

Other \`queryFlakyTests\` callers in \`src/cli/commands/analyze/*.ts\` and \`src/cli/commands/policy/quarantine.ts\` still use the wall-clock default. Those are production code paths where \`now\` injection isn't meaningful; out of scope for this patch.