### PR TITLE
feat(adapters): add chaosbringer test-result adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- New `chaosbringer` test-result adapter: `flaker import <chaos-report.json> --adapter chaosbringer`. Maps each visited page to one TestCaseResult (`suite=chaosbringer:pages`, `testName=<pathname>`, status from `page.status` + errors, recovered → flaky), and each invariant violation to its own row (`suite=chaosbringer:invariants`, `taskId=<pathname>`). Lets the existing flaky / quarantine / KPI pipeline ingest chaos crawl signals as if they were ordinary test runs.
+
 ## 0.10.7
 
 Fix: self-host nightly + PR advisory workflows called `flaker kpi` and `flaker analyze eval`, both removed in 0.8.0 (#37). The next scheduled run would have failed at `Snapshot KPI` / `Snapshot eval`, breaking the nightly issue update.

--- a/src/cli/adapters/chaosbringer.ts
+++ b/src/cli/adapters/chaosbringer.ts
@@ -1,0 +1,187 @@
+import type { TestCaseResult, TestResultAdapter } from "./types.js";
+import { resolveTestIdentity } from "../identity.js";
+
+/**
+ * Adapter for chaosbringer's `CrawlReport` JSON.
+ *
+ * chaosbringer is mizchi's Playwright-based chaos crawler. Each run produces
+ * a `CrawlReport` with per-page error attribution, network/console/exception
+ * clusters, invariant violations, and (optional) coverage feedback. We map
+ * those signals into flaker's `TestCaseResult` shape so the existing flaky
+ * detector / quarantine policy / KPI pipeline can treat them like any other
+ * test source.
+ *
+ * Mapping (v1):
+ *
+ *   1. Each visited `report.pages[i]` becomes one TestCaseResult.
+ *      - suite      = `chaosbringer:pages`
+ *      - testName   = the page's URL pathname (relative to `report.baseUrl`)
+ *      - status     = "failed" when `page.status` is `error` / `timeout`,
+ *                     or when `page.errors.length > 0`; "flaky" when
+ *                     `page.status === "recovered"` (a real retry happened);
+ *                     "passed" otherwise.
+ *      - retryCount = 1 when the page was recovered, else 0.
+ *      - errorMessage = a deduped, comma-joined preview of the unique
+ *                       `error.message` strings on this page (capped at
+ *                       4 messages × 200 chars to keep the storage row
+ *                       reasonable).
+ *
+ *   2. Each `page.errors[j]` whose `type === "invariant-violation"` ALSO
+ *      becomes its own TestCaseResult so flaker can track invariant
+ *      stability over time:
+ *      - suite      = `chaosbringer:invariants`
+ *      - testName   = the invariant's `name` (chaosbringer guarantees one).
+ *      - taskId     = the URL pathname so the same invariant on different
+ *                     URLs is tracked as different tests.
+ *      - status     = "failed" (invariant violations are always failures).
+ *      - errorMessage = the violation message (already includes the
+ *                       invariant name as `[name] reason`).
+ *
+ * The chaosbringer report is pure JSON with no external attachments to
+ * collect; we leave `artifacts` / `failureLocation` null. `variant.seed`
+ * carries the chaos seed so the run is identifiable in the storage row.
+ *
+ * What we deliberately don't emit: per-error-cluster rows for
+ * console / network / exception clusters. Their fingerprints are
+ * normalised (URLs / line:col / long ids stripped) but still drift across
+ * chaosbringer versions, so using them as stable test identities ends up
+ * fragile. Page-level rollups + per-invariant rows give flaker the
+ * deterministic identities it needs without inheriting that fragility.
+ */
+
+interface ChaosbringerPageError {
+  type: string;
+  message: string;
+  url?: string;
+  invariantName?: string;
+  timestamp?: number;
+}
+
+interface ChaosbringerPageResult {
+  url: string;
+  status: "success" | "error" | "timeout" | "recovered";
+  loadTime: number;
+  errors: ChaosbringerPageError[];
+  hasErrors?: boolean;
+}
+
+interface ChaosbringerReport {
+  baseUrl: string;
+  seed: number;
+  pages: ChaosbringerPageResult[];
+}
+
+const MAX_ERROR_MESSAGES_PER_PAGE = 4;
+const MAX_ERROR_MESSAGE_CHARS = 200;
+
+function relativePath(url: string, baseUrl: string): string {
+  try {
+    const u = new URL(url);
+    const base = new URL(baseUrl);
+    if (u.origin !== base.origin) {
+      // Different origin → keep the full URL so it's traceable.
+      return url;
+    }
+    return u.pathname + u.search + u.hash;
+  } catch {
+    return url;
+  }
+}
+
+function summarizeErrorMessages(errors: ReadonlyArray<ChaosbringerPageError>): string | undefined {
+  if (errors.length === 0) return undefined;
+  const seen = new Set<string>();
+  const picked: string[] = [];
+  let droppedUnique = 0;
+  for (const error of errors) {
+    const message = (error.message ?? "").trim();
+    if (message.length === 0 || seen.has(message)) continue;
+    seen.add(message);
+    if (picked.length >= MAX_ERROR_MESSAGES_PER_PAGE) {
+      droppedUnique++;
+      continue;
+    }
+    picked.push(
+      message.length > MAX_ERROR_MESSAGE_CHARS
+        ? `${message.slice(0, MAX_ERROR_MESSAGE_CHARS)}…`
+        : message,
+    );
+  }
+  if (picked.length === 0) return undefined;
+  // Suffix counts UNIQUE messages we had to drop, not duplicates we deduped —
+  // otherwise a noisy log line would inflate the count and mislead the reader.
+  const suffix = droppedUnique > 0 ? ` (+${droppedUnique} more)` : "";
+  return picked.join(" | ") + suffix;
+}
+
+function statusOf(page: ChaosbringerPageResult): TestCaseResult["status"] {
+  if (page.status === "recovered") return "flaky";
+  if (page.status === "error" || page.status === "timeout") return "failed";
+  if (page.errors.length > 0) return "failed";
+  return "passed";
+}
+
+function pageResult(
+  page: ChaosbringerPageResult,
+  baseUrl: string,
+  seed: number,
+): TestCaseResult {
+  const status = statusOf(page);
+  const result: TestCaseResult = resolveTestIdentity({
+    suite: "chaosbringer:pages",
+    testName: relativePath(page.url, baseUrl),
+    taskId: "chaosbringer:pages",
+    status,
+    durationMs: typeof page.loadTime === "number" ? page.loadTime : 0,
+    retryCount: page.status === "recovered" ? 1 : 0,
+    variant: { source: "chaosbringer", seed: String(seed) },
+  });
+  const errorMessage = summarizeErrorMessages(page.errors);
+  if (errorMessage !== undefined) {
+    result.errorMessage = errorMessage;
+  }
+  return result;
+}
+
+function invariantViolationResults(
+  page: ChaosbringerPageResult,
+  baseUrl: string,
+  seed: number,
+): TestCaseResult[] {
+  const path = relativePath(page.url, baseUrl);
+  const out: TestCaseResult[] = [];
+  for (const error of page.errors) {
+    if (error.type !== "invariant-violation") continue;
+    const name = error.invariantName ?? "unknown-invariant";
+    const result: TestCaseResult = resolveTestIdentity({
+      suite: "chaosbringer:invariants",
+      testName: name,
+      taskId: path,
+      status: "failed",
+      durationMs: 0,
+      retryCount: 0,
+      variant: { source: "chaosbringer", seed: String(seed), url: path },
+    });
+    if (error.message) {
+      result.errorMessage = error.message;
+    }
+    out.push(result);
+  }
+  return out;
+}
+
+export const chaosbringerAdapter: TestResultAdapter = {
+  name: "chaosbringer",
+  parse(input: string): TestCaseResult[] {
+    const report = JSON.parse(input) as ChaosbringerReport;
+    if (!Array.isArray(report?.pages)) return [];
+    const baseUrl = typeof report.baseUrl === "string" ? report.baseUrl : "";
+    const seed = typeof report.seed === "number" ? report.seed : 0;
+    const out: TestCaseResult[] = [];
+    for (const page of report.pages) {
+      out.push(pageResult(page, baseUrl, seed));
+      out.push(...invariantViolationResults(page, baseUrl, seed));
+    }
+    return out;
+  },
+};

--- a/src/cli/adapters/index.ts
+++ b/src/cli/adapters/index.ts
@@ -9,6 +9,7 @@ import { tapAdapter } from "./tap.js";
 import { gotestAdapter } from "./gotest.js";
 import { cargoTestAdapter } from "./cargo.js";
 import { moontestAdapter } from "./moontest.js";
+import { chaosbringerAdapter } from "./chaosbringer.js";
 
 export function createTestResultAdapter(
   type: string,
@@ -33,6 +34,8 @@ export function createTestResultAdapter(
       return cargoTestAdapter;
     case "moontest":
       return moontestAdapter;
+    case "chaosbringer":
+      return chaosbringerAdapter;
     case "custom":
       if (!customCommand) {
         throw new Error("Custom adapter requires a command (customCommand)");

--- a/tests/adapters/chaosbringer.test.ts
+++ b/tests/adapters/chaosbringer.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import { chaosbringerAdapter } from "../../src/cli/adapters/chaosbringer.js";
+
+const SAMPLE = JSON.stringify({
+  baseUrl: "http://127.0.0.1:4173",
+  seed: 42,
+  pages: [
+    {
+      url: "http://127.0.0.1:4173/",
+      status: "success",
+      loadTime: 320,
+      errors: [],
+    },
+    {
+      url: "http://127.0.0.1:4173/dashboard",
+      status: "success",
+      loadTime: 410,
+      errors: [
+        { type: "console", message: "Failed to load resource: status 500" },
+        { type: "network", message: "/api/x - net::ERR_ABORTED" },
+        { type: "console", message: "Failed to load resource: status 500" }, // dup
+      ],
+    },
+    {
+      url: "http://127.0.0.1:4173/diagnose",
+      status: "recovered",
+      loadTime: 1500,
+      errors: [
+        { type: "console", message: "HTTP 503" },
+      ],
+    },
+    {
+      url: "http://127.0.0.1:4173/ops",
+      status: "timeout",
+      loadTime: 30000,
+      errors: [],
+    },
+    {
+      url: "http://127.0.0.1:4173/cart",
+      status: "success",
+      loadTime: 200,
+      errors: [
+        {
+          type: "invariant-violation",
+          message: "[cart-monotonic] cart count went from 3 to 1",
+          invariantName: "cart-monotonic",
+        },
+        {
+          type: "invariant-violation",
+          message: "[has-h1] no <h1>",
+          invariantName: "has-h1",
+        },
+      ],
+    },
+  ],
+});
+
+describe("chaosbringerAdapter.parse", () => {
+  it("emits one TestCaseResult per page plus one per invariant violation", () => {
+    const results = chaosbringerAdapter.parse(SAMPLE);
+    // 5 pages + 2 invariant violations on /cart = 7
+    expect(results).toHaveLength(7);
+  });
+
+  it("uses chaosbringer:pages as the suite for page-level rows", () => {
+    const results = chaosbringerAdapter.parse(SAMPLE);
+    const pageRows = results.filter((r) => r.suite === "chaosbringer:pages");
+    expect(pageRows.map((r) => r.testName)).toEqual([
+      "/",
+      "/dashboard",
+      "/diagnose",
+      "/ops",
+      "/cart",
+    ]);
+  });
+
+  it("maps page.status correctly to passed / failed / flaky", () => {
+    const results = chaosbringerAdapter.parse(SAMPLE);
+    const pages = new Map(
+      results
+        .filter((r) => r.suite === "chaosbringer:pages")
+        .map((r) => [r.testName, r] as const),
+    );
+    expect(pages.get("/")?.status).toBe("passed");
+    expect(pages.get("/dashboard")?.status).toBe("failed"); // has errors
+    expect(pages.get("/diagnose")?.status).toBe("flaky"); // recovered
+    expect(pages.get("/ops")?.status).toBe("failed"); // timeout
+    expect(pages.get("/cart")?.status).toBe("failed"); // invariant violations are errors too
+  });
+
+  it("retryCount is 1 for recovered pages, 0 otherwise", () => {
+    const results = chaosbringerAdapter.parse(SAMPLE);
+    const pages = new Map(
+      results
+        .filter((r) => r.suite === "chaosbringer:pages")
+        .map((r) => [r.testName, r] as const),
+    );
+    expect(pages.get("/diagnose")?.retryCount).toBe(1);
+    expect(pages.get("/")?.retryCount).toBe(0);
+    expect(pages.get("/dashboard")?.retryCount).toBe(0);
+  });
+
+  it("dedupes errorMessage and joins with ' | '", () => {
+    const results = chaosbringerAdapter.parse(SAMPLE);
+    const dashboard = results.find(
+      (r) => r.suite === "chaosbringer:pages" && r.testName === "/dashboard",
+    );
+    expect(dashboard?.errorMessage).toBe(
+      "Failed to load resource: status 500 | /api/x - net::ERR_ABORTED",
+    );
+  });
+
+  it("emits one chaosbringer:invariants row per violation, keyed by invariant name + URL", () => {
+    const results = chaosbringerAdapter.parse(SAMPLE);
+    const inv = results.filter((r) => r.suite === "chaosbringer:invariants");
+    expect(inv).toHaveLength(2);
+    const cartMonotonic = inv.find((r) => r.testName === "cart-monotonic");
+    expect(cartMonotonic).toBeDefined();
+    expect(cartMonotonic?.status).toBe("failed");
+    expect(cartMonotonic?.taskId).toBe("/cart");
+    expect(cartMonotonic?.errorMessage).toBe("[cart-monotonic] cart count went from 3 to 1");
+    expect(cartMonotonic?.variant).toMatchObject({ source: "chaosbringer", url: "/cart" });
+  });
+
+  it("carries the chaos seed in variant so storage rows are identifiable per run", () => {
+    const results = chaosbringerAdapter.parse(SAMPLE);
+    for (const r of results) {
+      expect(r.variant).toMatchObject({ source: "chaosbringer", seed: "42" });
+    }
+  });
+
+  it("returns [] on a report with no pages", () => {
+    expect(chaosbringerAdapter.parse(JSON.stringify({ baseUrl: "x", seed: 1, pages: [] }))).toEqual(
+      [],
+    );
+  });
+
+  it("keeps the full URL when the page is on a different origin from baseUrl", () => {
+    const report = JSON.stringify({
+      baseUrl: "http://127.0.0.1:4173",
+      seed: 1,
+      pages: [{ url: "https://external.example.com/foo", status: "success", loadTime: 100, errors: [] }],
+    });
+    const [row] = chaosbringerAdapter.parse(report);
+    expect(row.testName).toBe("https://external.example.com/foo");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `chaosbringer` to `createTestResultAdapter` so chaos crawl reports flow into flaker via `flaker import <chaos-report.json> --adapter chaosbringer`.
- Maps each visited page to one TestCaseResult (`suite=chaosbringer:pages`, `testName=<pathname>`, status from `page.status` + errors, recovered → `flaky` with `retryCount=1`); each invariant violation gets its own row (`suite=chaosbringer:invariants`, `taskId=<pathname>`) so the same invariant on different URLs stays separable.
- Carries the chaos seed in `variant.seed` so storage rows are identifiable per run.
- 9 unit tests cover the shape mapping, dedup behaviour, the dropped-vs-deduped suffix, the recovered → flaky path, and the off-origin-URL fallback.
- End-to-end smoke tested against a real chaos report from sample-webapp-2026 (\`flaker import dogfood-feedback.json --adapter chaosbringer\` → \`Imported 1 test results\`).

## Why

chaosbringer's \`CrawlReport\` is a natural fit for flaker's flaky / quarantine / KPI pipeline — each chaos run produces a deterministic per-page outcome plus optional invariant violations, both of which behave like test results that drift over time. Right now the only way to feed chaos signals back into flaker is to translate the JSON manually. This adapter closes the loop: chaosbringer detects flakiness in the wild → flaker tracks per-URL / per-invariant stability across runs → existing quarantine / KPI machinery just works.

## Design notes

- Page-level rollups + per-invariant rows give flaker the deterministic test identities it needs.
- Per-error-cluster rows for console / network / exception are deliberately NOT emitted — fingerprints are normalised but still drift across chaosbringer versions, and using them as stable test identities would be fragile.
- The errorMessage \`(+N more)\` suffix counts UNIQUE messages we had to drop, not duplicates we deduped. The first cut conflated them and over-reported; the test \`dedupes errorMessage and joins with ' | '\` exists specifically to lock that in.

## Test plan

- [x] \`pnpm vitest run tests/adapters/chaosbringer.test.ts\` — 9 unit tests passing.
- [x] \`pnpm tsc --noEmit\` — clean.
- [x] \`pnpm vitest run\` — 179 files / 833 tests passing (was 178 / 824, +9 new).
- [x] End-to-end: \`pnpm run build && node dist/cli/main.js import <real-chaos-report.json> --adapter chaosbringer --commit smoke-001 --branch dogfood\` → \`Imported 1 test results\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)