### PR TITLE
fix: thread now?: Date through remaining CURRENT_TIMESTAMP queries (#64 part 2, closes)

### DIFF
--- a/src/cli/commands/analyze/bundle.ts
+++ b/src/cli/commands/analyze/bundle.ts
@@ -50,6 +50,8 @@ export interface AnalysisBundleOpts {
   failureHistoryLimit?: number;
   clusterTop?: number;
   insightsTop?: number;
+  /** Reference time for the window cutoff. Defaults to `new Date()`. */
+  now?: Date;
 }
 
 interface WorkflowRunCountsRow {
@@ -550,9 +552,13 @@ async function loadFailureEvidence(
 ): Promise<FlakerAnalysisBundleFailureEvidence[]> {
   const evidenceTop = opts.failureEvidenceTop ?? 10;
   const failureHistoryLimit = opts.failureHistoryLimit ?? 10;
+  const now = opts.now ?? new Date();
+  const cutoff = new Date(now.getTime() - opts.windowDays * 24 * 60 * 60 * 1000);
+  const cutoffLiteral = cutoff.toISOString().replace("T", " ").replace("Z", "");
   const flakyTests = await opts.store.queryFlakyTests({
     windowDays: opts.windowDays,
     top: evidenceTop,
+    now,
   });
 
   const evidence: FlakerAnalysisBundleFailureEvidence[] = [];
@@ -584,11 +590,11 @@ async function loadFailureEvidence(
         tr.created_at
       FROM test_results tr
       LEFT JOIN workflow_runs wr ON tr.workflow_run_id = wr.id
-      WHERE tr.created_at > CURRENT_TIMESTAMP - INTERVAL (? || ' days')
+      WHERE tr.created_at > '${cutoffLiteral}'::TIMESTAMP
         AND COALESCE(tr.test_id, '') = ?
       ORDER BY tr.created_at DESC, tr.id DESC
       LIMIT ?
-    `, [opts.windowDays.toString(), flaky.testId, failureHistoryLimit]);
+    `, [flaky.testId, failureHistoryLimit]);
 
     const sources = new Set<"ci" | "local">();
     for (const row of historyRows) {
@@ -641,6 +647,9 @@ export async function runAnalysisBundle(
   const recentFailuresLimit = opts.recentFailuresLimit ?? 20;
   const clusterTop = opts.clusterTop ?? 10;
   const insightsTop = opts.insightsTop ?? 10;
+  const now = opts.now ?? new Date();
+  const cutoff = new Date(now.getTime() - windowDays * 24 * 60 * 60 * 1000);
+  const cutoffLiteral = cutoff.toISOString().replace("T", " ").replace("Z", "");
   const workflowSourceExpr = workflowRunSourceSql("wr");
 
   const [
@@ -661,16 +670,16 @@ export async function runAnalysisBundle(
         COUNT(*) FILTER (WHERE ${workflowSourceExpr} = 'ci')::INTEGER AS ci_runs,
         COUNT(*) FILTER (WHERE ${workflowSourceExpr} = 'local')::INTEGER AS local_runs
       FROM workflow_runs wr
-      WHERE wr.created_at > CURRENT_TIMESTAMP - INTERVAL (? || ' days')
-    `, [windowDays.toString()]),
+      WHERE wr.created_at > '${cutoffLiteral}'::TIMESTAMP
+    `),
     opts.store.raw<TestResultCountsRow>(`
       SELECT
         COUNT(*)::INTEGER AS total_results,
         COUNT(DISTINCT COALESCE(NULLIF(test_id, ''), suite || '::' || test_name))::INTEGER AS unique_tests,
         COUNT(DISTINCT commit_sha)::INTEGER AS unique_commits
       FROM test_results
-      WHERE created_at > CURRENT_TIMESTAMP - INTERVAL (? || ' days')
-    `, [windowDays.toString()]),
+      WHERE created_at > '${cutoffLiteral}'::TIMESTAMP
+    `),
     opts.store.raw<RecentFailureRow>(`
       SELECT
         COALESCE(tr.test_id, '') AS test_id,
@@ -698,26 +707,28 @@ export async function runAnalysisBundle(
         tr.created_at
       FROM test_results tr
       LEFT JOIN workflow_runs wr ON tr.workflow_run_id = wr.id
-      WHERE tr.created_at > CURRENT_TIMESTAMP - INTERVAL (? || ' days')
+      WHERE tr.created_at > '${cutoffLiteral}'::TIMESTAMP
         AND (
           tr.status IN ('failed', 'flaky')
           OR (tr.retry_count > 0 AND tr.status = 'passed')
         )
       ORDER BY tr.created_at DESC, tr.id DESC
       LIMIT ?
-    `, [windowDays.toString(), recentFailuresLimit]),
+    `, [recentFailuresLimit]),
     buildContext(opts.store, {
       storagePath: opts.storagePath,
       resolverConfigured: opts.resolverConfigured,
+      now,
     }),
-    computeKpi(opts.store, { windowDays }),
-    runEval({ store: opts.store, windowDays }),
-    runReason({ store: opts.store, windowDays }),
-    runInsights({ store: opts.store, windowDays, top: insightsTop }),
+    computeKpi(opts.store, { windowDays, now }),
+    runEval({ store: opts.store, windowDays, now }),
+    runReason({ store: opts.store, windowDays, now }),
+    runInsights({ store: opts.store, windowDays, top: insightsTop, now }),
     runFailureClusters({
       store: opts.store,
       windowDays,
       top: clusterTop,
+      now,
     }),
     loadFailureEvidence({
       ...opts,

--- a/src/cli/commands/analyze/cluster.ts
+++ b/src/cli/commands/analyze/cluster.ts
@@ -7,6 +7,8 @@ export interface FailureClusterOpts {
   minCoFailures?: number;
   minCoRate?: number;
   top?: number;
+  /** Reference time for the window cutoff. Defaults to `new Date()`. */
+  now?: Date;
 }
 
 export async function runFailureClusters(
@@ -17,6 +19,7 @@ export async function runFailureClusters(
     windowDays: opts.windowDays ?? defaults.windowDays,
     minCoFailures: opts.minCoFailures ?? defaults.minCoFailures,
     minCoRate: opts.minCoRate ?? defaults.minCoRate,
+    ...(opts.now ? { now: opts.now } : {}),
   });
   const clusters = buildFailureClusters(pairs);
   return opts.top != null ? clusters.slice(0, opts.top) : clusters;

--- a/src/cli/commands/analyze/context.ts
+++ b/src/cli/commands/analyze/context.ts
@@ -29,8 +29,12 @@ export async function buildContext(
   opts: {
     storagePath: string;
     resolverConfigured: boolean;
+    /** Reference time for the data-age range. Defaults to `new Date()`. */
+    now?: Date;
   },
 ): Promise<FlakerContext> {
+  const now = opts.now ?? new Date();
+  const nowLiteral = now.toISOString().replace("T", " ").replace("Z", "");
   const modelsDir = resolve(dirname(opts.storagePath), "models");
   const gbdtModelAvailable = existsSync(resolve(modelsDir, "gbdt.json"));
   let tunedAlpha: number | null = null;
@@ -74,8 +78,8 @@ export async function buildContext(
   try {
     const [dateRange] = await store.raw<{ oldest: number; newest: number }>(
       `SELECT
-        DATEDIFF('day', MIN(created_at), CURRENT_TIMESTAMP)::INTEGER AS oldest,
-        DATEDIFF('day', MAX(created_at), CURRENT_TIMESTAMP)::INTEGER AS newest
+        DATEDIFF('day', MIN(created_at), '${nowLiteral}'::TIMESTAMP)::INTEGER AS oldest,
+        DATEDIFF('day', MAX(created_at), '${nowLiteral}'::TIMESTAMP)::INTEGER AS newest
        FROM test_results
        WHERE created_at IS NOT NULL`,
     );

--- a/src/cli/commands/analyze/eval.ts
+++ b/src/cli/commands/analyze/eval.ts
@@ -474,10 +474,13 @@ async function getBuildSamplingKpi(): Promise<(rows: CommitSignal[]) => Sampling
 }
 
 export async function runSamplingKpi(
-  opts: { store: MetricStore; windowDays?: number },
+  opts: { store: MetricStore; windowDays?: number; now?: Date },
 ): Promise<SamplingKpiReport> {
   const { store } = opts;
   const windowDays = opts.windowDays ?? 30;
+  const now = opts.now ?? new Date();
+  const cutoff = new Date(now.getTime() - windowDays * 24 * 60 * 60 * 1000);
+  const cutoffLiteral = cutoff.toISOString().replace("T", " ").replace("Z", "");
   const workflowSourceExpr = workflowRunSourceSql("wr");
   const commitSignalRows = await store.raw<CommitSignalRow>(`
     WITH recent_results AS (
@@ -494,7 +497,7 @@ export async function runSamplingKpi(
         tr.retry_count
       FROM workflow_runs wr
       INNER JOIN test_results tr ON tr.workflow_run_id = wr.id
-      WHERE tr.created_at > CURRENT_TIMESTAMP - INTERVAL (? || ' days')
+      WHERE tr.created_at > '${cutoffLiteral}'::TIMESTAMP
     ),
     aggregated_results AS (
       SELECT
@@ -520,7 +523,7 @@ export async function runSamplingKpi(
         ROW_NUMBER() OVER (PARTITION BY commit_sha ORDER BY created_at DESC, id DESC) AS row_num
       FROM sampling_runs
       WHERE command_kind = 'run'
-        AND created_at > CURRENT_TIMESTAMP - INTERVAL (? || ' days')
+        AND created_at > '${cutoffLiteral}'::TIMESTAMP
     )
     SELECT
       ar.commit_sha,
@@ -544,7 +547,7 @@ export async function runSamplingKpi(
       ON ar.run_kind = 'local'
      AND rs.commit_sha = ar.commit_sha
      AND rs.row_num = 1
-  `, [windowDays.toString(), windowDays.toString()]);
+  `);
   const buildSamplingKpi = await getBuildSamplingKpi();
   return buildSamplingKpi(
     commitSignalRows.map((row) => ({
@@ -559,9 +562,14 @@ export async function runSamplingKpi(
   );
 }
 
-export async function runEval(opts: { store: MetricStore; windowDays?: number }): Promise<EvalReport> {
+export async function runEval(opts: { store: MetricStore; windowDays?: number; now?: Date }): Promise<EvalReport> {
   const { store } = opts;
   const windowDays = opts.windowDays ?? 30;
+  const now = opts.now ?? new Date();
+  const cutoff = new Date(now.getTime() - windowDays * 24 * 60 * 60 * 1000);
+  const cutoffLiteral = cutoff.toISOString().replace("T", " ").replace("Z", "");
+  const cutoff7d = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+  const cutoff7dLiteral = cutoff7d.toISOString().replace("T", " ").replace("Z", "");
 
   // 1. Data Sufficiency
   const [statsRow] = await store.raw<{
@@ -610,16 +618,16 @@ export async function runEval(opts: { store: MetricStore; windowDays?: number })
     older_flaky AS (
       SELECT DISTINCT suite, test_name FROM test_results
       WHERE status IN ('failed', 'flaky')
-        AND created_at < CURRENT_TIMESTAMP - INTERVAL '7 days'
+        AND created_at < '${cutoff7dLiteral}'::TIMESTAMP
     ),
     recent_flaky AS (
       SELECT DISTINCT suite, test_name FROM test_results
       WHERE status IN ('failed', 'flaky')
-        AND created_at >= CURRENT_TIMESTAMP - INTERVAL '7 days'
+        AND created_at >= '${cutoff7dLiteral}'::TIMESTAMP
     ),
     recent_any AS (
       SELECT DISTINCT suite, test_name FROM test_results
-      WHERE created_at >= CURRENT_TIMESTAMP - INTERVAL '7 days'
+      WHERE created_at >= '${cutoff7dLiteral}'::TIMESTAMP
     )
     SELECT
       (SELECT COUNT(*)::INTEGER FROM older_flaky o

--- a/src/cli/commands/analyze/kpi.ts
+++ b/src/cli/commands/analyze/kpi.ts
@@ -50,9 +50,14 @@ export interface FlakerKpi {
 
 export async function computeKpi(
   store: MetricStore,
-  opts?: { windowDays?: number },
+  opts?: { windowDays?: number; now?: Date },
 ): Promise<FlakerKpi> {
   const window = opts?.windowDays ?? 30;
+  const now = opts?.now ?? new Date();
+  const cutoff = new Date(now.getTime() - window * 24 * 60 * 60 * 1000);
+  const cutoffLiteral = cutoff.toISOString().replace("T", " ").replace("Z", "");
+  const cutoffPrev = new Date(now.getTime() - window * 2 * 24 * 60 * 60 * 1000);
+  const cutoffPrevLiteral = cutoffPrev.toISOString().replace("T", " ").replace("Z", "");
   const workflowSourceExpr = workflowRunSourceSql("wr");
 
   // --- Sampling: confusion matrix from matched commits ---
@@ -71,14 +76,14 @@ export async function computeKpi(
         sr.selected_count, sr.candidate_count, sr.duration_ms
       FROM sampling_runs sr
       WHERE sr.command_kind = 'run'
-        AND sr.created_at > CURRENT_TIMESTAMP - INTERVAL (${Number(window)} || ' days')
+        AND sr.created_at > '${cutoffLiteral}'::TIMESTAMP
     ),
     sampled_tests AS (
       SELECT sr.commit_sha, srt.suite, srt.test_name
       FROM sampling_run_tests srt
       JOIN sampling_runs sr ON srt.sampling_run_id = sr.id
       WHERE sr.command_kind = 'run'
-        AND sr.created_at > CURRENT_TIMESTAMP - INTERVAL (${Number(window)} || ' days')
+        AND sr.created_at > '${cutoffLiteral}'::TIMESTAMP
         AND srt.is_holdout = FALSE
     ),
     holdout_tests AS (
@@ -86,7 +91,7 @@ export async function computeKpi(
       FROM sampling_run_tests srt
       JOIN sampling_runs sr ON srt.sampling_run_id = sr.id
       WHERE sr.command_kind = 'run'
-        AND sr.created_at > CURRENT_TIMESTAMP - INTERVAL (${Number(window)} || ' days')
+        AND sr.created_at > '${cutoffLiteral}'::TIMESTAMP
         AND srt.is_holdout = TRUE
     ),
     ci_results AS (
@@ -94,7 +99,7 @@ export async function computeKpi(
       FROM test_results tr
       JOIN workflow_runs wr ON tr.workflow_run_id = wr.id
       WHERE ${workflowSourceExpr} = 'ci'
-        AND tr.created_at > CURRENT_TIMESTAMP - INTERVAL (${Number(window)} || ' days')
+        AND tr.created_at > '${cutoffLiteral}'::TIMESTAMP
     ),
     matched_commits AS (
       SELECT DISTINCT ls.commit_sha
@@ -172,7 +177,7 @@ export async function computeKpi(
       JOIN sampling_runs sr ON srt.sampling_run_id = sr.id
       LEFT JOIN test_results tr ON tr.suite = srt.suite AND tr.test_name = srt.test_name
         AND tr.commit_sha = sr.commit_sha
-      WHERE sr.created_at > CURRENT_TIMESTAMP - INTERVAL (${Number(window)} || ' days')
+      WHERE sr.created_at > '${cutoffLiteral}'::TIMESTAMP
     ) sub
   `);
 
@@ -191,7 +196,7 @@ export async function computeKpi(
         suite || '::' || test_name AS key,
         ROUND(COUNT(*) FILTER (WHERE status IN ('failed', 'flaky')) * 100.0 / COUNT(*), 1) AS fail_rate
       FROM test_results
-      WHERE created_at > CURRENT_TIMESTAMP - INTERVAL (${Number(window)} || ' days')
+      WHERE created_at > '${cutoffLiteral}'::TIMESTAMP
       GROUP BY suite, test_name
       HAVING COUNT(*) >= 5
     ) sub
@@ -203,15 +208,15 @@ export async function computeKpi(
         SELECT suite, test_name, COUNT(*) AS runs,
           COUNT(*) FILTER (WHERE status IN ('failed', 'flaky')) AS fails
         FROM test_results
-        WHERE created_at > CURRENT_TIMESTAMP - INTERVAL (${Number(window)} || ' days')
+        WHERE created_at > '${cutoffLiteral}'::TIMESTAMP
         GROUP BY suite, test_name HAVING runs >= 5 AND fails > 0
       ) sub) AS current_count,
       (SELECT COUNT(DISTINCT suite || '::' || test_name)::INTEGER FROM (
         SELECT suite, test_name, COUNT(*) AS runs,
           COUNT(*) FILTER (WHERE status IN ('failed', 'flaky')) AS fails
         FROM test_results
-        WHERE created_at > CURRENT_TIMESTAMP - INTERVAL (${Number(window * 2)} || ' days')
-          AND created_at <= CURRENT_TIMESTAMP - INTERVAL (${Number(window)} || ' days')
+        WHERE created_at > '${cutoffPrevLiteral}'::TIMESTAMP
+          AND created_at <= '${cutoffLiteral}'::TIMESTAMP
         GROUP BY suite, test_name HAVING runs >= 5 AND fails > 0
       ) sub) AS previous_count
   `);
@@ -227,12 +232,12 @@ export async function computeKpi(
   }>(`
     SELECT
       (SELECT COUNT(DISTINCT commit_sha)::INTEGER FROM test_results
-       WHERE created_at > CURRENT_TIMESTAMP - INTERVAL (${Number(window)} || ' days')
+       WHERE created_at > '${cutoffLiteral}'::TIMESTAMP
          AND commit_sha IS NOT NULL) AS commit_count,
       (SELECT COUNT(DISTINCT commit_sha)::INTEGER FROM commit_changes
        WHERE commit_sha IN (
          SELECT DISTINCT commit_sha FROM test_results
-         WHERE created_at > CURRENT_TIMESTAMP - INTERVAL (${Number(window)} || ' days')
+         WHERE created_at > '${cutoffLiteral}'::TIMESTAMP
        )) AS commits_with_changes,
       (SELECT MAX(created_at)::VARCHAR FROM test_results) AS last_data_at
   `);

--- a/src/cli/commands/analyze/reason.ts
+++ b/src/cli/commands/analyze/reason.ts
@@ -37,11 +37,12 @@ export interface ReasoningReport {
   };
 }
 
-export async function runReason(opts: { store: MetricStore; windowDays?: number }): Promise<ReasoningReport> {
+export async function runReason(opts: { store: MetricStore; windowDays?: number; now?: Date }): Promise<ReasoningReport> {
   const { store } = opts;
   const windowDays = opts.windowDays ?? 30;
+  const now = opts.now;
 
-  const flakyTests = await store.queryFlakyTests({ windowDays });
+  const flakyTests = await store.queryFlakyTests({ windowDays, ...(now ? { now } : {}) });
   const trueFlakyTests = await store.queryTrueFlakyTests();
 
   const trueFlakyMap = new Map<string, TrueFlakyScore>();

--- a/src/cli/commands/status/summary.ts
+++ b/src/cli/commands/status/summary.ts
@@ -110,10 +110,12 @@ export async function runStatusSummary(input: {
 }): Promise<StatusSummary> {
   const now = input.now ?? new Date();
   const windowDays = input.windowDays ?? 30;
+  const cutoff = new Date(now.getTime() - windowDays * 24 * 60 * 60 * 1000);
+  const cutoffLiteral = cutoff.toISOString().replace("T", " ").replace("Z", "");
   const workflowSourceExpr = workflowRunSourceSql("wr");
 
   const [kpi, activityRows, currentQuarantine, quarantinePlan] = await Promise.all([
-    computeKpi(input.store, { windowDays }),
+    computeKpi(input.store, { windowDays, now }),
     input.store.raw<{
       total_runs: number;
       ci_runs: number;
@@ -124,13 +126,13 @@ export async function runStatusSummary(input: {
       WITH recent_runs AS (
         SELECT wr.id, ${workflowSourceExpr} AS source
         FROM workflow_runs wr
-        WHERE wr.created_at > CURRENT_TIMESTAMP - INTERVAL (${Number(windowDays)} || ' days')
+        WHERE wr.created_at > '${cutoffLiteral}'::TIMESTAMP
       ),
       recent_results AS (
         SELECT tr.status, tr.retry_count
         FROM test_results tr
         JOIN workflow_runs wr ON tr.workflow_run_id = wr.id
-        WHERE tr.created_at > CURRENT_TIMESTAMP - INTERVAL (${Number(windowDays)} || ' days')
+        WHERE tr.created_at > '${cutoffLiteral}'::TIMESTAMP
       )
       SELECT
         (SELECT COUNT(*)::INTEGER FROM recent_runs) AS total_runs,


### PR DESCRIPTION
Continuation of #84. **Closes #64** — every \`CURRENT_TIMESTAMP\`-based window query in the analyze/status surface now accepts an optional \`now?: Date\` and switches the SQL to literal cutoffs. Same pattern as \`FLAKY_QUERY\` (0.10.2).

## Sites covered (5 files, ~17 queries)

| File | Queries | Notes |
|---|---|---|
| \`commands/analyze/context.ts\` | 1 (DATEDIFF) | \`buildContext\` + \`now?: Date\`; nowLiteral inlined |
| \`commands/status/summary.ts\` | 2 | cutoffLiteral threaded; \`computeKpi\` now receives \`now\` |
| \`commands/analyze/bundle.ts\` | 4 | \`AnalysisBundleOpts\` + \`now?: Date\`; cutoffLiteral threaded; all child runs (\`runEval\` / \`runReason\` / \`runFailureClusters\` / \`runInsights\` / \`computeKpi\` / \`buildContext\` / \`queryFlakyTests\`) now pass \`now\` |
| \`commands/analyze/cluster.ts\` | (interface only) | \`FailureClusterOpts\` + \`now?: Date\` threads to \`queryTestCoFailures\` (already accepts it) |
| \`commands/analyze/reason.ts\` | (interface only) | \`runReason\` + \`now?: Date\` threads to \`queryFlakyTests\` |
| \`commands/analyze/eval.ts\` | 5 | \`runSamplingKpi\` + 2; \`runEval\` + 3 (hardcoded \`'7 days'\` -> \`cutoff7dLiteral\`) |
| \`commands/analyze/kpi.ts\` | 11 | \`computeKpi\` + \`now?: Date\`; 10 sites use \`cutoffLiteral\`, 1 uses \`cutoffPrevLiteral\` (trend-delta window-2) |

## Verified

- [x] \`pnpm test\` -> 834/834 + 1 skipped pass
- [x] \`pnpm exec tsc --noEmit\` clean
- [x] \`grep -nE "CURRENT_TIMESTAMP" src/cli/commands/\` returns nothing — no \`CURRENT_TIMESTAMP\` remains in the analyze/status SQL surface

The original \`co-failure-window\` test (which caught a missed caller during part 1 local dev) continues to pass.

## Audit anti-checklist (lessons from this slice)

- 4 files needed a child-call update (\`bundle.ts\`'s child Promise.all entries) — easy to miss when only patching the parent's queries
- One file (\`eval.ts\`) had a separate \`runSamplingKpi\` function with its own \`store.raw\` block; the partial fix at \`runEval\` left those unresolved \`cutoffLiteral\` references and tsc caught it. Pattern: don't trust grep alone for "all \`CURRENT_TIMESTAMP\` sites in a file" — re-grep after editing
- \`'7 days'\` literal interval (eval.ts) was easy to miss because the audit issue listed only \`(? || ' days')\` patterns — re-grepped \`CURRENT_TIMESTAMP -\` more broadly to catch them

Refs #64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)