### PR TITLE
fix(git): resolveCommitChanges handles merge commits (0.10.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.10.6
+
+Bug fix: `resolveCommitChanges` now returns the changed files for merge commits.
+
+### Fixed
+
+- `src/cli/core/git.ts`: `resolveCommitChanges` invokes `git diff-tree -m --first-parent --no-commit-id --name-status -r <sha>` instead of omitting `-m --first-parent`. Previously, calling it with a merge commit's SHA (common after GitHub "Merge pull request" lands) returned an empty array, making `collectCommitChanges` appear to succeed with 0 files. `publish.yml` was failing because `tests/commands/collect-commit-changes.test.ts` and `tests/core/git-diff-tree.test.ts` run against the CI HEAD, which for tag-triggered builds is the merge commit. `--first-parent` keeps non-merge commits behaving identically.
+
 ## 0.10.5
 
 Rebrand cleanup. Resolves the three deferred items from 0.10.4.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mizchi/flaker",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Flaky test detection, sampling, and test runner orchestration",
   "type": "module",
   "bin": {

--- a/src/cli/core/git.ts
+++ b/src/cli/core/git.ts
@@ -38,7 +38,7 @@ export function resolveCommitChanges(cwd: string, commitSha: string): CommitChan
   try {
     const result = spawnSync(
       "git",
-      ["diff-tree", "--no-commit-id", "--name-status", "-r", commitSha],
+      ["diff-tree", "-m", "--first-parent", "--no-commit-id", "--name-status", "-r", commitSha],
       { cwd, stdio: ["ignore", "pipe", "ignore"] },
     );
     if (result.status !== 0) return null;

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -32,7 +32,7 @@ export function createProgram(): Command {
   program
     .name("flaker")
     .description("Intelligent test selection — run fewer tests, catch more failures")
-    .version("0.10.5")
+    .version("0.10.6")
     .showHelpAfterError()
     .showSuggestionAfterError();
 


### PR DESCRIPTION
## Summary
- \`git diff-tree --no-commit-id --name-status -r <sha>\` emits nothing for merge commits. Tag-triggered CI (\`publish.yml\`) checks out the merge commit after a PR merges, so \`tests/commands/collect-commit-changes.test.ts\` and \`tests/core/git-diff-tree.test.ts\` have been failing on every release since 0.8.0.
- Adds \`-m --first-parent\` to the diff-tree call. Merge commits now yield the first-parent diff; non-merge commits behave identically.
- This is why \`@mizchi/flaker\` has not appeared on npm since 0.7.1 — all releases 0.8.0–0.10.5 had published tags but the CI publish step never reached \`npm publish\`.

## Test plan
- [x] Reproduced locally by running the two tests against a checked-out merge commit HEAD
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm test\` — 820 passed (1 skipped) across 176 files
- [ ] Tag v0.10.6 after merge; \`publish.yml\` should now complete and push to npm