### PR TITLE
fix: thread now?: Date through co-failure / insights queries (#64 part 1)

### DIFF
--- a/src/cli/commands/analyze/insights.ts
+++ b/src/cli/commands/analyze/insights.ts
@@ -5,6 +5,18 @@ export interface InsightsOpts {
   store: MetricStore;
   windowDays?: number;
   top?: number;
+  /**
+   * Reference time for the window cutoff. Defaults to `new Date()`.
+   * Threaded so tests / scripts can inject a stable now without relying
+   * on `CURRENT_TIMESTAMP` (which is evaluated by DuckDB in UTC and was
+   * the root cause of the 0.10.2 timezone flake).
+   */
+  now?: Date;
+}
+
+function toCutoffLiteral(now: Date, windowDays: number): string {
+  const cutoff = new Date(now.getTime() - windowDays * 24 * 60 * 60 * 1000);
+  return cutoff.toISOString().replace("T", " ").replace("Z", "");
 }
 
 interface TestSourceStats {
@@ -38,6 +50,8 @@ export interface InsightsResult {
 export async function runInsights(opts: InsightsOpts): Promise<InsightsResult> {
   const window = opts.windowDays ?? 90;
   const top = opts.top ?? 20;
+  const now = opts.now ?? new Date();
+  const cutoffLiteral = toCutoffLiteral(now, window);
   const workflowSourceExpr = workflowRunSourceSql("wr");
 
   const rows = await opts.store.raw<{
@@ -59,7 +73,7 @@ export async function runInsights(opts: InsightsOpts): Promise<InsightsResult> {
         AND tr.status IN ('failed', 'flaky'))::INTEGER AS local_fails
     FROM test_results tr
     LEFT JOIN workflow_runs wr ON tr.workflow_run_id = wr.id
-    WHERE tr.created_at > CURRENT_TIMESTAMP - INTERVAL (${Number(window)} || ' days')
+    WHERE tr.created_at > '${cutoffLiteral}'::TIMESTAMP
     GROUP BY tr.suite, tr.test_name
     HAVING ci_runs + local_runs >= 2
   `);

--- a/src/cli/commands/dev/eval-co-failure.ts
+++ b/src/cli/commands/dev/eval-co-failure.ts
@@ -26,8 +26,11 @@ export async function analyzeCoFailureWindows(
 ): Promise<CoFailureWindowReport> {
   const windows = windowDays ?? DEFAULT_WINDOWS;
   const rows: CoFailureWindowRow[] = [];
+  const now = new Date();
 
   for (const days of windows) {
+    const cutoff = new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+    const cutoffLiteral = cutoff.toISOString().replace("T", " ").replace("Z", "");
     const result = await store.raw<{
       file_path: string;
       test_id: string;
@@ -36,7 +39,7 @@ export async function analyzeCoFailureWindows(
       co_runs: number;
       co_failures: number;
       co_failure_rate: number;
-    }>(CO_FAILURE_QUERY, [String(days), String(minCoRuns)]);
+    }>(CO_FAILURE_QUERY, [cutoffLiteral, minCoRuns]);
 
     if (result.length === 0) {
       rows.push({

--- a/src/cli/storage/duckdb.ts
+++ b/src/cli/storage/duckdb.ts
@@ -504,7 +504,10 @@ export class DuckDBStore implements MetricStore {
   async queryCoFailures(opts: CoFailureQueryOpts): Promise<CoFailureResult[]> {
     const windowDays = opts.windowDays ?? 90;
     const minCoRuns = opts.minCoRuns ?? 3;
-    const rows = await this.all(CO_FAILURE_QUERY, [windowDays.toString(), minCoRuns]);
+    const now = opts.now ?? new Date();
+    const cutoff = new Date(now.getTime() - windowDays * 24 * 60 * 60 * 1000);
+    const cutoffLiteral = cutoff.toISOString().replace("T", " ").replace("Z", "");
+    const rows = await this.all(CO_FAILURE_QUERY, [cutoffLiteral, minCoRuns]);
     return rows.map((r: any) => ({
       filePath: r.file_path,
       testId: r.test_id,
@@ -538,9 +541,12 @@ export class DuckDBStore implements MetricStore {
     const windowDays = opts?.windowDays ?? 90;
     const minCoFailures = opts?.minCoFailures ?? 2;
     const minCoRate = opts?.minCoRate ?? 0.8;
+    const now = opts?.now ?? new Date();
+    const cutoff = new Date(now.getTime() - windowDays * 24 * 60 * 60 * 1000);
+    const cutoffLiteral = cutoff.toISOString().replace("T", " ").replace("Z", "");
     const rows = await this.all(
       TEST_CO_FAILURE_QUERY,
-      [windowDays.toString(), minCoFailures, minCoRate],
+      [cutoffLiteral, minCoFailures, minCoRate],
     );
     return rows.map((row: any) => ({
       testAId: row.test_a_id,

--- a/src/cli/storage/schema.ts
+++ b/src/cli/storage/schema.ts
@@ -147,7 +147,7 @@ SELECT
   )::DOUBLE AS co_failure_rate
 FROM commit_changes cc
 JOIN test_results tr ON cc.commit_sha = tr.commit_sha
-WHERE tr.created_at > CURRENT_TIMESTAMP - INTERVAL (? || ' days')
+WHERE tr.created_at > ?::TIMESTAMP
 GROUP BY cc.file_path, tr.test_id, tr.suite, tr.test_name
 HAVING co_runs >= ? AND co_failures > 0
 ORDER BY co_failure_rate DESC
@@ -163,7 +163,7 @@ WITH failed_results AS (
     test_name,
     filter_text
   FROM test_results
-  WHERE created_at > CURRENT_TIMESTAMP - INTERVAL (? || ' days')
+  WHERE created_at > ?::TIMESTAMP
     AND (
       status IN ('failed', 'flaky')
       OR (retry_count > 0 AND status = 'passed')

--- a/src/cli/storage/types.ts
+++ b/src/cli/storage/types.ts
@@ -170,6 +170,8 @@ export interface CoFailureResult {
 export interface CoFailureQueryOpts {
   windowDays?: number;
   minCoRuns?: number;
+  /** Reference time for the window cutoff. Defaults to `new Date()`. */
+  now?: Date;
 }
 
 export interface TestCoFailurePair {
@@ -193,6 +195,8 @@ export interface TestCoFailureQueryOpts {
   windowDays?: number;
   minCoFailures?: number;
   minCoRate?: number;
+  /** Reference time for the window cutoff. Defaults to `new Date()`. */
+  now?: Date;
 }
 
 export interface ExportResult {


### PR DESCRIPTION
First slice of the audit from #64. Threads \`now?: Date\` through the caller chain for SQL sites that used \`CURRENT_TIMESTAMP - INTERVAL\` and switches the SQL to literal cutoffs. Mirrors the \`FLAKY_QUERY\` pattern from 0.10.2 (which fixed the original ops-daily TZ flake).

## Sites in this PR

| File | Query | Change |
|---|---|---|
| \`src/cli/storage/schema.ts\` | \`CO_FAILURE_QUERY\` | \`WHERE tr.created_at > ?::TIMESTAMP\` |
| \`src/cli/storage/schema.ts\` | \`TEST_CO_FAILURE_QUERY\` | \`WHERE created_at > ?::TIMESTAMP\` |
| \`src/cli/storage/duckdb.ts\` | \`queryCoFailures\` / \`queryTestCoFailures\` | compute cutoff literal in JS |
| \`src/cli/storage/types.ts\` | \`CoFailureQueryOpts\` / \`TestCoFailureQueryOpts\` | add \`now?: Date\` |
| \`src/cli/commands/analyze/insights.ts\` | \`runInsights\` | add \`now?: Date\`, inline cutoff literal |
| \`src/cli/commands/dev/eval-co-failure.ts\` | direct caller of \`CO_FAILURE_QUERY\` | pass cutoff literal (kept in parity) |

## NOT yet covered (tracked in #64, future slices)

- \`src/cli/commands/status/summary.ts\` (2 queries)
- \`src/cli/commands/analyze/bundle.ts\` (4 queries)
- \`src/cli/commands/analyze/context.ts\` (1 query)
- \`src/cli/commands/analyze/eval.ts\` (5 queries)
- \`src/cli/commands/analyze/kpi.ts\` (5+ queries)

## Verified

- [x] \`pnpm test\` -> 834/834 + 1 skipped (no regression; the \`co-failure-window\` test caught a missed caller during dev — now also fixed in this PR)
- [x] \`pnpm exec tsc --noEmit\` clean

## Test plan

- [ ] CI \`test\` / \`core-tests\` pass
- [ ] Reviewer scans \`schema.ts\` to confirm both queries now use \`?::TIMESTAMP\` (not \`CURRENT_TIMESTAMP\`)

Refs #64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)