### PR TITLE
feat(explain): add --json to flaker explain cluster

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"46d84a88-dacc-407c-af78-c8234ab32dab","pid":25668,"procStart":"Wed Apr 29 04:01:59 2026","acquiredAt":1777641741962}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"46d84a88-dacc-407c-af78-c8234ab32dab","pid":25668,"procStart":"Wed Apr 29 04:01:59 2026","acquiredAt":1777641741962}

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ result
 .artifacts/
 .direnv
 .worktrees/
+
+# Claude Code runtime locks
+.claude/scheduled_tasks.lock

--- a/src/cli/categories/analyze.ts
+++ b/src/cli/categories/analyze.ts
@@ -135,6 +135,7 @@ export async function analyzeClusterAction(opts: {
   minCoFailures: string;
   minCoRate: string;
   top: string;
+  json?: boolean;
 }): Promise<void> {
   const config = loadConfig(process.cwd());
   const store = new DuckDBStore(resolve(config.storage.path));
@@ -147,7 +148,11 @@ export async function analyzeClusterAction(opts: {
       minCoRate: Number(opts.minCoRate),
       top: parseInt(opts.top, 10),
     });
-    console.log(formatFailureClusters(clusters));
+    if (opts.json) {
+      console.log(JSON.stringify(clusters, null, 2));
+    } else {
+      console.log(formatFailureClusters(clusters));
+    }
   } finally {
     await store.close();
   }

--- a/src/cli/categories/explain.ts
+++ b/src/cli/categories/explain.ts
@@ -33,6 +33,7 @@ export function registerExplainCommands(program: Command): void {
     .option("--min-co-failures <n>", "Minimum shared failing runs", "2")
     .option("--min-co-rate <ratio>", "Minimum co-failure rate as ratio (0.0-1.0)", "0.8")
     .option("--top <n>", "Number of clusters to show", "20")
+    .option("--json", "Output clusters as machine-readable JSON")
     .action(analyzeClusterAction);
 
   explain

--- a/tests/commands/cluster.test.ts
+++ b/tests/commands/cluster.test.ts
@@ -123,4 +123,37 @@ describe("failure clusters", () => {
     expect(text).toContain("cms-a.spec.ts");
     expect(text).toContain("100.0%");
   });
+
+  it("returns JSON-serializable cluster shape with the documented fields", async () => {
+    const clusters = await runFailureClusters({
+      store,
+      minCoFailures: 2,
+      minCoRate: 0.8,
+    });
+
+    // JSON.stringify must succeed without throwing (no functions / cycles / BigInt).
+    const json = JSON.stringify(clusters);
+    expect(json).toBeTypeOf("string");
+
+    // Round-trip through JSON to confirm the shape is plain data.
+    const restored = JSON.parse(json) as typeof clusters;
+    expect(restored).toEqual(clusters);
+
+    // Per issue #73, each cluster must expose: id, members, edges,
+    // totalCoFailRuns, avgCoFailRate / maxCoFailRate.
+    for (const cluster of restored) {
+      expect(typeof cluster.id).toBe("string");
+      expect(Array.isArray(cluster.members)).toBe(true);
+      expect(Array.isArray(cluster.edges)).toBe(true);
+      expect(typeof cluster.totalCoFailRuns).toBe("number");
+      expect(typeof cluster.avgCoFailRate).toBe("number");
+      expect(typeof cluster.maxCoFailRate).toBe("number");
+      for (const member of cluster.members) {
+        expect(typeof member.testId).toBe("string");
+        expect(typeof member.suite).toBe("string");
+        expect(typeof member.testName).toBe("string");
+        expect(typeof member.failRuns).toBe("number");
+      }
+    }
+  });
 });


### PR DESCRIPTION
Closes #73.

## Summary

\`flaker explain cluster --json\` emits the \`FailureCluster[]\` shape verbatim (already JSON-serializable), so downstream automation can consume it without scraping the human-readable text format.

## Output shape

Each cluster contains:
- \`id\` (string)
- \`members[]\` (testId, taskId, suite, testName, filter, failRuns)
- \`edges[]\` (TestCoFailurePair: testA*/testB*/coFailRuns/coFailRate)
- \`totalCoFailRuns\` (number)
- \`avgCoFailRate\` / \`maxCoFailRate\` (numbers in 0..1)

## Out of scope

The "representative shared run ids" item from the issue's "nice to have" list is NOT in this PR — it requires a new query against \`queryTestCoFailures\` (currently aggregates only). Tracked as a follow-up if downstream wants per-cluster representative run samples.

## Tests

- Existing text-format tests untouched
- New shape test asserts JSON.stringify round-trips and the documented fields are present / of expected types

## Verified

- [x] \`pnpm test\` -> 834/834 + 1 skipped
- [x] \`pnpm exec tsc --noEmit\` clean
- [x] \`flaker explain cluster --help\` shows \`--json\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)