### PR TITLE
chore(release): 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+## 0.11.1
+
+Patch follow-up to 0.11.0 — version-string only.
+
+### Fixed
+
+- `src/cli/main.ts`: the bundled CLI's `.version("0.10.7")` string was not bumped during the 0.11.0 release, so `flaker --version` on `@mizchi/flaker@0.11.0` reported `0.10.7`. Now reports `0.11.1`.
+
+## 0.11.0
+
+Minor release — `feat:` change ships a new public adapter.
+
 ### Added
 
 - New `chaosbringer` test-result adapter: `flaker import <chaos-report.json> --adapter chaosbringer`. Maps each visited page to one TestCaseResult (`suite=chaosbringer:pages`, `testName=<pathname>`, status from `page.status` + errors, recovered → flaky), and each invariant violation to its own row (`suite=chaosbringer:invariants`, `taskId=<pathname>`). Lets the existing flaky / quarantine / KPI pipeline ingest chaos crawl signals as if they were ordinary test runs.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mizchi/flaker",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Flaky test detection, sampling, and test runner orchestration",
   "type": "module",
   "bin": {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -41,7 +41,7 @@ export function createProgram(): Command {
   program
     .name("flaker")
     .description("Intelligent test selection — run fewer tests, catch more failures")
-    .version("0.10.7")
+    .version("0.11.1")
     .showHelpAfterError()
     .showSuggestionAfterError();
 


### PR DESCRIPTION
## Summary

Patch follow-up to 0.11.0 — version-string only.

The 0.11.0 release shipped the new chaosbringer test-result adapter (#79) but skipped two cosmetic bumps:

- \`src/cli/main.ts\` still hard-coded \`.version("0.10.7")\` from the prior release, so \`@mizchi/flaker@0.11.0\`'s bundled CLI reports \`0.10.7\` for \`flaker --version\`. Caused real confusion when debugging the chaosbringer-side \`pnpm flaker:*\` silent-no-op bug (chaosbringer#34) — the version output didn't match the npm tag, so it took an extra round trip to confirm the right module was loaded.
- \`CHANGELOG.md\` left the chaosbringer adapter entry under the \`## Unreleased\` heading instead of moving it under \`## 0.11.0\`.

This PR retroactively documents 0.11.0 in CHANGELOG and ships a 0.11.1 patch whose only behavioural change is \`flaker --version\` now reporting \`0.11.1\`.

No code change in the adapter / CLI / storage layer beyond the version string.

## Test plan

- [x] \`pnpm typecheck\` — clean.
- [x] \`pnpm build\` — clean.
- [x] \`pnpm vitest run tests/adapters/chaosbringer.test.ts\` — 9/9 (no regressions in the just-shipped adapter).
- [x] \`node dist/cli/main.js --version\` → \`0.11.1\` (was \`0.10.7\` on the published 0.11.0).
- [ ] After merge: \`git tag v0.11.1 <merge-sha> && git push origin v0.11.1\` → \`publish.yml\` fires the OIDC publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)