### PR TITLE
chore(release): 0.10.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.10.7
+
 Fix: self-host nightly + PR advisory workflows called `flaker kpi` and `flaker analyze eval`, both removed in 0.8.0 (#37). The next scheduled run would have failed at `Snapshot KPI` / `Snapshot eval`, breaking the nightly issue update.
 
 ### Added
@@ -15,6 +17,7 @@ Fix: self-host nightly + PR advisory workflows called `flaker kpi` and `flaker a
 - `.github/workflows/nightly-self-host.yml`, `.github/workflows/ci.yml`: also migrated `collect --days 30 --output X` → `apply --target collect_ci 2>&1 | tee X`, `import parquet <dir>` → `import <dir> --adapter parquet`, and `import report <file> ...` → `import <file> ...`. All three old forms were removed in 0.8.0 and were breaking the PR advisory job (first surfaced on the PR for this fix).
 - `.github/workflows/ci.yml`: the main `test` job used the default shallow checkout (`fetch-depth: 1`), making `tests/core/git-diff-tree.test.ts` / `tests/commands/collect-commit-changes.test.ts` fail 100% in CI because `git diff-tree -m --first-parent HEAD` can't reach HEAD's parent. Both tests were appearing in the self-host flaky report (#37). `fetch-depth: 0` aligns the `test` job with `self-host-advisory` / nightly, which already use full history.
 - `src/cli/commands/analyze/bundle.ts`: `flaker explain bundle` crashed with `Conversion Error: Type INT64 ... out of range for the destination type INT32` against real GitHub data because `workflow_run_id` / `artifact_id` were cast via `::INTEGER` (DuckDB INT32, max ~2.1 billion) while GitHub IDs are already in the 24-billion range. Casts are now `::BIGINT` with a `bigIntToNumber` helper that demotes safely to JS Number at the query boundary (values outside safe-integer range become null instead of silently losing precision), and `formatAnalysisBundle` uses a JSON replacer as defence in depth.
+- `src/cli/commands/analyze/flaky-tag-triage.ts`: `runFlakyTagTriage` did not propagate its `now` argument to `store.queryFlakyTests`, so the underlying flaky cutoff defaulted to `new Date()` instead of the caller's reference time. Callers like `runOpsWeekly` that pin `now` for deterministic windows silently lost any test results older than `wallclock - windowDays`, producing zero `addCandidates` whenever the data sat outside that real-time window. The cutoff now honours the caller's `now`, matching `runQuarantineSuggest`.
 
 ## 0.10.6
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mizchi/flaker",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "Flaky test detection, sampling, and test runner orchestration",
   "type": "module",
   "bin": {

--- a/src/cli/commands/analyze/flaky-tag-triage.ts
+++ b/src/cli/commands/analyze/flaky-tag-triage.ts
@@ -201,7 +201,7 @@ export async function runFlakyTagTriage(
     || a.testName.localeCompare(b.testName),
   );
 
-  const addCandidates = (await opts.store.queryFlakyTests({ windowDays: opts.windowDays }))
+  const addCandidates = (await opts.store.queryFlakyTests({ windowDays: opts.windowDays, now }))
     .filter((score) =>
       score.totalRuns >= opts.minRuns
       && score.flakyRate >= opts.addThresholdPercentage

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -41,7 +41,7 @@ export function createProgram(): Command {
   program
     .name("flaker")
     .description("Intelligent test selection — run fewer tests, catch more failures")
-    .version("0.10.6")
+    .version("0.10.7")
     .showHelpAfterError()
     .showSuggestionAfterError();
 


### PR DESCRIPTION
## Summary

- Self-host nightly + PR advisory workflows were calling `flaker kpi` and `flaker analyze eval`, both removed in 0.8.0 (#37). Migrates them to the new `dev kpi` / `dev eval` maintainer tools, plus the `apply --target collect_ci` / `import --adapter parquet` / `import <file>` migrations that the same workflows still depended on.
- Pulls in two bundle-time regressions that were sitting in `Unreleased`:
  - `flaker explain bundle` INT64→INT32 cast crash against real GitHub IDs.
  - `runFlakyTagTriage` was not propagating its `now` argument into `queryFlakyTests`, so any caller that pins `now` for a deterministic window (e.g. `runOpsWeekly`) silently lost data older than `wallclock - windowDays`. Surfaced today by `tests/commands/ops-weekly.test.ts` failing locally while CI's `Test` step (which only runs a 4-file subset) was unaffected. Cutoff now honours the caller's `now`, matching `runQuarantineSuggest`.
- Bumps `package.json`, `src/cli/main.ts` `.version("...")`, and adds the `## 0.10.7` CHANGELOG section per `docs/contributing.md`.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm test` — 178 files, 824 passed, 1 skipped (was 1 failing on `main` due to the now-fixed flaky-tag-triage bug)
- [ ] After merge: `git tag v0.10.7 <merge-sha> && git push origin v0.10.7`, then `gh release create v0.10.7`. `publish.yml` handles npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)