### PR TITLE
chore(skills): add project-local flaker-manual-release skill

### DIFF
--- a/.claude/skills/flaker-manual-release/SKILL.md
+++ b/.claude/skills/flaker-manual-release/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: flaker-manual-release
+description: Cut a flaker patch/minor release manually — branch → bump 3 version sites → CHANGELOG → PR → merge → tag → GitHub release → publish.yml OIDC publish. Use when the user asks to "release flaker N.N.N", "bump flaker", "publish flaker", or runs the equivalent in 日本語 ("flaker をリリース", "patch bump"). MAINTAINER-ONLY — only the npm OIDC trusted publisher (mizchi) can complete the publish step. Does NOT apply to chaosbringer (release-please) or other repos.
+---
+
+# flaker manual release
+
+Procedure encoded from `docs/contributing.md` § Releases plus the 0.10.7 and 0.11.1 release sessions. The 0.x line is hand-released — `release-please` was removed in 0.10.5 (see commit `c5da2ea` and ADR if asked why).
+
+## Pre-flight
+
+1. `git status` clean on `main`. `git pull --ff-only`.
+2. Pick the bump type:
+   - **patch** (X.Y.Z → X.Y.Z+1): bug fix, doc update, version-string-only fix
+   - **minor** (X.Y.0 → X.Y+1.0): a `feat:` commit landed since the last release
+   - **major**: ASK first; rare in the 0.x line.
+3. Branch name: `fix/<version>-<slug>` (patch) or `feat/<version>-<slug>` (minor) per contributing.md. Slug 1-3 words describing the dominant change.
+
+## Bump 3 places (one is easy to miss)
+
+| File | Edit |
+|---|---|
+| `package.json` | `"version": "<new>"` |
+| `src/cli/main.ts` | `.version("<new>")` ← **forgotten in 0.11.0**, caused a 0.11.1 patch detour. Always grep `\.version\(` after the bump. |
+| `CHANGELOG.md` | Convert `## Unreleased` → `## <version>` heading. Match the existing per-version section format (no date suffix in the 0.x line). |
+
+## Build / verify
+
+```bash
+pnpm typecheck   # tsc --noEmit
+pnpm build       # writes dist/cli/main.js + dist/moonbit/flaker.js
+pnpm test        # vitest run — full suite
+```
+
+All three MUST pass before the PR. If `tests/commands/ops-weekly.test.ts` fails locally but CI is green, that is/was the date-sensitive flaky-tag-triage `now` bug fixed in 0.10.7 — not your release.
+
+## PR → merge
+
+1. One commit: `chore(release): <version>` subject. Body summarises CHANGELOG.
+2. `gh pr create --title "chore(release): <version>" --body ...`
+3. Wait for CI: `test`, `core-tests (with_moonbit_build)`, `core-tests (without_moonbit_build)`. All must be SUCCESS.
+4. `gh pr merge <N> --merge --subject "Merge pull request #<N> from ..."` (merge-commit style; matches existing main history).
+5. `git checkout main && git pull --ff-only` → note the merge SHA from `git log --oneline -3`.
+
+## Tag + GitHub release + publish
+
+```bash
+git tag v<version> <merge-sha>
+git push origin v<version>
+
+gh release create v<version> \
+  --title "v<version>" \
+  --notes "<curated body — typically a tightened version of the CHANGELOG entry>"
+```
+
+`publish.yml` fires automatically on tag push (OIDC trusted publishing + npm provenance). Wait for it:
+
+```bash
+gh run list --workflow publish.yml --limit 1 --json status,conclusion
+# Or, blocking:
+until [ "$(gh run view <run-id> --json status -q .status)" = "completed" ]; do sleep 15; done
+gh run view <run-id> --json conclusion -q .conclusion   # expect: success
+```
+
+## Verify the published version
+
+```bash
+npm view @mizchi/flaker version            # must equal <new>
+npx @mizchi/flaker@<version> --version     # must equal <new> too — THIS catches the .version() miss
+```
+
+If `npx ... --version` reports the previous version while `npm view version` is correct, the `src/cli/main.ts` bump was missed. Roll forward with a tiny patch release — **do NOT retag**, npm doesn't allow re-publishing the same version and consumers may have already pulled.
+
+## Gotchas
+
+- **chaosbringer's `flaker-merge` advisory check** is a pre-existing flake on its side, unrelated to flaker releases. Ignore the FAILURE on that check when merging flaker PRs.
+- **`gh release create` requires the tag to already be on origin** — don't try to create the release before pushing the tag.
+- **Don't skip CHANGELOG** — release-please was removed in 0.10.5, so nothing else generates one. Missing entries are user-visible.
+
+## What this skill is NOT for
+
+- chaosbringer release (use release-please-driven flow there)
+- One-off `npm publish` from a workstation (the OIDC flow is mandatory; manual `npm publish` from a laptop will fail without the trusted-publisher token)


### PR DESCRIPTION
## Summary

Adds the first \`.claude/skills/<name>/SKILL.md\` in the repo: a project-local, maintainer-only skill that encodes the manual 0.x release flow.

I executed the procedure twice today — 0.10.7 (#78) and 0.11.1 (#80) — and the second time discovered that 0.11.0 had shipped with the bundled CLI's \`.version("0.10.7")\` string never bumped, forcing a 0.11.1 patch detour. That kind of bump-3-files gotcha is exactly what a skill should encode.

## Why \`.claude/skills/\` and not \`skills/\`

- \`skills/\` (root) ships via the Claude Code plugin (\`.claude-plugin/plugin.json\`) to end users. Maintainer ops doesn't belong there.
- \`.claude/skills/\` is the project-local auto-load path per the global agent guidance — only loaded inside this repo's working tree, not distributed.

First file under that path → sets the convention.

## What the skill encodes

- **When to use / NOT use** (explicit anti-applies: chaosbringer release-please, manual npm publish).
- **3 version sites** that must move together (\`package.json\`, \`src/cli/main.ts\` \`.version(...)\`, \`CHANGELOG.md\`), with the \`.version()\` site flagged as the historical miss.
- **Build / test gating** including the note about the date-sensitive \`ops-weekly\` test fixed in 0.10.7 (so a re-occurrence isn't mistaken for a release blocker).
- **PR → merge → tag → GitHub release → publish.yml OIDC** sequence.
- **Verification that catches the \`.version()\` miss**: \`npx @mizchi/flaker@<v> --version\` must equal \`<v>\`.
- **Gotchas**: chaosbringer's \`flaker-merge\` advisory FAILURE is pre-existing and unrelated; tag must precede \`gh release create\`; npm forbids retagging — roll forward.

## Test plan

- [x] No NUL bytes (\`perl -nle 'print if /\\x00/'\` clean).
- [x] 83 lines — well under the 150-line skill budget.
- [x] frontmatter \`description\` is specific enough that the agent will only invoke this for \`flaker\` releases (not chaosbringer / other repos).
- [ ] Next flaker release (whenever) is the real test — the agent should pick this up and follow it without re-deriving the 7 steps from \`docs/contributing.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)