### PR TITLE
feat(explain cluster): workflow / lane / tag filter to reduce same-batch bias (#74)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- `flaker explain cluster --workflow <name> | --lane <name> | --tag k=v` (#74). Co-failure clustering can now be narrowed to a specific GitHub Actions workflow, lane, or arbitrary tag, reducing the same-batch / same-workflow bias that inflates clusters when tests are always observed together in fixed cohorts. Three new optional columns on `workflow_runs` (`workflow_name`, `lane`, `tags JSON`) are populated automatically from the GitHub API at `flaker apply --target collect_ci` time. A new optional `[workflow_lanes]` map in `flaker.toml` resolves `workflow_name → lane`. `flaker import` gains symmetric `--workflow-name <name>`, `--lane <name>`, and repeatable `--tag k=v` flags so locally-imported reports can also be tagged. Filters are AND-combined; backwards compatible (no filter = previous behaviour).
+
 ## 0.12.0
 
 Minor release — `feat:` change ships a new public surface for `flaker explain cluster` plus a follow-up audit that closes the JST/UTC drift class in CURRENT_TIMESTAMP-based queries (issue #64).

--- a/src/cli/categories/analyze.ts
+++ b/src/cli/categories/analyze.ts
@@ -17,6 +17,7 @@ import {
   runStatusListQuarantined,
 } from "../commands/status/summary.js";
 import { type GateName, VALID_GATE_NAMES } from "../gate.js";
+import { parseTagOption, WorkflowFilterError } from "../workflow-filter.js";
 
 export async function analyzeKpiAction(opts: { windowDays: string; json?: boolean }): Promise<void> {
   const config = loadConfig(process.cwd());
@@ -172,33 +173,22 @@ function parseWorkflowFilterOptions(opts: {
   lane?: string;
   tag?: string[];
 }): { name?: string; lane?: string; tags?: Record<string, string> } | undefined {
-  const tags: Record<string, string> = {};
-  if (opts.tag) {
-    for (const raw of opts.tag) {
-      const eq = raw.indexOf("=");
-      if (eq <= 0) {
-        console.error(`Error: --tag value must be key=value, got "${raw}"`);
-        process.exit(2);
-      }
-      const key = raw.slice(0, eq).trim();
-      const value = raw.slice(eq + 1);
-      if (!key) {
-        console.error(`Error: --tag key must be non-empty, got "${raw}"`);
-        process.exit(2);
-      }
-      if (!/^[A-Za-z0-9_\-./]+$/.test(key)) {
-        console.error(`Error: --tag key contains unsupported characters: "${key}". Allowed: alphanumeric, _ - . /`);
-        process.exit(2);
-      }
-      tags[key] = value;
+  let tags: Record<string, string> | undefined;
+  try {
+    tags = parseTagOption(opts.tag);
+  } catch (err) {
+    if (err instanceof WorkflowFilterError) {
+      console.error(`Error: ${err.message}`);
+      process.exit(2);
     }
+    throw err;
   }
-  const hasAny = opts.workflow != null || opts.lane != null || Object.keys(tags).length > 0;
+  const hasAny = opts.workflow != null || opts.lane != null || (tags && Object.keys(tags).length > 0);
   if (!hasAny) return undefined;
   return {
     ...(opts.workflow ? { name: opts.workflow } : {}),
     ...(opts.lane ? { lane: opts.lane } : {}),
-    ...(Object.keys(tags).length > 0 ? { tags } : {}),
+    ...(tags ? { tags } : {}),
   };
 }
 

--- a/src/cli/categories/analyze.ts
+++ b/src/cli/categories/analyze.ts
@@ -136,7 +136,15 @@ export async function analyzeClusterAction(opts: {
   minCoRate: string;
   top: string;
   json?: boolean;
+  workflow?: string;
+  lane?: string;
+  tag?: string[];
 }): Promise<void> {
+  const workflowFilter = parseWorkflowFilterOptions({
+    workflow: opts.workflow,
+    lane: opts.lane,
+    tag: opts.tag,
+  });
   const config = loadConfig(process.cwd());
   const store = new DuckDBStore(resolve(config.storage.path));
   await store.initialize();
@@ -147,6 +155,7 @@ export async function analyzeClusterAction(opts: {
       minCoFailures: parseInt(opts.minCoFailures, 10),
       minCoRate: Number(opts.minCoRate),
       top: parseInt(opts.top, 10),
+      ...(workflowFilter ? { workflow: workflowFilter } : {}),
     });
     if (opts.json) {
       console.log(JSON.stringify(clusters, null, 2));
@@ -156,6 +165,41 @@ export async function analyzeClusterAction(opts: {
   } finally {
     await store.close();
   }
+}
+
+function parseWorkflowFilterOptions(opts: {
+  workflow?: string;
+  lane?: string;
+  tag?: string[];
+}): { name?: string; lane?: string; tags?: Record<string, string> } | undefined {
+  const tags: Record<string, string> = {};
+  if (opts.tag) {
+    for (const raw of opts.tag) {
+      const eq = raw.indexOf("=");
+      if (eq <= 0) {
+        console.error(`Error: --tag value must be key=value, got "${raw}"`);
+        process.exit(2);
+      }
+      const key = raw.slice(0, eq).trim();
+      const value = raw.slice(eq + 1);
+      if (!key) {
+        console.error(`Error: --tag key must be non-empty, got "${raw}"`);
+        process.exit(2);
+      }
+      if (!/^[A-Za-z0-9_\-./]+$/.test(key)) {
+        console.error(`Error: --tag key contains unsupported characters: "${key}". Allowed: alphanumeric, _ - . /`);
+        process.exit(2);
+      }
+      tags[key] = value;
+    }
+  }
+  const hasAny = opts.workflow != null || opts.lane != null || Object.keys(tags).length > 0;
+  if (!hasAny) return undefined;
+  return {
+    ...(opts.workflow ? { name: opts.workflow } : {}),
+    ...(opts.lane ? { lane: opts.lane } : {}),
+    ...(Object.keys(tags).length > 0 ? { tags } : {}),
+  };
 }
 
 export async function analyzeReasonAction(opts: { window: string; json?: boolean }): Promise<void> {

--- a/src/cli/categories/explain.ts
+++ b/src/cli/categories/explain.ts
@@ -34,6 +34,9 @@ export function registerExplainCommands(program: Command): void {
     .option("--min-co-rate <ratio>", "Minimum co-failure rate as ratio (0.0-1.0)", "0.8")
     .option("--top <n>", "Number of clusters to show", "20")
     .option("--json", "Output clusters as machine-readable JSON")
+    .option("--workflow <name>", "Restrict co-failure analysis to runs with the given workflow_name")
+    .option("--lane <lane>", "Restrict co-failure analysis to runs in the given lane (e.g. sampled, cohort, interaction)")
+    .option("--tag <k=v...>", "Repeatable key=value tag filters (AND-combined)", collectTagOption, [] as string[])
     .action(analyzeClusterAction);
 
   explain
@@ -48,4 +51,8 @@ export function registerExplainCommands(program: Command): void {
     .description("Show environment data and strategy characteristics for decision-making")
     .option("--json", "Output as JSON for programmatic consumption")
     .action(analyzeContextAction);
+}
+
+function collectTagOption(value: string, previous: string[]): string[] {
+  return [...previous, value];
 }

--- a/src/cli/categories/import.ts
+++ b/src/cli/categories/import.ts
@@ -5,6 +5,7 @@ import { loadConfig } from "../config.js";
 import { runImport } from "../commands/import/report.js";
 import { runImportParquet } from "../commands/import/parquet.js";
 import { parseWorkflowRunSource } from "../run-source.js";
+import { parseTagOption, WorkflowFilterError } from "../workflow-filter.js";
 
 export function detectAdapter(filePath: string): string | undefined {
   const lower = filePath.toLowerCase();
@@ -50,22 +51,14 @@ export function registerImportCommands(program: Command): void {
         return;
       }
       let tags: Record<string, string> | undefined;
-      if (opts.tag && opts.tag.length > 0) {
-        tags = {};
-        for (const raw of opts.tag) {
-          const eq = raw.indexOf("=");
-          if (eq <= 0) {
-            process.stderr.write(`error: --tag value must be key=value, got "${raw}"\n`);
-            process.exit(2);
-          }
-          const key = raw.slice(0, eq).trim();
-          const value = raw.slice(eq + 1);
-          if (!key) {
-            process.stderr.write(`error: --tag key must be non-empty, got "${raw}"\n`);
-            process.exit(2);
-          }
-          tags[key] = value;
+      try {
+        tags = parseTagOption(opts.tag);
+      } catch (err) {
+        if (err instanceof WorkflowFilterError) {
+          process.stderr.write(`error: ${err.message}\n`);
+          process.exit(2);
         }
+        throw err;
       }
       const config = loadConfig(process.cwd());
       const store = new DuckDBStore(resolve(config.storage.path));

--- a/src/cli/categories/import.ts
+++ b/src/cli/categories/import.ts
@@ -24,7 +24,16 @@ export function registerImportCommands(program: Command): void {
     .option("--commit <sha>", "Commit SHA")
     .option("--branch <branch>", "Branch name")
     .option("--source <source>", "Workflow run source: ci or local", "local")
-    .action(async (file: string | undefined, opts: { adapter?: string; customCommand?: string; commit?: string; branch?: string; source?: string }) => {
+    .option("--workflow-name <name>", "Workflow name to attach to the imported run (used by `explain cluster --workflow`)")
+    .option("--lane <lane>", "Lane label to attach to the imported run (e.g. sampled, cohort, interaction; used by `explain cluster --lane`)")
+    .option("--tag <k=v...>", "Repeatable key=value tags attached to the imported run (used by `explain cluster --tag`)", collectTagOption, [] as string[])
+    .action(async (
+      file: string | undefined,
+      opts: {
+        adapter?: string; customCommand?: string; commit?: string; branch?: string; source?: string;
+        workflowName?: string; lane?: string; tag?: string[];
+      },
+    ) => {
       if (!file) {
         importCmd.help();
         return;
@@ -40,6 +49,24 @@ export function registerImportCommands(program: Command): void {
         await runImportParquet(file);
         return;
       }
+      let tags: Record<string, string> | undefined;
+      if (opts.tag && opts.tag.length > 0) {
+        tags = {};
+        for (const raw of opts.tag) {
+          const eq = raw.indexOf("=");
+          if (eq <= 0) {
+            process.stderr.write(`error: --tag value must be key=value, got "${raw}"\n`);
+            process.exit(2);
+          }
+          const key = raw.slice(0, eq).trim();
+          const value = raw.slice(eq + 1);
+          if (!key) {
+            process.stderr.write(`error: --tag key must be non-empty, got "${raw}"\n`);
+            process.exit(2);
+          }
+          tags[key] = value;
+        }
+      }
       const config = loadConfig(process.cwd());
       const store = new DuckDBStore(resolve(config.storage.path));
       await store.initialize();
@@ -53,6 +80,9 @@ export function registerImportCommands(program: Command): void {
           branch: opts.branch,
           repo: `${config.repo.owner}/${config.repo.name}`,
           source: parseWorkflowRunSource(opts.source),
+          workflowName: opts.workflowName,
+          lane: opts.lane,
+          tags,
         });
         console.log(`Imported ${result.testsImported} test results`);
       } finally {
@@ -60,4 +90,8 @@ export function registerImportCommands(program: Command): void {
       }
     });
 
+}
+
+function collectTagOption(value: string, previous: string[]): string[] {
+  return [...previous, value];
 }

--- a/src/cli/commands/analyze/cluster.ts
+++ b/src/cli/commands/analyze/cluster.ts
@@ -9,6 +9,11 @@ export interface FailureClusterOpts {
   top?: number;
   /** Reference time for the window cutoff. Defaults to `new Date()`. */
   now?: Date;
+  /**
+   * Workflow filter applied to the underlying co-failure query (#74).
+   * Reduces same-batch / same-workflow co-failure bias.
+   */
+  workflow?: { name?: string; lane?: string; tags?: Record<string, string> };
 }
 
 export async function runFailureClusters(
@@ -20,6 +25,7 @@ export async function runFailureClusters(
     minCoFailures: opts.minCoFailures ?? defaults.minCoFailures,
     minCoRate: opts.minCoRate ?? defaults.minCoRate,
     ...(opts.now ? { now: opts.now } : {}),
+    ...(opts.workflow ? { workflow: opts.workflow } : {}),
   });
   const clusters = buildFailureClusters(pairs);
   return opts.top != null ? clusters.slice(0, opts.top) : clusters;

--- a/src/cli/commands/collect/ci.ts
+++ b/src/cli/commands/collect/ci.ts
@@ -15,6 +15,7 @@ export interface GitHubClient {
     total_count: number;
     workflow_runs: Array<{
       id: number;
+      name?: string;
       path?: string;
       status?: string;
       head_branch: string;
@@ -48,6 +49,12 @@ export interface CollectOpts {
   customCommand?: string;
   storagePath?: string;
   workflowPaths?: string[];
+  /**
+   * Optional GitHub-Actions workflow-name → lane mapping. Sourced from
+   * flaker.toml `[workflow_lanes]`. Looked up by `run.name` (preferred) and
+   * falls back to the workflow path.
+   */
+  workflowLanes?: Record<string, string>;
 }
 
 export interface CollectFailure {
@@ -167,6 +174,12 @@ export async function collectWorkflowRuns(
 
   const adapter = getAdapter(adapterType, customCommand);
   const { workflow_runs } = await github.listWorkflowRuns();
+  const workflowLanes = opts.workflowLanes ?? {};
+  const resolveLane = (name?: string | null, path?: string | null): string | null => {
+    if (name && workflowLanes[name]) return workflowLanes[name];
+    if (path && workflowLanes[path]) return workflowLanes[path];
+    return null;
+  };
 
   let runsCollected = 0;
   let testsCollected = 0;
@@ -207,6 +220,8 @@ export async function collectWorkflowRuns(
       status: run.conclusion,
       createdAt: new Date(run.created_at),
       durationMs,
+      workflowName: run.name ?? null,
+      lane: resolveLane(run.name, run.path),
     };
 
     await store.insertWorkflowRun(workflowRun);
@@ -384,6 +399,7 @@ export async function runCollectCi(opts: RunCollectCiOpts): Promise<RunCollectCi
         total_count: response.data.total_count,
         workflow_runs: response.data.workflow_runs.map((run) => ({
           id: run.id,
+          name: run.name ?? undefined,
           path: (run as { path?: string }).path,
           status: run.status ?? undefined,
           head_branch: run.head_branch ?? "",
@@ -433,6 +449,7 @@ export async function runCollectCi(opts: RunCollectCiOpts): Promise<RunCollectCi
     customCommand: config.adapter.command,
     storagePath: config.storage.path,
     workflowPaths: config.collect?.workflow_paths,
+    workflowLanes: config.workflow_lanes,
   });
 
   const exitCode = resolveCollectExitCode(result, { failOnErrors });

--- a/src/cli/commands/import/report.ts
+++ b/src/cli/commands/import/report.ts
@@ -14,6 +14,9 @@ interface ImportOpts {
   branch?: string;
   repo?: string;
   source?: WorkflowRunSource;
+  workflowName?: string;
+  lane?: string;
+  tags?: Record<string, string>;
 }
 
 interface ImportResult {
@@ -48,6 +51,9 @@ export async function runImport(opts: ImportOpts): Promise<ImportResult> {
     status: "completed",
     createdAt: now,
     durationMs: null,
+    workflowName: opts.workflowName ?? null,
+    lane: opts.lane ?? null,
+    tags: opts.tags ?? null,
   };
   await store.insertWorkflowRun(workflowRun);
 

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -61,6 +61,12 @@ export interface FlakerConfig {
   repo: { owner: string; name: string };
   storage: { path: string };
   collect?: { workflow_paths?: string[] };
+  /**
+   * Optional GitHub-Actions workflow-name → lane mapping. Applied at collect/import
+   * time so `flaker explain cluster --lane <name>` can filter by lane afterwards.
+   * Example: { "cohort-regression-test" = "cohort", "ci.yml" = "sampled" }
+   */
+  workflow_lanes?: Record<string, string>;
   adapter: { type: string; command?: string; artifact_name?: string };
   runner: {
     type: string;

--- a/src/cli/storage/duckdb.ts
+++ b/src/cli/storage/duckdb.ts
@@ -1,6 +1,6 @@
 import { mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { SCHEMA_DDL, FLAKY_QUERY, CO_FAILURE_QUERY, TEST_CO_FAILURE_QUERY } from "./schema.js";
+import { SCHEMA_DDL, FLAKY_QUERY, CO_FAILURE_QUERY, buildTestCoFailureQuery } from "./schema.js";
 import { createStableTestId, resolveTestIdentity } from "../identity.js";
 import type {
   MetricStore,
@@ -90,8 +90,8 @@ export class DuckDBStore implements MetricStore {
 
   async insertWorkflowRun(run: WorkflowRun): Promise<void> {
     await this.run(
-      `INSERT INTO workflow_runs (id, repo, branch, commit_sha, event, source, status, created_at, duration_ms)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `INSERT INTO workflow_runs (id, repo, branch, commit_sha, event, source, status, created_at, duration_ms, workflow_name, lane, tags)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT (id) DO NOTHING`,
       [
         run.id,
@@ -103,6 +103,9 @@ export class DuckDBStore implements MetricStore {
         run.status,
         run.createdAt,
         run.durationMs,
+        run.workflowName ?? null,
+        run.lane ?? null,
+        run.tags ? JSON.stringify(run.tags) : null,
       ]
     );
   }
@@ -544,9 +547,10 @@ export class DuckDBStore implements MetricStore {
     const now = opts?.now ?? new Date();
     const cutoff = new Date(now.getTime() - windowDays * 24 * 60 * 60 * 1000);
     const cutoffLiteral = cutoff.toISOString().replace("T", " ").replace("Z", "");
+    const { sql, extraParams } = buildTestCoFailureQuery({ workflow: opts?.workflow });
     const rows = await this.all(
-      TEST_CO_FAILURE_QUERY,
-      [cutoffLiteral, minCoFailures, minCoRate],
+      sql,
+      [cutoffLiteral, ...extraParams, minCoFailures, minCoRate],
     );
     return rows.map((row: any) => ({
       testAId: row.test_a_id,

--- a/src/cli/storage/schema.ts
+++ b/src/cli/storage/schema.ts
@@ -112,6 +112,9 @@ CREATE TABLE IF NOT EXISTS sampling_run_tests (
 );
 
 ALTER TABLE workflow_runs ADD COLUMN IF NOT EXISTS source VARCHAR DEFAULT 'ci';
+ALTER TABLE workflow_runs ADD COLUMN IF NOT EXISTS workflow_name VARCHAR;
+ALTER TABLE workflow_runs ADD COLUMN IF NOT EXISTS lane VARCHAR;
+ALTER TABLE workflow_runs ADD COLUMN IF NOT EXISTS tags JSON;
 
 CREATE TABLE IF NOT EXISTS commit_changes (
   commit_sha  VARCHAR NOT NULL,
@@ -153,22 +156,70 @@ HAVING co_runs >= ? AND co_failures > 0
 ORDER BY co_failure_rate DESC
 `;
 
-export const TEST_CO_FAILURE_QUERY = `
+/**
+ * Build the TEST_CO_FAILURE query, optionally narrowing the `failed_results`
+ * CTE to a workflow lane / name / tag set so callers can avoid same-batch bias.
+ *
+ * Returns `{ sql, extraParams }`. Callers prepend `[cutoffLiteral, ...extraParams,
+ * minCoFailures, minCoRate]` to keep the original positional ordering.
+ *
+ * `tags` is rendered inline because DuckDB's parameterised `json_extract` is
+ * awkward — keys/values are validated at the CLI layer (alnum + `_-./`) so the
+ * inline path is safe.
+ */
+export function buildTestCoFailureQuery(filter?: {
+  workflow?: { name?: string; lane?: string; tags?: Record<string, string> };
+}): { sql: string; extraParams: unknown[] } {
+  const wf = filter?.workflow;
+  const hasWorkflowFilter = !!wf && (wf.name != null || wf.lane != null || (wf.tags && Object.keys(wf.tags).length > 0));
+  const extraParams: unknown[] = [];
+  let workflowJoin = "";
+  let workflowWhere = "";
+  if (hasWorkflowFilter) {
+    workflowJoin = "JOIN workflow_runs wr ON wr.id = tr.workflow_run_id";
+    const conds: string[] = [];
+    if (wf!.name != null) {
+      conds.push("wr.workflow_name = ?");
+      extraParams.push(wf!.name);
+    }
+    if (wf!.lane != null) {
+      conds.push("wr.lane = ?");
+      extraParams.push(wf!.lane);
+    }
+    if (wf!.tags) {
+      for (const [k, v] of Object.entries(wf!.tags)) {
+        if (!/^[A-Za-z0-9_\-./]+$/.test(k)) {
+          throw new Error(`tag key contains unsupported characters: ${JSON.stringify(k)}`);
+        }
+        conds.push(`json_extract_string(wr.tags, '$.${k}') = ?`);
+        extraParams.push(v);
+      }
+    }
+    workflowWhere = "AND " + conds.join(" AND ");
+  }
+  const sql = `
 WITH failed_results AS (
   SELECT DISTINCT
-    workflow_run_id,
-    COALESCE(test_id, '') AS test_id,
-    COALESCE(task_id, suite) AS task_id,
-    suite,
-    test_name,
-    filter_text
-  FROM test_results
-  WHERE created_at > ?::TIMESTAMP
+    tr.workflow_run_id,
+    COALESCE(tr.test_id, '') AS test_id,
+    COALESCE(tr.task_id, tr.suite) AS task_id,
+    tr.suite,
+    tr.test_name,
+    tr.filter_text
+  FROM test_results tr
+  ${workflowJoin}
+  WHERE tr.created_at > ?::TIMESTAMP
     AND (
-      status IN ('failed', 'flaky')
-      OR (retry_count > 0 AND status = 'passed')
+      tr.status IN ('failed', 'flaky')
+      OR (tr.retry_count > 0 AND tr.status = 'passed')
     )
+    ${workflowWhere}
 ),
+${TEST_CO_FAILURE_QUERY_TAIL}`;
+  return { sql, extraParams };
+}
+
+const TEST_CO_FAILURE_QUERY_TAIL = `
 fail_counts AS (
   SELECT
     test_id,

--- a/src/cli/storage/schema.ts
+++ b/src/cli/storage/schema.ts
@@ -1,3 +1,5 @@
+import { validateTagKey } from "../workflow-filter.js";
+
 export const SCHEMA_DDL = `
 CREATE TABLE IF NOT EXISTS workflow_runs (
   id            BIGINT PRIMARY KEY,
@@ -156,69 +158,6 @@ HAVING co_runs >= ? AND co_failures > 0
 ORDER BY co_failure_rate DESC
 `;
 
-/**
- * Build the TEST_CO_FAILURE query, optionally narrowing the `failed_results`
- * CTE to a workflow lane / name / tag set so callers can avoid same-batch bias.
- *
- * Returns `{ sql, extraParams }`. Callers prepend `[cutoffLiteral, ...extraParams,
- * minCoFailures, minCoRate]` to keep the original positional ordering.
- *
- * `tags` is rendered inline because DuckDB's parameterised `json_extract` is
- * awkward — keys/values are validated at the CLI layer (alnum + `_-./`) so the
- * inline path is safe.
- */
-export function buildTestCoFailureQuery(filter?: {
-  workflow?: { name?: string; lane?: string; tags?: Record<string, string> };
-}): { sql: string; extraParams: unknown[] } {
-  const wf = filter?.workflow;
-  const hasWorkflowFilter = !!wf && (wf.name != null || wf.lane != null || (wf.tags && Object.keys(wf.tags).length > 0));
-  const extraParams: unknown[] = [];
-  let workflowJoin = "";
-  let workflowWhere = "";
-  if (hasWorkflowFilter) {
-    workflowJoin = "JOIN workflow_runs wr ON wr.id = tr.workflow_run_id";
-    const conds: string[] = [];
-    if (wf!.name != null) {
-      conds.push("wr.workflow_name = ?");
-      extraParams.push(wf!.name);
-    }
-    if (wf!.lane != null) {
-      conds.push("wr.lane = ?");
-      extraParams.push(wf!.lane);
-    }
-    if (wf!.tags) {
-      for (const [k, v] of Object.entries(wf!.tags)) {
-        if (!/^[A-Za-z0-9_\-./]+$/.test(k)) {
-          throw new Error(`tag key contains unsupported characters: ${JSON.stringify(k)}`);
-        }
-        conds.push(`json_extract_string(wr.tags, '$.${k}') = ?`);
-        extraParams.push(v);
-      }
-    }
-    workflowWhere = "AND " + conds.join(" AND ");
-  }
-  const sql = `
-WITH failed_results AS (
-  SELECT DISTINCT
-    tr.workflow_run_id,
-    COALESCE(tr.test_id, '') AS test_id,
-    COALESCE(tr.task_id, tr.suite) AS task_id,
-    tr.suite,
-    tr.test_name,
-    tr.filter_text
-  FROM test_results tr
-  ${workflowJoin}
-  WHERE tr.created_at > ?::TIMESTAMP
-    AND (
-      tr.status IN ('failed', 'flaky')
-      OR (tr.retry_count > 0 AND tr.status = 'passed')
-    )
-    ${workflowWhere}
-),
-${TEST_CO_FAILURE_QUERY_TAIL}`;
-  return { sql, extraParams };
-}
-
 const TEST_CO_FAILURE_QUERY_TAIL = `
 fail_counts AS (
   SELECT
@@ -287,6 +226,69 @@ ORDER BY
   pairs.test_a_suite ASC,
   pairs.test_b_suite ASC
 `;
+
+/**
+ * Build the TEST_CO_FAILURE query, optionally narrowing the `failed_results`
+ * CTE to a workflow lane / name / tag set so callers can avoid same-batch bias.
+ *
+ * Returns `{ sql, extraParams }`. Callers prepend `[cutoffLiteral, ...extraParams,
+ * minCoFailures, minCoRate]` to keep the original positional ordering.
+ *
+ * `tags` is rendered inline because DuckDB's parameterised `json_extract` is
+ * awkward — keys are validated against `TAG_KEY_PATTERN` (alnum + `_-./`) via
+ * `validateTagKey` so the inline path is safe; values stay parameterised.
+ */
+export function buildTestCoFailureQuery(filter?: {
+  workflow?: { name?: string; lane?: string; tags?: Record<string, string> };
+}): { sql: string; extraParams: unknown[] } {
+  const wf = filter?.workflow;
+  const hasWorkflowFilter = !!wf && (wf.name != null || wf.lane != null || (wf.tags && Object.keys(wf.tags).length > 0));
+  const extraParams: unknown[] = [];
+  let workflowJoin = "";
+  let workflowWhere = "";
+  if (hasWorkflowFilter) {
+    workflowJoin = "JOIN workflow_runs wr ON wr.id = tr.workflow_run_id";
+    const conds: string[] = [];
+    if (wf!.name != null) {
+      conds.push("wr.workflow_name = ?");
+      extraParams.push(wf!.name);
+    }
+    if (wf!.lane != null) {
+      conds.push("wr.lane = ?");
+      extraParams.push(wf!.lane);
+    }
+    if (wf!.tags) {
+      for (const [k, v] of Object.entries(wf!.tags)) {
+        validateTagKey(k);
+        conds.push(`json_extract_string(wr.tags, '$.${k}') = ?`);
+        extraParams.push(v);
+      }
+    }
+    workflowWhere = "AND " + conds.join(" AND ");
+  }
+  return {
+    sql: `
+WITH failed_results AS (
+  SELECT DISTINCT
+    tr.workflow_run_id,
+    COALESCE(tr.test_id, '') AS test_id,
+    COALESCE(tr.task_id, tr.suite) AS task_id,
+    tr.suite,
+    tr.test_name,
+    tr.filter_text
+  FROM test_results tr
+  ${workflowJoin}
+  WHERE tr.created_at > ?::TIMESTAMP
+    AND (
+      tr.status IN ('failed', 'flaky')
+      OR (tr.retry_count > 0 AND tr.status = 'passed')
+    )
+    ${workflowWhere}
+),
+${TEST_CO_FAILURE_QUERY_TAIL}`,
+    extraParams,
+  };
+}
 
 export const FLAKY_QUERY = `
 WITH recent AS (

--- a/src/cli/storage/types.ts
+++ b/src/cli/storage/types.ts
@@ -15,6 +15,12 @@ export interface WorkflowRun {
   status: string | null;
   createdAt: Date;
   durationMs: number | null;
+  /** GitHub Actions workflow name, or adapter-supplied workflow identifier. */
+  workflowName?: string | null;
+  /** Coarse lane classifier (e.g. `sampled`, `cohort`, `interaction`, `full-batch`). */
+  lane?: string | null;
+  /** Arbitrary key-value metadata attached to the run. */
+  tags?: Record<string, string> | null;
 }
 
 export interface TestResult {
@@ -197,6 +203,17 @@ export interface TestCoFailureQueryOpts {
   minCoRate?: number;
   /** Reference time for the window cutoff. Defaults to `new Date()`. */
   now?: Date;
+  /**
+   * Optional workflow filter applied to the underlying test_results → workflow_runs join.
+   * All conditions are AND-combined. Used by `flaker explain cluster --lane / --workflow / --tag`
+   * to reduce same-batch / same-workflow co-failure bias (#74).
+   */
+  workflow?: {
+    name?: string;
+    lane?: string;
+    /** Tag matches `tags[key] = value`. Multiple tags AND-combined. */
+    tags?: Record<string, string>;
+  };
 }
 
 export interface ExportResult {

--- a/src/cli/workflow-filter.ts
+++ b/src/cli/workflow-filter.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared helpers for `workflow_runs` filter inputs (#74).
+ *
+ * Tag keys are constrained to a safe character set so that they can be
+ * interpolated into DuckDB's `json_extract_string($.<key>)` path at query
+ * time without risk of SQL injection. Tag values stay parameterised.
+ */
+
+export const TAG_KEY_PATTERN = /^[A-Za-z0-9_\-./]+$/;
+
+export class WorkflowFilterError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WorkflowFilterError";
+  }
+}
+
+export function validateTagKey(key: string): void {
+  if (!TAG_KEY_PATTERN.test(key)) {
+    throw new WorkflowFilterError(
+      `tag key contains unsupported characters: ${JSON.stringify(key)}. Allowed: alphanumeric, _ - . /`,
+    );
+  }
+}
+
+/**
+ * Parse `["k=v", "owner=me"]` (commander's repeatable option output) into
+ * a tag map. Throws WorkflowFilterError on malformed input. Empty input
+ * returns undefined so callers can omit the field cleanly.
+ */
+export function parseTagOption(raw: string[] | undefined): Record<string, string> | undefined {
+  if (!raw || raw.length === 0) return undefined;
+  const tags: Record<string, string> = {};
+  for (const entry of raw) {
+    const eq = entry.indexOf("=");
+    if (eq <= 0) {
+      throw new WorkflowFilterError(`--tag value must be key=value, got ${JSON.stringify(entry)}`);
+    }
+    const key = entry.slice(0, eq).trim();
+    const value = entry.slice(eq + 1);
+    if (!key) {
+      throw new WorkflowFilterError(`--tag key must be non-empty, got ${JSON.stringify(entry)}`);
+    }
+    validateTagKey(key);
+    tags[key] = value;
+  }
+  return tags;
+}

--- a/tests/commands/cluster-filter.test.ts
+++ b/tests/commands/cluster-filter.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { DuckDBStore } from "../../src/cli/storage/duckdb.js";
+import { runFailureClusters } from "../../src/cli/commands/analyze/cluster.js";
+
+/**
+ * #74: workflow / lane / tag filter on `flaker explain cluster`.
+ * Two synthetic clusters:
+ *   - carousel cluster runs in lane=cohort, workflow_name=cohort-regression
+ *   - cms cluster runs in lane=interaction, workflow_name=interaction-suite, tag.suite=cms
+ * No filter must return both clusters; lane/workflow/tag filters must narrow.
+ */
+describe("failure clusters: workflow filter (#74)", () => {
+  let store: DuckDBStore;
+
+  beforeEach(async () => {
+    store = new DuckDBStore(":memory:");
+    await store.initialize();
+
+    const cohortRuns = [1, 2, 3];
+    const interactionRuns = [4, 5, 6];
+
+    for (const id of cohortRuns) {
+      await store.insertWorkflowRun({
+        id,
+        repo: "test/repo",
+        branch: "main",
+        commitSha: `cohort-sha${id}`,
+        event: "push",
+        status: "completed",
+        createdAt: new Date(Date.now() - (10 - id) * 86400000),
+        durationMs: 60000,
+        workflowName: "cohort-regression",
+        lane: "cohort",
+        tags: { suite: "carousel" },
+      });
+      await store.insertTestResults([
+        {
+          workflowRunId: id,
+          suite: "tests/carousel-a.spec.ts",
+          testName: "carousel A",
+          status: "failed",
+          durationMs: 100,
+          retryCount: 0,
+          errorMessage: "shared root cause",
+          commitSha: `cohort-sha${id}`,
+          variant: null,
+          createdAt: new Date(Date.now() - (10 - id) * 86400000),
+        },
+        {
+          workflowRunId: id,
+          suite: "tests/carousel-b.spec.ts",
+          testName: "carousel B",
+          status: "failed",
+          durationMs: 100,
+          retryCount: 0,
+          errorMessage: "shared root cause",
+          commitSha: `cohort-sha${id}`,
+          variant: null,
+          createdAt: new Date(Date.now() - (10 - id) * 86400000),
+        },
+      ]);
+    }
+
+    for (const id of interactionRuns) {
+      await store.insertWorkflowRun({
+        id,
+        repo: "test/repo",
+        branch: "main",
+        commitSha: `inter-sha${id}`,
+        event: "push",
+        status: "completed",
+        createdAt: new Date(Date.now() - (10 - id) * 86400000),
+        durationMs: 60000,
+        workflowName: "interaction-suite",
+        lane: "interaction",
+        tags: { suite: "cms" },
+      });
+      await store.insertTestResults([
+        {
+          workflowRunId: id,
+          suite: "tests/cms-a.spec.ts",
+          testName: "cms A",
+          status: "failed",
+          durationMs: 100,
+          retryCount: 0,
+          errorMessage: "shared root cause",
+          commitSha: `inter-sha${id}`,
+          variant: null,
+          createdAt: new Date(Date.now() - (10 - id) * 86400000),
+        },
+        {
+          workflowRunId: id,
+          suite: "tests/cms-b.spec.ts",
+          testName: "cms B",
+          status: "failed",
+          durationMs: 100,
+          retryCount: 0,
+          errorMessage: "shared root cause",
+          commitSha: `inter-sha${id}`,
+          variant: null,
+          createdAt: new Date(Date.now() - (10 - id) * 86400000),
+        },
+      ]);
+    }
+  });
+
+  afterEach(async () => {
+    await store.close();
+  });
+
+  it("returns both clusters when no workflow filter is supplied", async () => {
+    const clusters = await runFailureClusters({
+      store,
+      minCoFailures: 2,
+      minCoRate: 0.8,
+    });
+    expect(clusters).toHaveLength(2);
+  });
+
+  it("narrows to one cluster when filtered by lane", async () => {
+    const clusters = await runFailureClusters({
+      store,
+      minCoFailures: 2,
+      minCoRate: 0.8,
+      workflow: { lane: "cohort" },
+    });
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0].members.map((m) => m.suite).sort()).toEqual([
+      "tests/carousel-a.spec.ts",
+      "tests/carousel-b.spec.ts",
+    ]);
+  });
+
+  it("narrows to one cluster when filtered by workflow_name", async () => {
+    const clusters = await runFailureClusters({
+      store,
+      minCoFailures: 2,
+      minCoRate: 0.8,
+      workflow: { name: "interaction-suite" },
+    });
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0].members.map((m) => m.suite).sort()).toEqual([
+      "tests/cms-a.spec.ts",
+      "tests/cms-b.spec.ts",
+    ]);
+  });
+
+  it("narrows to one cluster when filtered by tag (k=v)", async () => {
+    const clusters = await runFailureClusters({
+      store,
+      minCoFailures: 2,
+      minCoRate: 0.8,
+      workflow: { tags: { suite: "cms" } },
+    });
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0].members.map((m) => m.suite).sort()).toEqual([
+      "tests/cms-a.spec.ts",
+      "tests/cms-b.spec.ts",
+    ]);
+  });
+
+  it("returns no clusters when filter excludes everything", async () => {
+    const clusters = await runFailureClusters({
+      store,
+      minCoFailures: 2,
+      minCoRate: 0.8,
+      workflow: { lane: "does-not-exist" },
+    });
+    expect(clusters).toHaveLength(0);
+  });
+
+  it("AND-combines multiple filter conditions", async () => {
+    // lane=cohort + workflow_name=interaction-suite → no overlap → empty
+    const clusters = await runFailureClusters({
+      store,
+      minCoFailures: 2,
+      minCoRate: 0.8,
+      workflow: { lane: "cohort", name: "interaction-suite" },
+    });
+    expect(clusters).toHaveLength(0);
+  });
+});

--- a/tests/commands/collect.test.ts
+++ b/tests/commands/collect.test.ts
@@ -789,6 +789,73 @@ describe("collectWorkflowRuns", () => {
     expect(runs.map((row) => Number(row.id))).toEqual([3001]);
   });
 
+  it("populates workflow_name from the GitHub API run.name and applies workflowLanes mapping (#74)", async () => {
+    const mockRuns = [
+      {
+        id: 4001,
+        name: "cohort-regression",
+        head_branch: "main",
+        head_sha: "wf4001",
+        event: "push",
+        conclusion: "success",
+        created_at: "2025-06-12T00:00:00Z",
+        run_started_at: "2025-06-12T00:00:00Z",
+        updated_at: "2025-06-12T00:05:00Z",
+        path: ".github/workflows/cohort.yml",
+      },
+      {
+        id: 4002,
+        name: "interaction-suite",
+        head_branch: "main",
+        head_sha: "wf4002",
+        event: "push",
+        conclusion: "success",
+        created_at: "2025-06-12T00:10:00Z",
+        run_started_at: "2025-06-12T00:10:00Z",
+        updated_at: "2025-06-12T00:15:00Z",
+      },
+      {
+        id: 4003,
+        // No `name` and no mapping match — workflow_name should be null and lane should be null
+        head_branch: "main",
+        head_sha: "wf4003",
+        event: "push",
+        conclusion: "success",
+        created_at: "2025-06-12T00:20:00Z",
+        run_started_at: "2025-06-12T00:20:00Z",
+        updated_at: "2025-06-12T00:25:00Z",
+      },
+    ];
+
+    const github = createMockGitHubClient(mockRuns, {
+      4001: [{ name: "playwright-report", content: fixtureReport }],
+      4002: [{ name: "playwright-report", content: fixtureReport }],
+      4003: [{ name: "playwright-report", content: fixtureReport }],
+    });
+
+    const result = await collectWorkflowRuns({
+      store,
+      github,
+      repo: "owner/repo",
+      adapterType: "playwright",
+      artifactName: "playwright-report",
+      workflowLanes: {
+        "cohort-regression": "cohort",
+        "interaction-suite": "interaction",
+      },
+    });
+    expect(result.runsCollected).toBe(3);
+
+    const rows = await store.raw<{ id: number; workflow_name: string | null; lane: string | null }>(
+      "SELECT id, workflow_name, lane FROM workflow_runs WHERE id IN (4001, 4002, 4003) ORDER BY id",
+    );
+    expect(rows.map((r) => ({ id: Number(r.id), workflow_name: r.workflow_name, lane: r.lane }))).toEqual([
+      { id: 4001, workflow_name: "cohort-regression", lane: "cohort" },
+      { id: 4002, workflow_name: "interaction-suite", lane: "interaction" },
+      { id: 4003, workflow_name: null, lane: null },
+    ]);
+  });
+
   it("treats completed non-success runs without artifacts as failures", async () => {
     const mockRuns = [
       {

--- a/tests/commands/import.test.ts
+++ b/tests/commands/import.test.ts
@@ -217,6 +217,28 @@ describe("import command", () => {
     expect(rows[0].cnt).toBe(result.testsImported);
   });
 
+  it("attaches workflowName, lane, and tags to the imported run (#74)", async () => {
+    const fixture = resolve(import.meta.dirname, "../fixtures/playwright-report.json");
+    await runImport({
+      store,
+      filePath: fixture,
+      adapterType: "playwright",
+      commitSha: "wflane123",
+      branch: "main",
+      repo: "mizchi/crater",
+      workflowName: "smoke",
+      lane: "sampled",
+      tags: { suite: "smoke", owner: "platform" },
+    });
+    const runs = await store.raw<{ workflow_name: string | null; lane: string | null; tags: string | null }>(
+      "SELECT workflow_name, lane, tags FROM workflow_runs",
+    );
+    expect(runs).toHaveLength(1);
+    expect(runs[0].workflow_name).toBe("smoke");
+    expect(runs[0].lane).toBe("sampled");
+    expect(JSON.parse(runs[0].tags ?? "null")).toEqual({ suite: "smoke", owner: "platform" });
+  });
+
   it("requires a custom command when adapterType is custom", async () => {
     const fixture = resolve(import.meta.dirname, "../fixtures/playwright-report.json");
 

--- a/tests/workflow-filter.test.ts
+++ b/tests/workflow-filter.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { parseTagOption, validateTagKey, WorkflowFilterError } from "../src/cli/workflow-filter.js";
+
+describe("workflow-filter helpers (#74)", () => {
+  describe("validateTagKey", () => {
+    it("accepts alphanumeric and the safe punctuation set", () => {
+      expect(() => validateTagKey("suite")).not.toThrow();
+      expect(() => validateTagKey("a-b_c.d/e")).not.toThrow();
+      expect(() => validateTagKey("Owner123")).not.toThrow();
+    });
+
+    it("rejects keys containing SQL-significant characters", () => {
+      expect(() => validateTagKey("foo'bar")).toThrow(WorkflowFilterError);
+      expect(() => validateTagKey("foo bar")).toThrow(WorkflowFilterError);
+      expect(() => validateTagKey("foo;DROP")).toThrow(WorkflowFilterError);
+      expect(() => validateTagKey("")).toThrow(WorkflowFilterError);
+    });
+  });
+
+  describe("parseTagOption", () => {
+    it("returns undefined for missing or empty input", () => {
+      expect(parseTagOption(undefined)).toBeUndefined();
+      expect(parseTagOption([])).toBeUndefined();
+    });
+
+    it("parses k=v pairs into a record", () => {
+      expect(parseTagOption(["suite=cms"])).toEqual({ suite: "cms" });
+      expect(parseTagOption(["suite=cms", "owner=platform"])).toEqual({
+        suite: "cms",
+        owner: "platform",
+      });
+    });
+
+    it("preserves '=' inside the value", () => {
+      expect(parseTagOption(["jwt=a=b=c"])).toEqual({ jwt: "a=b=c" });
+    });
+
+    it("rejects malformed entries", () => {
+      expect(() => parseTagOption(["nokey"])).toThrow(WorkflowFilterError);
+      expect(() => parseTagOption(["=value"])).toThrow(WorkflowFilterError);
+    });
+
+    it("rejects keys with unsupported characters", () => {
+      expect(() => parseTagOption(["foo bar=ok"])).toThrow(WorkflowFilterError);
+      expect(() => parseTagOption(["foo'=ok"])).toThrow(WorkflowFilterError);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #74. `flaker explain cluster` now accepts three optional filters that narrow the underlying co-failure pair query to a subset of workflow runs:

```bash
flaker explain cluster --workflow cohort-regression-test
flaker explain cluster --lane interaction
flaker explain cluster --tag suite=cms
```

Multiple filters AND-combine. With no filter, behaviour is unchanged.

## Why

Per the issue: fixed cohort / batch runs create strong co-failure groups whose linkage comes from "always observed in the same workflow run" rather than from a shared root cause, polluting cluster output. Letting users narrow by lane (sampled / cohort / interaction / full-batch) or by an arbitrary tag map gives them a way to separate "real correlation" from "always sampled together".

## What's in this PR

### Schema (3 new optional columns on `workflow_runs`)

| Column | Type | Source |
| --- | --- | --- |
| `workflow_name` | VARCHAR | GitHub Actions run.name (or adapter-supplied) |
| `lane` | VARCHAR | resolved via `[workflow_lanes]` map in flaker.toml |
| `tags` | JSON | arbitrary key-value, set via `flaker import --tag k=v` |

All added via `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`. Backwards compatible — existing rows have NULL.

### Populator paths

- `flaker apply --target collect_ci`: reads `run.name` from GitHub Actions API, then resolves `lane` via `[workflow_lanes]` map.
- `flaker import`: gains `--workflow-name <name>`, `--lane <name>`, repeatable `--tag k=v` flags.

### `flaker.toml` additions

```toml
[workflow_lanes]
"cohort-regression" = "cohort"
"interaction-suite" = "interaction"
```

### Query layer

- `buildTestCoFailureQuery(filter)` (new, `schema.ts`): parameterised query builder, replaces the static `TEST_CO_FAILURE_QUERY` constant. Adds `JOIN workflow_runs wr` + filter predicates only when needed.
- Tag values stay parameterised; tag keys are validated to `[A-Za-z0-9_\-./]+` at the CLI layer so the inline `json_extract_string($.<key>)` path is safe.

### Tests (8 new cases)

- `tests/commands/cluster-filter.test.ts` (NEW): synthetic 2-cluster fixture covering lane / workflow_name / tag filters, AND-combine, and exclude-all paths.
- `tests/commands/collect.test.ts`: new case for the GitHub-API populator (workflow_name + workflowLanes mapping + null-pass-through).
- `tests/commands/import.test.ts`: new case for `--workflow-name` / `--lane` / `--tag` round-trip.

### Out of scope

Same-run bias score (lift / shared-run ratio / normalized score) from the issue's "Future extension" section is left for a follow-up PR; this PR delivers only the schema + populator + filter plumbing.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` — 180 files / 842 passed, 1 skipped (8 new cases)
- [x] `grep -rn 'CURRENT_TIMESTAMP - INTERVAL' src/` still empty (no regression to #64)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)