### PR TITLE
fix: thread now?: Date through remaining CURRENT_TIMESTAMP queries (#64 part 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- `src/cli/commands/analyze/reason.ts`, `src/cli/commands/collect/calibrate.ts`, `src/cli/commands/gate/history.ts`, `src/cli/commands/dev/train.ts`, `src/cli/categories/dev.ts`: completed the `now?: Date` audit started in #84/#85 (issue #64). Twelve more `created_at > CURRENT_TIMESTAMP - INTERVAL '... days'` cutoffs across `runReason` (`detectPatterns`, `predictRisks`), `analyzeProject`, `queryTopTests`, `runGateHistory`, `trainModel`, and the inline `dev tune` query were converted to JS-computed literal cutoffs (`'YYYY-MM-DD HH:MM:SS'::TIMESTAMP`). Callers that pin `now` (snapshot/replay tests, `bundle.ts`) now get the same window across every sub-query instead of mixing pinned and `wallclock - windowDays` cutoffs, removing the JST-vs-UTC flake class for the analyze/calibrate/gate-history/train commands.
+
 ## 0.11.1
 
 Patch follow-up to 0.11.0 — version-string only.

--- a/src/cli/categories/dev.ts
+++ b/src/cli/categories/dev.ts
@@ -57,12 +57,14 @@ export function registerDevCommands(program: Command): void {
       try {
         const windowDays = parseInt(opts.window, 10);
         const samplePercentage = parseInt(opts.samplePercentage, 10);
+        const tuneCutoff = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000);
+        const tuneCutoffLiteral = tuneCutoff.toISOString().replace("T", " ").replace("Z", "");
 
         // Get recent commits with changed files and test results
         const commits = await store.raw<{
           commit_sha: string;
         }>(`SELECT DISTINCT commit_sha FROM test_results
-            WHERE created_at > CURRENT_TIMESTAMP - INTERVAL (${Number(windowDays)} || ' days')
+            WHERE created_at > '${tuneCutoffLiteral}'::TIMESTAMP
             ORDER BY commit_sha`);
 
         if (commits.length < 5) {

--- a/src/cli/commands/analyze/reason.ts
+++ b/src/cli/commands/analyze/reason.ts
@@ -40,9 +40,9 @@ export interface ReasoningReport {
 export async function runReason(opts: { store: MetricStore; windowDays?: number; now?: Date }): Promise<ReasoningReport> {
   const { store } = opts;
   const windowDays = opts.windowDays ?? 30;
-  const now = opts.now;
+  const now = opts.now ?? new Date();
 
-  const flakyTests = await store.queryFlakyTests({ windowDays, ...(now ? { now } : {}) });
+  const flakyTests = await store.queryFlakyTests({ windowDays, now });
   const trueFlakyTests = await store.queryTrueFlakyTests();
 
   const trueFlakyMap = new Map<string, TrueFlakyScore>();
@@ -51,8 +51,8 @@ export async function runReason(opts: { store: MetricStore; windowDays?: number;
   }
 
   const classifications = await classifyTests(store, flakyTests, trueFlakyMap);
-  const patterns = await detectPatterns(store, flakyTests);
-  const riskPredictions = await predictRisks(store, windowDays);
+  const patterns = await detectPatterns(store, flakyTests, now);
+  const riskPredictions = await predictRisks(store, windowDays, now);
 
   return {
     classifications,
@@ -154,6 +154,7 @@ async function classifyTests(
 async function detectPatterns(
   store: MetricStore,
   flakyTests: FlakyScore[],
+  now: Date,
 ): Promise<Pattern[]> {
   const patterns: Pattern[] = [];
 
@@ -177,11 +178,13 @@ async function detectPatterns(
 
   // New test risk
   try {
+    const recentCutoff = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+    const recentLiteral = recentCutoff.toISOString().replace("T", " ").replace("Z", "");
     const newTestRows = await store.raw<{ suite: string; test_name: string; total: number; fails: number }>(`
       SELECT suite, test_name, COUNT(*)::INTEGER as total,
         COUNT(*) FILTER (WHERE status IN ('failed', 'flaky'))::INTEGER as fails
       FROM test_results
-      WHERE created_at > CURRENT_TIMESTAMP - INTERVAL '7 days'
+      WHERE created_at > '${recentLiteral}'::TIMESTAMP
       GROUP BY suite, test_name
       HAVING COUNT(*) <= 5 AND COUNT(*) FILTER (WHERE status IN ('failed', 'flaky')) > 0
     `);
@@ -200,8 +203,12 @@ async function detectPatterns(
   return patterns;
 }
 
-async function predictRisks(store: MetricStore, windowDays: number): Promise<RiskPrediction[]> {
+async function predictRisks(store: MetricStore, windowDays: number, now: Date): Promise<RiskPrediction[]> {
   try {
+    const recentCutoff = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+    const recentLiteral = recentCutoff.toISOString().replace("T", " ").replace("Z", "");
+    const windowCutoff = new Date(now.getTime() - windowDays * 24 * 60 * 60 * 1000);
+    const windowLiteral = windowCutoff.toISOString().replace("T", " ").replace("Z", "");
     const rows = await store.raw<{
       suite: string; test_name: string;
       total: number; recent_fails: number; avg_duration: number; duration_variance: number;
@@ -211,11 +218,11 @@ async function predictRisks(store: MetricStore, windowDays: number): Promise<Ris
           suite, test_name,
           COUNT(*)::INTEGER as total,
           COUNT(*) FILTER (WHERE status IN ('failed', 'flaky')
-            AND created_at > CURRENT_TIMESTAMP - INTERVAL '7 days')::INTEGER as recent_fails,
+            AND created_at > '${recentLiteral}'::TIMESTAMP)::INTEGER as recent_fails,
           AVG(duration_ms)::DOUBLE as avg_duration,
           STDDEV(duration_ms)::DOUBLE as duration_variance
         FROM test_results
-        WHERE created_at > CURRENT_TIMESTAMP - INTERVAL (${Number(windowDays)} || ' days')
+        WHERE created_at > '${windowLiteral}'::TIMESTAMP
         GROUP BY suite, test_name
         HAVING COUNT(*) >= 5
           AND COUNT(*) FILTER (WHERE status IN ('failed', 'flaky')) * 100.0 / COUNT(*) < 10

--- a/src/cli/commands/collect/calibrate.ts
+++ b/src/cli/commands/collect/calibrate.ts
@@ -30,15 +30,18 @@ export interface CalibrationResult {
  */
 export async function analyzeProject(
   store: MetricStore,
-  opts: { hasResolver: boolean; hasGBDTModel: boolean; windowDays?: number },
+  opts: { hasResolver: boolean; hasGBDTModel: boolean; windowDays?: number; now?: Date },
 ): Promise<ProjectProfile> {
   const window = opts.windowDays ?? 90;
+  const now = opts.now ?? new Date();
+  const cutoff = new Date(now.getTime() - window * 24 * 60 * 60 * 1000);
+  const cutoffLiteral = cutoff.toISOString().replace("T", " ").replace("Z", "");
 
   const testCountRows = await store.raw<{ cnt: number }>(`
     SELECT COUNT(DISTINCT tr.suite || '::' || tr.test_name) AS cnt
     FROM test_results tr
     JOIN workflow_runs wr ON tr.workflow_run_id = wr.id
-    WHERE tr.created_at > CURRENT_TIMESTAMP - INTERVAL (${Number(window)} || ' days')
+    WHERE tr.created_at > '${cutoffLiteral}'::TIMESTAMP
       AND COALESCE(wr.source, 'ci') = 'ci'
   `);
   const testCount = Number(testCountRows[0]?.cnt ?? 0);
@@ -62,7 +65,7 @@ export async function analyzeProject(
         ROUND(COUNT(*) FILTER (WHERE tr.status IN ('failed', 'flaky')) * 100.0 / COUNT(*), 1) AS fail_rate
       FROM test_results tr
       JOIN workflow_runs wr ON tr.workflow_run_id = wr.id
-      WHERE tr.created_at > CURRENT_TIMESTAMP - INTERVAL (${Number(window)} || ' days')
+      WHERE tr.created_at > '${cutoffLiteral}'::TIMESTAMP
         AND COALESCE(wr.source, 'ci') = 'ci'
       GROUP BY tr.suite, tr.test_name
       HAVING COUNT(*) >= 5
@@ -98,7 +101,7 @@ export async function analyzeProject(
               ELSE 0 END AS co_fail_rate
           FROM commit_changes cc
           JOIN test_results tr ON cc.commit_sha = tr.commit_sha
-          WHERE tr.created_at > CURRENT_TIMESTAMP - INTERVAL (${Number(window)} || ' days')
+          WHERE tr.created_at > '${cutoffLiteral}'::TIMESTAMP
           GROUP BY cc.file_path, test_key
           HAVING co_runs >= 3 AND co_fails > 0
         ) sub
@@ -112,7 +115,7 @@ export async function analyzeProject(
   const commitRows = await store.raw<{ cnt: number }>(`
     SELECT COUNT(DISTINCT commit_sha) AS cnt
     FROM test_results
-    WHERE created_at > CURRENT_TIMESTAMP - INTERVAL (${Number(window)} || ' days')
+    WHERE created_at > '${cutoffLiteral}'::TIMESTAMP
       AND commit_sha IS NOT NULL
   `);
   const commitCount = Number(commitRows[0]?.cnt ?? 0);
@@ -304,15 +307,19 @@ export function buildExplainContext(
 export async function queryTopTests(
   store: MetricStore,
   windowDays: number,
+  now?: Date,
 ): Promise<{ broken: string[]; flaky: string[] }> {
   const window = Number(windowDays);
+  const ref = now ?? new Date();
+  const cutoff = new Date(ref.getTime() - window * 24 * 60 * 60 * 1000);
+  const cutoffLiteral = cutoff.toISOString().replace("T", " ").replace("Z", "");
   const rows = await store.raw<{ key: string; fail_rate: number }>(`
     SELECT
       tr.suite || ' > ' || tr.test_name AS key,
       ROUND(COUNT(*) FILTER (WHERE tr.status IN ('failed', 'flaky')) * 100.0 / COUNT(*), 1) AS fail_rate
     FROM test_results tr
     JOIN workflow_runs wr ON tr.workflow_run_id = wr.id
-    WHERE tr.created_at > CURRENT_TIMESTAMP - INTERVAL (${window} || ' days')
+    WHERE tr.created_at > '${cutoffLiteral}'::TIMESTAMP
       AND COALESCE(wr.source, 'ci') = 'ci'
     GROUP BY tr.suite, tr.test_name
     HAVING COUNT(*) >= 5 AND fail_rate > 0

--- a/src/cli/commands/dev/train.ts
+++ b/src/cli/commands/dev/train.ts
@@ -11,6 +11,7 @@ export interface TrainOpts {
   learningRate?: number;
   windowDays?: number;
   outputPath?: string;
+  now?: Date;
 }
 
 export interface TrainResult {
@@ -29,6 +30,9 @@ export async function trainModel(opts: TrainOpts): Promise<TrainResult> {
   const numTrees = opts.numTrees ?? 15;
   const learningRate = opts.learningRate ?? 0.2;
   const windowDays = opts.windowDays ?? 90;
+  const now = opts.now ?? new Date();
+  const cutoff = new Date(now.getTime() - windowDays * 24 * 60 * 60 * 1000);
+  const cutoffLiteral = cutoff.toISOString().replace("T", " ").replace("Z", "");
 
   // Query historical test results with commit context and source info
   const rows = await opts.store.raw<{
@@ -50,7 +54,7 @@ export async function trainModel(opts: TrainOpts): Promise<TrainResult> {
       COALESCE(wr.source, 'ci') AS source
     FROM test_results tr
     LEFT JOIN workflow_runs wr ON tr.workflow_run_id = wr.id
-    WHERE tr.created_at > CURRENT_TIMESTAMP - INTERVAL (${Number(windowDays)} || ' days')
+    WHERE tr.created_at > '${cutoffLiteral}'::TIMESTAMP
   `);
 
   // Single-pass: build per-test aggregates and per-commit test maps

--- a/src/cli/commands/gate/history.ts
+++ b/src/cli/commands/gate/history.ts
@@ -32,8 +32,12 @@ export async function runGateHistory(input: {
   gate: GateName;
   config: FlakerConfig;
   windowDays?: number;
+  now?: Date;
 }): Promise<GateHistoryReport> {
   const windowDays = input.windowDays ?? 14;
+  const now = input.now ?? new Date();
+  const cutoff = new Date(now.getTime() - windowDays * 24 * 60 * 60 * 1000);
+  const cutoffLiteral = cutoff.toISOString().replace("T", " ").replace("Z", "");
   const backingProfile = profileNameFromGateName(input.gate);
   const workflowSourceExpr = workflowRunSourceSql("wr");
   const source = sourceForGate(input.gate);
@@ -56,7 +60,7 @@ export async function runGateHistory(input: {
       FROM workflow_runs wr
       LEFT JOIN test_results tr ON tr.workflow_run_id = wr.id
       WHERE ${workflowSourceExpr} = '${source}'
-        AND wr.created_at > CURRENT_TIMESTAMP - INTERVAL (${Number(windowDays)} || ' days')
+        AND wr.created_at > '${cutoffLiteral}'::TIMESTAMP
       GROUP BY day
     ),
     sample_days AS (
@@ -65,7 +69,7 @@ export async function runGateHistory(input: {
         ROUND(AVG(sample_ratio), 1)::DOUBLE AS avg_sample_ratio
       FROM sampling_runs
       WHERE command_kind = 'run'
-        AND created_at > CURRENT_TIMESTAMP - INTERVAL (${Number(windowDays)} || ' days')
+        AND created_at > '${cutoffLiteral}'::TIMESTAMP
       GROUP BY day
     )
     SELECT
@@ -81,7 +85,7 @@ export async function runGateHistory(input: {
   `);
 
   const profile = resolveProfile(backingProfile, input.config.profile, input.config.sampling);
-  const kpi = await computeKpi(input.store, { windowDays });
+  const kpi = await computeKpi(input.store, { windowDays, now });
   const currentReview = buildGateReview({ gate: input.gate, profile, kpi });
 
   const entries: GateHistoryEntry[] = rows.map((row, index) => {


### PR DESCRIPTION
## Summary

- Completes the `now?: Date` audit started in #84 / #85 (issue #64). 12 remaining `CURRENT_TIMESTAMP - INTERVAL` cutoffs across analyze/calibrate/gate-history/train were converted to JS-computed literal cutoffs.
- After this PR, `grep -rn 'CURRENT_TIMESTAMP - INTERVAL' src/` returns zero. The only remaining `CURRENT_TIMESTAMP` is in schema DEFAULT columns (INSERT-time, unaffected).
- Closes #64.

### Files

| File | Function(s) | Cutoffs converted |
| --- | --- | --- |
| `src/cli/commands/analyze/reason.ts` | `runReason` → `detectPatterns`, `predictRisks` | 3 (7-day recent + windowDays) |
| `src/cli/commands/collect/calibrate.ts` | `analyzeProject`, `queryTopTests` | 5 |
| `src/cli/commands/gate/history.ts` | `runGateHistory` (+ `computeKpi` call) | 2 |
| `src/cli/commands/dev/train.ts` | `trainModel` | 1 |
| `src/cli/categories/dev.ts` | `dev tune` action body | 1 |

`runGateHistory` also now forwards `now` into the `computeKpi` call so the gate-history view stays consistent with the KPI snapshot for the same window.

## Test plan

- [x] `pnpm test` — 179 files / 834 passed, 1 skipped
- [x] `grep -rn 'CURRENT_TIMESTAMP - INTERVAL' src/` returns empty
- [x] `pnpm tsc --noEmit` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)