### PR TITLE
chore(release): 0.10.3 — EN Vitest adapter correction + SQL audit findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.10.3
+
+Docs patch + Tier-1 audit results.
+
+### Docs
+
+- `docs/how-to-use.md` Vitest adapter example now writes `type = "vitest"` (was `"playwright"` with a misleading "vitest --reporter json is Playwright-compatible" comment). JA was corrected in 0.7.1; EN parallel fix was missed until now. Also adds the `vitest run --reporter=json --outputFile=report.json` incantation alongside `flaker import`.
+
+### Audit surfaced but deferred
+
+- ~20 other SQL sites (`CO_FAILURE_QUERY`, status activity query, analyze/{bundle,context,eval,insights,kpi}.ts) still use `CURRENT_TIMESTAMP - INTERVAL`, the same pattern 0.10.2 fixed in `FLAKY_QUERY`. Tests currently pass because window sizes are generous; latent bug tracked as #64 for a future minor.
+
 ## 0.10.2
 
 Bug fix: `queryFlakyTests` window cutoff is now computed from a caller-supplied `now` (or wall clock) in JS, not from DuckDB's `CURRENT_TIMESTAMP`. Resolves a timezone-dependent flake that surfaced as a failing `tests/commands/ops-daily.test.ts` whenever wall clock advanced past the test's injected `now`.

--- a/docs/how-to-use.md
+++ b/docs/how-to-use.md
@@ -594,12 +594,14 @@ Defaults emitted by `flaker init --adapter <type> --runner <type>` are shown bel
 
 ```toml
 [adapter]
-type = "playwright"    # vitest --reporter json is Playwright-compatible
+type = "vitest"
 
 [runner]
 type = "vitest"
 command = "pnpm exec vitest run"
 ```
+
+To feed Vitest JSON reports into `flaker import <file>`, generate them with `vitest run --reporter=json --outputFile=report.json`. `flaker report <file> --summary --adapter vitest` takes the same JSON input.
 
 ### Playwright Test
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mizchi/flaker",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Flaky test detection, sampling, and test runner orchestration",
   "type": "module",
   "bin": {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -32,7 +32,7 @@ export function createProgram(): Command {
   program
     .name("flaker")
     .description("Intelligent test selection — run fewer tests, catch more failures")
-    .version("0.10.2")
+    .version("0.10.3")
     .showHelpAfterError()
     .showSuggestionAfterError();
 


### PR DESCRIPTION
## Summary

Tier-1 follow-up from the \"Other things to manage\" triage:

- **T1-3 (shipped)**: EN \`docs/how-to-use.md\` Vitest adapter example corrected from \`type = "playwright"\` to \`type = "vitest"\`. JA was fixed in 0.7.1; EN parallel fix was missed until now.
- **T1-1 (documented)**: wall-clock SQL audit — 20+ \`CURRENT_TIMESTAMP - INTERVAL\` sites across \`analyze/*.ts\`, \`status/summary.ts\`, and \`storage/schema.ts\`. Same latent bug class 0.10.2 fixed. No current test failures (window sizes generous enough). Tracked in #64.
- **T1-2 (nothing to ship)**: hardcoded \`new Date("2026-04-19...")\` in tests — 820 passing; these will fail as wall clock advances, but refactoring them is scope-coupled with #64 (tests need deterministic SQL to benefit).

## Test plan
- [x] \`pnpm test\` — 176 files, 820 passed, 1 skipped, 0 failed
- [x] \`pnpm typecheck\` / \`pnpm build\` clean

## After merge
- Tag v0.10.3 + publish (docs-only release)
- #64 remains open for 0.11.0 or later

## Why not batch T1-1 into this patch

The audit turned up ~20 queries + ~7 caller chains needing \`now?: Date\` threading. That's a minor-release refactor, not a patch. See #64 for the full surface.