### PR TITLE
chore(ci): gate ops and flaky-tag-triage tests in the Test step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
           tests/reporting/*.test.ts
           tests/commands/collect.test.ts
           tests/storage/duckdb.test.ts
+          tests/commands/ops-*.test.ts
+          tests/commands/flaky-tag-triage.test.ts
 
       - name: Install DuckDB C library
         run: |


### PR DESCRIPTION
## Problem

`.github/workflows/ci.yml` has a test-gating gap discovered during the 0.10.7 release (PR #78):

1. The **`Test` step** that actually gates the job only runs a 4-file subset.
2. The **`Full test with JSON report`** step runs the complete suite but pipes through `|| true`, so its exit code is discarded — regressions in any non-listed file are invisible to the merge gate.

The concrete incident: a flaky-tag-triage bug (`src/cli/commands/analyze/flaky-tag-triage.ts` not propagating `now` into `queryFlakyTests`) sat undetected on `main` until release time because `tests/commands/ops-weekly.test.ts` and `tests/commands/flaky-tag-triage.test.ts` were not in the gating subset. Local `pnpm test` caught it; CI did not.

## Approach taken: option (b) — expand the gating subset

Option (a) (drop `|| true` from the Full-test step) was evaluated first. Running `pnpm exec vitest run` on `main` returned exit code 1 with **46 failing test files** (see list below), so removing `|| true` would immediately break CI. Option (a) is deferred until those pre-existing failures are triaged and fixed.

This PR instead implements **option (b)**: expand the `Test` step to include the ops family and the specific flaky-tag-triage path that triggered the incident.

## Changes

**`.github/workflows/ci.yml` lines 47–55** — two new glob entries added to the `Test` step:

```diff
       - name: Test
         run: >
           pnpm exec vitest run
           tests/adapters/playwright.test.ts
           tests/reporting/*.test.ts
           tests/commands/collect.test.ts
           tests/storage/duckdb.test.ts
+          tests/commands/ops-*.test.ts
+          tests/commands/flaky-tag-triage.test.ts
```

`tests/commands/analyze/**/*.test.ts` was also considered (mentioned in the task spec) but the `analyze/` subdirectory does not exist in `tests/commands/`, so that glob was omitted.

All 17 test files (63 tests) in the expanded set were verified green on `main` locally before opening this PR.

## Pre-existing failures on main (need separate triage)

The following 46 test files fail on the current `main` HEAD and are **not** introduced by this PR:

<details>
<summary>46 failing test files</summary>

```
tests/cli/apply-artifact-emission.test.ts
tests/cli/apply-cli.test.ts
tests/cli/apply-emit-incident.test.ts
tests/cli/apply-plan-file.test.ts
tests/cli/apply-refresh-only.test.ts
tests/cli/apply-target.test.ts
tests/cli/exec-run-dry-run.test.ts
tests/cli/explain.test.ts
tests/cli/help-primary-shape.test.ts
tests/cli/help-shape.test.ts
tests/cli/import-cli.test.ts
tests/cli/init-profile-defaults.test.ts
tests/cli/query-top-level.test.ts
tests/cli/removed-ops-daily.test.ts
tests/cli/report-flags.test.ts
tests/cli/setup-init-flags.test.ts
tests/cli/surface-reduction.test.ts
tests/cli/top-level-aliases.test.ts
tests/cli/version-single-line.test.ts
tests/commands/check.test.ts
tests/commands/report.test.ts
tests/commands/run.test.ts
tests/commands/sample-cluster-mode.test.ts
tests/commands/sample-co-failure.test.ts
tests/commands/sample-holdout-gbdt.test.ts
tests/commands/sample-hybrid.test.ts
tests/commands/sample.test.ts
tests/commands/self-eval.test.ts
tests/commands/skip-quarantined.test.ts
tests/core/build-artifact.test.ts
tests/eval/coverage-guided.test.ts
tests/eval/fixture-evaluator.test.ts
tests/eval/fixture-generator.test.ts
tests/eval/fixture-loader.test.ts
tests/eval/gbdt.test.ts
tests/graph/analyzer.test.ts
tests/integration-e2e-flow.test.ts
tests/integration-phase2.test.ts
tests/integration.test.ts
tests/package/cold-start.test.ts
tests/parquet/duckdb-interop.test.ts
tests/pipeline/accumulation.test.ts
tests/quarantine-manifest.test.ts
tests/resolvers/graph.test.ts
tests/runners/quarantine-runtime.test.ts
tests/runners/retry.test.ts
```

</details>

Once these are fixed, option (a) should be revisited: drop `|| true` from the `Full test with JSON report` step so the complete suite gates the job unconditionally.

## Test plan

- [x] Verified `pnpm exec vitest run tests/adapters/playwright.test.ts tests/reporting/*.test.ts tests/commands/collect.test.ts tests/storage/duckdb.test.ts tests/commands/ops-*.test.ts tests/commands/flaky-tag-triage.test.ts` exits 0 (17 files, 63 tests)
- [ ] CI passes on this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01X817mmjRKb3TPNTmTPVqom)_