### PR TITLE
fix(cli): canonicalize argv[1] so the CLI runs under pnpm symlinks (#76)

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { resolve } from "node:path";
+import { realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { Command } from "commander";
 import { setupInitAction } from "./commands/setup/init.js";
@@ -14,8 +14,17 @@ import { registerDevCommands } from "./categories/dev.js";
 import { registerApplyCommands } from "./categories/apply.js";
 
 function isDirectCliExecution(): boolean {
-  return process.argv[1] != null
-    && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+  if (process.argv[1] == null) return false;
+  // Both sides must be canonicalized: under pnpm's default isolated layout
+  // node_modules/.bin/flaker and node_modules/<pkg>/dist/cli/main.js are
+  // symlinks, so process.argv[1] is the symlink path while
+  // fileURLToPath(import.meta.url) is the realpath under .pnpm/. Without
+  // realpathSync on argv[1] the strings diverge and the CLI exits silently.
+  try {
+    return realpathSync(process.argv[1]) === fileURLToPath(import.meta.url);
+  } catch {
+    return false;
+  }
 }
 
 export function createProgram(): Command {

--- a/tests/package/cli-direct-execution.test.ts
+++ b/tests/package/cli-direct-execution.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Regression test for issue #76: under pnpm's default isolated layout,
+ * `node_modules/.bin/flaker` (and `node_modules/<pkg>/dist/cli/main.js`)
+ * are symlinks. The CLI's `isDirectCliExecution()` check used to compare
+ * `resolve(process.argv[1])` against `fileURLToPath(import.meta.url)`, which
+ * diverge when argv[1] is a symlink path. The CLI then exited 0 silently.
+ */
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const builtMain = resolve(repoRoot, "dist/cli/main.js");
+
+describe.skipIf(!existsSync(builtMain))("CLI entry under symlinks", () => {
+  it("emits help when invoked through a symlinked path", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "flaker-link-"));
+    try {
+      const link = join(tmp, "symlinked-main.js");
+      symlinkSync(builtMain, link);
+
+      const result = spawnSync(process.execPath, [link, "--help"], {
+        encoding: "utf8",
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("Usage: flaker");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Closes #76.

## Root cause

\`src/cli/main.ts\` gated the CLI on:

\`\`\`ts
function isDirectCliExecution(): boolean {
  return process.argv[1] != null
    && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
}
\`\`\`

Under pnpm's default isolated layout, \`node_modules/.bin/flaker\` and \`node_modules/<pkg>/dist/cli/main.js\` are both symlinks pointing into \`.pnpm/\`. Node's ESM loader returns the realpath for \`import.meta.url\` but \`process.argv[1]\` keeps whatever the launcher passed — the symlink path. The strings diverge, the gate returns false, and every subcommand exits 0 with empty stdout.

## Fix

Canonicalize \`argv[1]\` before comparing:

\`\`\`ts
function isDirectCliExecution(): boolean {
  if (process.argv[1] == null) return false;
  try {
    return realpathSync(process.argv[1]) === fileURLToPath(import.meta.url);
  } catch {
    return false;
  }
}
\`\`\`

## Why this also fixes the DuckDB error from #76

The duckdb resolution failure only appeared after users worked around the silent exit with \`NODE_OPTIONS=--preserve-symlinks-main\`. That flag tells Node to keep the symlink path as the base for ESM resolution, which then can't reach \`.pnpm/\` for native deps. With the gate fixed, no flag is required, Node uses realpath everywhere by default, and \`await import("duckdb")\` resolves correctly.

## Verified

\`\`\`
# In a fresh test project linking this branch
$ ./node_modules/.bin/flaker --help
Usage: flaker [options] [command]
...
$ ./node_modules/.bin/flaker doctor
OK  duckdb    DuckDB initialized successfully
\`\`\`

## Test

Adds \`tests/package/cli-direct-execution.test.ts\`: spawns \`node\` against a symlinked copy of \`dist/cli/main.js\` and asserts the help output appears. \`describe.skipIf\` skips when \`dist/\` isn't built so unit-test-only runs are unaffected.

## Downstream

Once this lands and is released, https://github.com/mizchi/chaosbringer/pull/25 can drop \`.npmrc\` (\`node-linker=hoisted\`) and the \`NODE_OPTIONS=--preserve-symlinks-main\` prefix on every \`flaker:*\` script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)